### PR TITLE
Update to new rust syntax.

### DIFF
--- a/src/audio/listener.rs
+++ b/src/audio/listener.rs
@@ -38,13 +38,13 @@ pub mod ffi {
     pub use std::libc::{c_int};    
     pub use system::vector3;
 
-    pub extern "C" {
-        fn sfListener_setGlobalVolume(volume : f32) -> ();
-        fn sfListener_getGlobalVolume() -> f32;
-        fn sfListener_setPosition(position : vector3::Vector3f) -> ();
-        fn sfListener_getPosition() -> vector3::Vector3f;
-        fn sfListener_setDirection(orientation : vector3::Vector3f) -> ();
-        fn sfListener_getDirection() -> vector3::Vector3f;
+    extern "C" {
+        pub fn sfListener_setGlobalVolume(volume : f32) -> ();
+        pub fn sfListener_getGlobalVolume() -> f32;
+        pub fn sfListener_setPosition(position : vector3::Vector3f) -> ();
+        pub fn sfListener_getPosition() -> vector3::Vector3f;
+        pub fn sfListener_setDirection(orientation : vector3::Vector3f) -> ();
+        pub fn sfListener_getDirection() -> vector3::Vector3f;
     }
 }
 /**

--- a/src/audio/music.rs
+++ b/src/audio/music.rs
@@ -53,34 +53,34 @@ pub mod ffi {
         This1 : *c_void
     }
 
-    pub extern "C" {
-        fn sfMusic_createFromFile(filename : *c_char) -> *sfMusic;
+    extern "C" {
+        pub fn sfMusic_createFromFile(filename : *c_char) -> *sfMusic;
         // sfMusic* sfMusic_createFromMemory(const void* data, size_t sizeInBytes);
         // sfMusic* sfMusic_createFromStream(sfInputStream* stream);
-        fn sfMusic_destroy(music : *sfMusic) -> ();
-        fn sfMusic_setLoop(music : *sfMusic, lloop : sfBool) -> ();
-        fn sfMusic_getLoop(music : *sfMusic) -> sfBool;
-        fn sfMusic_getDuration(music : *sfMusic) -> time::ffi::sfTime;
-        fn sfMusic_play(music : *sfMusic) -> ();
-        fn sfMusic_pause(music : *sfMusic) -> ();
-        fn sfMusic_stop(music : *sfMusic) -> ();
-        fn sfMusic_getChannelCount(music : *sfMusic) -> c_uint;
-        fn sfMusic_getSampleRate(music : *sfMusic) -> c_uint;
-        fn sfMusic_getStatus(music : *sfMusic) -> sound_status::ffi::sfSoundStatus;
-        fn sfMusic_getPlayingOffset(music : *sfMusic) -> time::ffi::sfTime;
-        fn sfMusic_setPitch(music : *sfMusic, pitch : c_float) -> ();
-        fn sfMusic_setVolume(music : *sfMusic, volume : c_float) -> ();
-        fn sfMusic_setPosition(music : *sfMusic, position : Vector3f) -> ();
-        fn sfMusic_setRelativeToListener(music : *sfMusic, relative : sfBool) -> ();
-        fn sfMusic_setMinDistance(music : *sfMusic, distance : c_float) -> ();
-        fn sfMusic_setAttenuation(music : *sfMusic, attenuation : c_float) -> ();
-        fn sfMusic_setPlayingOffset(music : *sfMusic, timeOffset : time::ffi::sfTime) -> ();
-        fn sfMusic_getPitch(music : *sfMusic) -> c_float;
-        fn sfMusic_getVolume(music : *sfMusic) -> c_float;
-        fn sfMusic_getPosition(music : *sfMusic) -> Vector3f;
-        fn sfMusic_isRelativeToListener(music : *sfMusic) -> sfBool;
-        fn sfMusic_getMinDistance(music : *sfMusic) -> c_float;
-        fn sfMusic_getAttenuation(music : *sfMusic) -> c_float;
+        pub fn sfMusic_destroy(music : *sfMusic) -> ();
+        pub fn sfMusic_setLoop(music : *sfMusic, lloop : sfBool) -> ();
+        pub fn sfMusic_getLoop(music : *sfMusic) -> sfBool;
+        pub fn sfMusic_getDuration(music : *sfMusic) -> time::ffi::sfTime;
+        pub fn sfMusic_play(music : *sfMusic) -> ();
+        pub fn sfMusic_pause(music : *sfMusic) -> ();
+        pub fn sfMusic_stop(music : *sfMusic) -> ();
+        pub fn sfMusic_getChannelCount(music : *sfMusic) -> c_uint;
+        pub fn sfMusic_getSampleRate(music : *sfMusic) -> c_uint;
+        pub fn sfMusic_getStatus(music : *sfMusic) -> sound_status::ffi::sfSoundStatus;
+        pub fn sfMusic_getPlayingOffset(music : *sfMusic) -> time::ffi::sfTime;
+        pub fn sfMusic_setPitch(music : *sfMusic, pitch : c_float) -> ();
+        pub fn sfMusic_setVolume(music : *sfMusic, volume : c_float) -> ();
+        pub fn sfMusic_setPosition(music : *sfMusic, position : Vector3f) -> ();
+        pub fn sfMusic_setRelativeToListener(music : *sfMusic, relative : sfBool) -> ();
+        pub fn sfMusic_setMinDistance(music : *sfMusic, distance : c_float) -> ();
+        pub fn sfMusic_setAttenuation(music : *sfMusic, attenuation : c_float) -> ();
+        pub fn sfMusic_setPlayingOffset(music : *sfMusic, timeOffset : time::ffi::sfTime) -> ();
+        pub fn sfMusic_getPitch(music : *sfMusic) -> c_float;
+        pub fn sfMusic_getVolume(music : *sfMusic) -> c_float;
+        pub fn sfMusic_getPosition(music : *sfMusic) -> Vector3f;
+        pub fn sfMusic_isRelativeToListener(music : *sfMusic) -> sfBool;
+        pub fn sfMusic_getMinDistance(music : *sfMusic) -> c_float;
+        pub fn sfMusic_getAttenuation(music : *sfMusic) -> c_float;
     }
 }
 

--- a/src/audio/sound.rs
+++ b/src/audio/sound.rs
@@ -54,32 +54,32 @@ pub mod ffi {
         This2 : *c_void
     }
     
-    pub extern "C" {
-        fn sfSound_create() -> *sfSound;
-        fn sfSound_copy(sound : *sfSound) -> *sfSound;
-        fn sfSound_destroy(sound : *sfSound) -> ();
-        fn sfSound_play(sound : *sfSound) -> ();
-        fn sfSound_pause(sound : *sfSound) -> ();
-        fn sfSound_stop(sound : *sfSound) -> ();
-        fn sfSound_setBuffer(sound : *sfSound, buffer : *sound_buffer::ffi::sfSoundBuffer) -> (); // a faire
-        fn sfSound_getBuffer(sound : *sfSound) -> *sound_buffer::ffi::sfSoundBuffer; // a faire
-        fn sfSound_setLoop(sound : *sfSound, lloop : sfBool) -> ();
-        fn sfSound_getLoop(sound : *sfSound) -> sfBool;
-        fn sfSound_getStatus(sound : *sfSound) -> sound_status::ffi::sfSoundStatus;
-        fn sfSound_setPitch(sound : *sfSound, pitch : c_float) -> ();
-        fn sfSound_setVolume(sound : *sfSound, volume : c_float) -> ();
-        fn sfSound_setPosition(sound : *sfSound, position : Vector3f) -> ();
-        fn sfSound_setRelativeToListener(sound : *sfSound, relative : sfBool) -> ();
-        fn sfSound_setMinDistance(sound : *sfSound, distance : c_float) -> ();
-        fn sfSound_setAttenuation(sound : *sfSound, attenuation : c_float) -> ();
-        fn sfSound_setPlayingOffset(sound : *sfSound, timeOffset : time::ffi::sfTime) -> ();
-        fn sfSound_getPitch(sound : *sfSound) -> c_float;
-        fn sfSound_getVolume(sound : *sfSound) -> c_float;
-        fn sfSound_getPosition(sound : *sfSound) -> Vector3f;
-        fn sfSound_isRelativeToListener(sound : *sfSound) -> sfBool;
-        fn sfSound_getMinDistance(sound : *sfSound) -> c_float;
-        fn sfSound_getAttenuation(sound : *sfSound) -> c_float;
-        fn sfSound_getPlayingOffset(sound : *sfSound) -> time::ffi::sfTime;
+    extern "C" {
+        pub fn sfSound_create() -> *sfSound;
+        pub fn sfSound_copy(sound : *sfSound) -> *sfSound;
+        pub fn sfSound_destroy(sound : *sfSound) -> ();
+        pub fn sfSound_play(sound : *sfSound) -> ();
+        pub fn sfSound_pause(sound : *sfSound) -> ();
+        pub fn sfSound_stop(sound : *sfSound) -> ();
+        pub fn sfSound_setBuffer(sound : *sfSound, buffer : *sound_buffer::ffi::sfSoundBuffer) -> (); // a faire
+        pub fn sfSound_getBuffer(sound : *sfSound) -> *sound_buffer::ffi::sfSoundBuffer; // a faire
+        pub fn sfSound_setLoop(sound : *sfSound, lloop : sfBool) -> ();
+        pub fn sfSound_getLoop(sound : *sfSound) -> sfBool;
+        pub fn sfSound_getStatus(sound : *sfSound) -> sound_status::ffi::sfSoundStatus;
+        pub fn sfSound_setPitch(sound : *sfSound, pitch : c_float) -> ();
+        pub fn sfSound_setVolume(sound : *sfSound, volume : c_float) -> ();
+        pub fn sfSound_setPosition(sound : *sfSound, position : Vector3f) -> ();
+        pub fn sfSound_setRelativeToListener(sound : *sfSound, relative : sfBool) -> ();
+        pub fn sfSound_setMinDistance(sound : *sfSound, distance : c_float) -> ();
+        pub fn sfSound_setAttenuation(sound : *sfSound, attenuation : c_float) -> ();
+        pub fn sfSound_setPlayingOffset(sound : *sfSound, timeOffset : time::ffi::sfTime) -> ();
+        pub fn sfSound_getPitch(sound : *sfSound) -> c_float;
+        pub fn sfSound_getVolume(sound : *sfSound) -> c_float;
+        pub fn sfSound_getPosition(sound : *sfSound) -> Vector3f;
+        pub fn sfSound_isRelativeToListener(sound : *sfSound) -> sfBool;
+        pub fn sfSound_getMinDistance(sound : *sfSound) -> c_float;
+        pub fn sfSound_getAttenuation(sound : *sfSound) -> c_float;
+        pub fn sfSound_getPlayingOffset(sound : *sfSound) -> time::ffi::sfTime;
     }
 }
 

--- a/src/audio/sound_buffer.rs
+++ b/src/audio/sound_buffer.rs
@@ -46,16 +46,16 @@ pub mod ffi {
         This : *c_void
     }
 
-    pub extern "C" {
-        fn sfSoundBuffer_createFromFile(filename : *c_char) -> *sfSoundBuffer;
-        fn sfSoundBuffer_copy(soundBuffer : *sfSoundBuffer) -> *sfSoundBuffer;
-        fn sfSoundBuffer_destroy(soundBuffer : *sfSoundBuffer) -> ();
-        fn sfSoundBuffer_saveToFile(soundBuffer : *sfSoundBuffer, filename : *c_char) -> sfBool;
+    extern "C" {
+        pub fn sfSoundBuffer_createFromFile(filename : *c_char) -> *sfSoundBuffer;
+        pub fn sfSoundBuffer_copy(soundBuffer : *sfSoundBuffer) -> *sfSoundBuffer;
+        pub fn sfSoundBuffer_destroy(soundBuffer : *sfSoundBuffer) -> ();
+        pub fn sfSoundBuffer_saveToFile(soundBuffer : *sfSoundBuffer, filename : *c_char) -> sfBool;
        // fn sfSoundBuffer_getSamples(soundBuffer : *sfSoundBuffer) -> *i16;
-        fn sfSoundBuffer_getSampleCount(soundBuffer : *sfSoundBuffer) -> size_t;
-        fn sfSoundBuffer_getChannelCount(soundBuffer : *sfSoundBuffer) -> c_uint;
-        fn sfSoundBuffer_getDuration(soundBuffer : *sfSoundBuffer) -> time::ffi::sfTime;
-        fn sfSoundBuffer_getSampleRate(soundBuffer : *sfSoundBuffer) -> c_uint;
+        pub fn sfSoundBuffer_getSampleCount(soundBuffer : *sfSoundBuffer) -> size_t;
+        pub fn sfSoundBuffer_getChannelCount(soundBuffer : *sfSoundBuffer) -> c_uint;
+        pub fn sfSoundBuffer_getDuration(soundBuffer : *sfSoundBuffer) -> time::ffi::sfTime;
+        pub fn sfSoundBuffer_getSampleRate(soundBuffer : *sfSoundBuffer) -> c_uint;
     }
 }
 

--- a/src/audio/sound_buffer_recorder.rs
+++ b/src/audio/sound_buffer_recorder.rs
@@ -45,13 +45,13 @@ pub mod ffi {
         This : *c_void
     }
 
-    pub extern "C" {
-        fn sfSoundBufferRecorder_create() -> *sfSoundBufferRecorder;
-        fn sfSoundBufferRecorder_destroy(soundBufferRecorder : *sfSoundBufferRecorder) -> ();
-        fn sfSoundBufferRecorder_start(soundBufferRecorder : *sfSoundBufferRecorder, sampleRate : c_uint) -> ();
-        fn sfSoundBufferRecorder_stop(soundBufferRecorder : *sfSoundBufferRecorder) -> ();
-        fn sfSoundBufferRecorder_getSampleRate(soundBufferRecorder : *sfSoundBufferRecorder) -> c_uint;
-        fn sfSoundBufferRecorder_getBuffer(soundBufferRecorder : *sfSoundBufferRecorder) -> *sound_buffer::ffi::sfSoundBuffer;
+    extern "C" {
+        pub fn sfSoundBufferRecorder_create() -> *sfSoundBufferRecorder;
+        pub fn sfSoundBufferRecorder_destroy(soundBufferRecorder : *sfSoundBufferRecorder) -> ();
+        pub fn sfSoundBufferRecorder_start(soundBufferRecorder : *sfSoundBufferRecorder, sampleRate : c_uint) -> ();
+        pub fn sfSoundBufferRecorder_stop(soundBufferRecorder : *sfSoundBufferRecorder) -> ();
+        pub fn sfSoundBufferRecorder_getSampleRate(soundBufferRecorder : *sfSoundBufferRecorder) -> c_uint;
+        pub fn sfSoundBufferRecorder_getBuffer(soundBufferRecorder : *sfSoundBufferRecorder) -> *sound_buffer::ffi::sfSoundBuffer;
     }
 }
 

--- a/src/audio/sound_recorder.rs
+++ b/src/audio/sound_recorder.rs
@@ -41,13 +41,13 @@ pub mod ffi{
         This : *c_void
     }
 
-    pub extern "C" {
-        fn sfSoundRecorder_create(onStart : *u8, onProcess : *u8, onStop : *u8, data : *c_void) -> *sfSoundRecorder;
-        fn sfSoundRecorder_destroy(soundRecorder : *sfSoundRecorder) -> ();
-        fn sfSoundRecorder_start(soundRecorder : *sfSoundRecorder, sampleRate : c_uint) -> ();
-        fn sfSoundRecorder_stop(soundRecorder : *sfSoundRecorder) -> ();
-        fn sfSoundRecorder_getSampleRate(soundRecorder : *sfSoundRecorder) -> c_uint;
-        fn sfSoundRecorder_isAvailable() -> sfBool; // static
+    extern "C" {
+        pub fn sfSoundRecorder_create(onStart : *u8, onProcess : *u8, onStop : *u8, data : *c_void) -> *sfSoundRecorder;
+        pub fn sfSoundRecorder_destroy(soundRecorder : *sfSoundRecorder) -> ();
+        pub fn sfSoundRecorder_start(soundRecorder : *sfSoundRecorder, sampleRate : c_uint) -> ();
+        pub fn sfSoundRecorder_stop(soundRecorder : *sfSoundRecorder) -> ();
+        pub fn sfSoundRecorder_getSampleRate(soundRecorder : *sfSoundRecorder) -> c_uint;
+        pub fn sfSoundRecorder_isAvailable() -> sfBool; // static
 
     }
 }

--- a/src/graphics/circle_shape.rs
+++ b/src/graphics/circle_shape.rs
@@ -62,40 +62,40 @@ pub mod ffi {
         InverseTransform : Transform
     }
     
-    pub extern "C" {
-        fn sfCircleShape_create() -> *sfCircleShape;
-        fn sfCircleShape_copy(shape : *sfCircleShape) -> *sfCircleShape;
-        fn sfCircleShape_destroy(shape : *sfCircleShape) -> ();
-        fn sfCircleShape_setPosition(shape : *sfCircleShape, position : Vector2f) -> ();
-        fn sfCircleShape_setRotation(shape : *sfCircleShape, angle : c_float) -> ();
-        fn sfCircleShape_setScale(shape : *sfCircleShape, scale : Vector2f) -> ();
-        fn sfCircleShape_setOrigin(shape : *sfCircleShape, origin : Vector2f) -> ();
-        fn sfCircleShape_getPosition(shape : *sfCircleShape) -> Vector2f;
-        fn sfCircleShape_getRotation(shape : *sfCircleShape) -> c_float;
-        fn sfCircleShape_getScale(shape : *sfCircleShape) -> Vector2f;
-        fn sfCircleShape_getOrigin(shape : *sfCircleShape) -> Vector2f;
-        fn sfCircleShape_move(shape : *sfCircleShape, offset : Vector2f) -> ();
-        fn sfCircleShape_rotate(shape : *sfCircleShape, angle : c_float) -> ();
-        fn sfCircleShape_scale(shape : *sfCircleShape, factors : Vector2f) -> ();
-        fn sfCircleShape_getTransform(shape : *sfCircleShape) -> Transform;
-        fn sfCircleShape_getInverseTransform(shape : *sfCircleShape) -> Transform;
-        fn sfCircleShape_setTexture(shape : *sfCircleShape, texture : *texture::ffi::sfTexture, resetRect : sfBool) -> ();
-        fn sfCircleShape_setTextureRect(shape : *sfCircleShape, rect : IntRect) -> ();
-        fn sfCircleShape_setFillColor(shape : *sfCircleShape, color : Color) -> ();
-        fn sfCircleShape_setOutlineColor(shape : *sfCircleShape, color : Color) -> ();
-        fn sfCircleShape_setOutlineThickness(shape : *sfCircleShape, thickness : c_float) -> ();
-        fn sfCircleShape_getTexture(shape : *sfCircleShape) -> *texture::ffi::sfTexture;
-        fn sfCircleShape_getTextureRect(shape : *sfCircleShape) -> IntRect;
-        fn sfCircleShape_getFillColor(shape : *sfCircleShape) -> Color;
-        fn sfCircleShape_getOutlineColor(shape : *sfCircleShape) -> Color;
-        fn sfCircleShape_getOutlineThickness(shape : *sfCircleShape) -> c_float;
-        fn sfCircleShape_getPointCount(shape : *sfCircleShape) -> c_uint;
-        fn sfCircleShape_getPoint(shape : *sfCircleShape, index : c_uint) -> ();
-        fn sfCircleShape_setRadius(shape : *sfCircleShape, radius : c_float) -> ();
-        fn sfCircleShape_getRadius(shape : *sfCircleShape) -> c_float;
-        fn sfCircleShape_setPointCount(shape : *sfCircleShape, count : c_uint) -> ();
-        fn sfCircleShape_getLocalBounds(shape : *sfCircleShape) -> FloatRect;
-        fn sfCircleShape_getGlobalBounds(shape : *sfCircleShape) -> FloatRect;
+    extern "C" {
+        pub fn sfCircleShape_create() -> *sfCircleShape;
+        pub fn sfCircleShape_copy(shape : *sfCircleShape) -> *sfCircleShape;
+        pub fn sfCircleShape_destroy(shape : *sfCircleShape) -> ();
+        pub fn sfCircleShape_setPosition(shape : *sfCircleShape, position : Vector2f) -> ();
+        pub fn sfCircleShape_setRotation(shape : *sfCircleShape, angle : c_float) -> ();
+        pub fn sfCircleShape_setScale(shape : *sfCircleShape, scale : Vector2f) -> ();
+        pub fn sfCircleShape_setOrigin(shape : *sfCircleShape, origin : Vector2f) -> ();
+        pub fn sfCircleShape_getPosition(shape : *sfCircleShape) -> Vector2f;
+        pub fn sfCircleShape_getRotation(shape : *sfCircleShape) -> c_float;
+        pub fn sfCircleShape_getScale(shape : *sfCircleShape) -> Vector2f;
+        pub fn sfCircleShape_getOrigin(shape : *sfCircleShape) -> Vector2f;
+        pub fn sfCircleShape_move(shape : *sfCircleShape, offset : Vector2f) -> ();
+        pub fn sfCircleShape_rotate(shape : *sfCircleShape, angle : c_float) -> ();
+        pub fn sfCircleShape_scale(shape : *sfCircleShape, factors : Vector2f) -> ();
+        pub fn sfCircleShape_getTransform(shape : *sfCircleShape) -> Transform;
+        pub fn sfCircleShape_getInverseTransform(shape : *sfCircleShape) -> Transform;
+        pub fn sfCircleShape_setTexture(shape : *sfCircleShape, texture : *texture::ffi::sfTexture, resetRect : sfBool) -> ();
+        pub fn sfCircleShape_setTextureRect(shape : *sfCircleShape, rect : IntRect) -> ();
+        pub fn sfCircleShape_setFillColor(shape : *sfCircleShape, color : Color) -> ();
+        pub fn sfCircleShape_setOutlineColor(shape : *sfCircleShape, color : Color) -> ();
+        pub fn sfCircleShape_setOutlineThickness(shape : *sfCircleShape, thickness : c_float) -> ();
+        pub fn sfCircleShape_getTexture(shape : *sfCircleShape) -> *texture::ffi::sfTexture;
+        pub fn sfCircleShape_getTextureRect(shape : *sfCircleShape) -> IntRect;
+        pub fn sfCircleShape_getFillColor(shape : *sfCircleShape) -> Color;
+        pub fn sfCircleShape_getOutlineColor(shape : *sfCircleShape) -> Color;
+        pub fn sfCircleShape_getOutlineThickness(shape : *sfCircleShape) -> c_float;
+        pub fn sfCircleShape_getPointCount(shape : *sfCircleShape) -> c_uint;
+        pub fn sfCircleShape_getPoint(shape : *sfCircleShape, index : c_uint) -> ();
+        pub fn sfCircleShape_setRadius(shape : *sfCircleShape, radius : c_float) -> ();
+        pub fn sfCircleShape_getRadius(shape : *sfCircleShape) -> c_float;
+        pub fn sfCircleShape_setPointCount(shape : *sfCircleShape, count : c_uint) -> ();
+        pub fn sfCircleShape_getLocalBounds(shape : *sfCircleShape) -> FloatRect;
+        pub fn sfCircleShape_getGlobalBounds(shape : *sfCircleShape) -> FloatRect;
     }
 }
 

--- a/src/graphics/color.rs
+++ b/src/graphics/color.rs
@@ -34,11 +34,11 @@ pub mod ffi {
     
     use graphics::color::Color;
     
-    pub extern "C" {
-        fn sfColor_fromRGB(red : u8, green : u8, blue : u8) -> Color;
-        fn sfColor_fromRGBA(red : u8, green : u8, blue : u8, alpha : u8) -> Color;
-        fn sfColor_add(color1 : Color, color2 : Color) -> Color;
-        fn sfColor_modulate(color1 : Color, color2 : Color) -> Color;
+    extern "C" {
+        pub fn sfColor_fromRGB(red : u8, green : u8, blue : u8) -> Color;
+        pub fn sfColor_fromRGBA(red : u8, green : u8, blue : u8, alpha : u8) -> Color;
+        pub fn sfColor_add(color1 : Color, color2 : Color) -> Color;
+        pub fn sfColor_modulate(color1 : Color, color2 : Color) -> Color;
     }
 }
 

--- a/src/graphics/convex_shape.rs
+++ b/src/graphics/convex_shape.rs
@@ -62,39 +62,39 @@ pub mod ffi {
         InverseTransform : Transform
     }
 
-    pub extern "C" {
-        fn sfConvexShape_create() -> *sfConvexShape;
-        fn sfConvexShape_copy(shape : *sfConvexShape) -> *sfConvexShape;
-        fn sfConvexShape_destroy(shape : *sfConvexShape) -> ();
-        fn sfConvexShape_setPosition(shape : *sfConvexShape, position : Vector2f) -> ();
-        fn sfConvexShape_setRotation(shape : *sfConvexShape, angle : c_float) -> ();
-        fn sfConvexShape_setScale(shape : *sfConvexShape, scale : Vector2f) -> ();
-        fn sfConvexShape_setOrigin(shape : *sfConvexShape, origin : Vector2f) -> ();
-        fn sfConvexShape_getPosition(shape : *sfConvexShape) -> Vector2f;
-        fn sfConvexShape_getRotation(shape : *sfConvexShape) -> c_float;
-        fn sfConvexShape_getScale(shape : *sfConvexShape) -> Vector2f;
-        fn sfConvexShape_getOrigin(shape : *sfConvexShape) -> Vector2f;
-        fn sfConvexShape_move(shape : *sfConvexShape, offset : Vector2f) -> ();
-        fn sfConvexShape_rotate(shape : *sfConvexShape, angle : c_float) -> ();
-        fn sfConvexShape_scale(shape : *sfConvexShape, factors : Vector2f) -> ();
-        fn sfConvexShape_getTransform(shape : *sfConvexShape) -> Transform;
-        fn sfConvexShape_getInverseTransform(shape : *sfConvexShape) -> Transform;
-        fn sfConvexShape_setTexture(shape : *sfConvexShape, texture : *texture::ffi::sfTexture, resetRect : sfBool) -> ();
-        fn sfConvexShape_setTextureRect(shape : *sfConvexShape, rect : IntRect) -> ();
-        fn sfConvexShape_setFillColor(shape : *sfConvexShape, color : Color) -> ();
-        fn sfConvexShape_setOutlineColor(shape : *sfConvexShape, color : Color) -> ();
-        fn sfConvexShape_setOutlineThickness(shape : *sfConvexShape, thickness : c_float) -> ();
-        fn sfConvexShape_getTexture(shape : *sfConvexShape) -> *texture::ffi::sfTexture;
-        fn sfConvexShape_getTextureRect(shape : *sfConvexShape) -> IntRect;
-        fn sfConvexShape_getFillColor(shape : *sfConvexShape) -> Color;
-        fn sfConvexShape_getOutlineColor(shape : *sfConvexShape) -> Color;
-        fn sfConvexShape_getOutlineThickness(shape : *sfConvexShape) -> c_float;
-        fn sfConvexShape_getPointCount(shape : *sfConvexShape) -> c_uint;
-        fn sfConvexShape_getPoint(shape : *sfConvexShape, index : c_uint) -> Vector2f;
-        fn sfConvexShape_setPointCount(shape : *sfConvexShape, count : c_uint) -> ();
-        fn sfConvexShape_setPoint(shape : *sfConvexShape, index : c_uint, point : Vector2f) -> ();
-        fn sfConvexShape_getLocalBounds(shape : *sfConvexShape) -> FloatRect;
-        fn sfConvexShape_getGlobalBounds(shape : *sfConvexShape) -> FloatRect;
+    extern "C" {
+        pub fn sfConvexShape_create() -> *sfConvexShape;
+        pub fn sfConvexShape_copy(shape : *sfConvexShape) -> *sfConvexShape;
+        pub fn sfConvexShape_destroy(shape : *sfConvexShape) -> ();
+        pub fn sfConvexShape_setPosition(shape : *sfConvexShape, position : Vector2f) -> ();
+        pub fn sfConvexShape_setRotation(shape : *sfConvexShape, angle : c_float) -> ();
+        pub fn sfConvexShape_setScale(shape : *sfConvexShape, scale : Vector2f) -> ();
+        pub fn sfConvexShape_setOrigin(shape : *sfConvexShape, origin : Vector2f) -> ();
+        pub fn sfConvexShape_getPosition(shape : *sfConvexShape) -> Vector2f;
+        pub fn sfConvexShape_getRotation(shape : *sfConvexShape) -> c_float;
+        pub fn sfConvexShape_getScale(shape : *sfConvexShape) -> Vector2f;
+        pub fn sfConvexShape_getOrigin(shape : *sfConvexShape) -> Vector2f;
+        pub fn sfConvexShape_move(shape : *sfConvexShape, offset : Vector2f) -> ();
+        pub fn sfConvexShape_rotate(shape : *sfConvexShape, angle : c_float) -> ();
+        pub fn sfConvexShape_scale(shape : *sfConvexShape, factors : Vector2f) -> ();
+        pub fn sfConvexShape_getTransform(shape : *sfConvexShape) -> Transform;
+        pub fn sfConvexShape_getInverseTransform(shape : *sfConvexShape) -> Transform;
+        pub fn sfConvexShape_setTexture(shape : *sfConvexShape, texture : *texture::ffi::sfTexture, resetRect : sfBool) -> ();
+        pub fn sfConvexShape_setTextureRect(shape : *sfConvexShape, rect : IntRect) -> ();
+        pub fn sfConvexShape_setFillColor(shape : *sfConvexShape, color : Color) -> ();
+        pub fn sfConvexShape_setOutlineColor(shape : *sfConvexShape, color : Color) -> ();
+        pub fn sfConvexShape_setOutlineThickness(shape : *sfConvexShape, thickness : c_float) -> ();
+        pub fn sfConvexShape_getTexture(shape : *sfConvexShape) -> *texture::ffi::sfTexture;
+        pub fn sfConvexShape_getTextureRect(shape : *sfConvexShape) -> IntRect;
+        pub fn sfConvexShape_getFillColor(shape : *sfConvexShape) -> Color;
+        pub fn sfConvexShape_getOutlineColor(shape : *sfConvexShape) -> Color;
+        pub fn sfConvexShape_getOutlineThickness(shape : *sfConvexShape) -> c_float;
+        pub fn sfConvexShape_getPointCount(shape : *sfConvexShape) -> c_uint;
+        pub fn sfConvexShape_getPoint(shape : *sfConvexShape, index : c_uint) -> Vector2f;
+        pub fn sfConvexShape_setPointCount(shape : *sfConvexShape, count : c_uint) -> ();
+        pub fn sfConvexShape_setPoint(shape : *sfConvexShape, index : c_uint, point : Vector2f) -> ();
+        pub fn sfConvexShape_getLocalBounds(shape : *sfConvexShape) -> FloatRect;
+        pub fn sfConvexShape_getGlobalBounds(shape : *sfConvexShape) -> FloatRect;
     }
 }
 

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -50,16 +50,16 @@ pub mod ffi {
         This : *c_void
     }
 
-    pub extern "C" {
-        fn sfFont_createFromFile(filename : *c_char) -> *sfFont;
-        fn sfFont_copy(font : *sfFont) -> *sfFont;
+    extern "C" {
+        pub fn sfFont_createFromFile(filename : *c_char) -> *sfFont;
+        pub fn sfFont_copy(font : *sfFont) -> *sfFont;
         // fn sfFont_createFromMemory(data : *c_void, sizeInBytes : size_t) -> *sfFont;
         // fn sfFont_createFromStream(stream : *sfInputStream) -> *sfFont;
-        fn sfFont_destroy(font : *sfFont) -> ();
-        fn sfFont_getGlyph(font : *sfFont, codepoint : u32, characterSize : c_uint, bold :sfBool) -> Glyph;
-        fn sfFont_getKerning(font : *sfFont, first : u32, second : u32, characterSize : c_uint) -> c_int;
-        fn sfFont_getLineSpacing(font : *sfFont, characterSize : c_uint) -> c_int;
-        fn sfFont_getTexture(font : *sfFont, characterSize : c_uint) -> *texture::ffi::sfTexture;
+        pub fn sfFont_destroy(font : *sfFont) -> ();
+        pub fn sfFont_getGlyph(font : *sfFont, codepoint : u32, characterSize : c_uint, bold :sfBool) -> Glyph;
+        pub fn sfFont_getKerning(font : *sfFont, first : u32, second : u32, characterSize : c_uint) -> c_int;
+        pub fn sfFont_getLineSpacing(font : *sfFont, characterSize : c_uint) -> c_int;
+        pub fn sfFont_getTexture(font : *sfFont, characterSize : c_uint) -> *texture::ffi::sfTexture;
     }
 }
 

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -53,24 +53,24 @@ pub mod ffi {
         This : *c_void
     }
 
-    pub extern "C" {
-        fn sfImage_create(width : c_uint, height : c_uint) -> *sfImage;
-        fn sfImage_createFromColor(width : c_uint, height : c_uint, color : color::Color) -> *sfImage;
-        fn sfImage_createFromPixels(width : c_uint, height : c_uint, pixels : *u8) -> *sfImage;
-        fn sfImage_createFromFile(filename : *c_char) -> *sfImage;
+    extern "C" {
+        pub fn sfImage_create(width : c_uint, height : c_uint) -> *sfImage;
+        pub fn sfImage_createFromColor(width : c_uint, height : c_uint, color : color::Color) -> *sfImage;
+        pub fn sfImage_createFromPixels(width : c_uint, height : c_uint, pixels : *u8) -> *sfImage;
+        pub fn sfImage_createFromFile(filename : *c_char) -> *sfImage;
         //fn sfImage_createFromMemory(data : *c_void, size : size_t) -> *sfImage;
         //fn sfImage_createFromStream(stream : *sfInputStream) -> *sfImage;
-        fn sfImage_copy(image : *sfImage) -> *sfImage;
-        fn sfImage_destroy(image : *sfImage) -> ();
-        fn sfImage_saveToFile(image : *sfImage, filename : *c_char) -> sfBool;
-        fn sfImage_getSize(image : *sfImage) -> vector2::Vector2u;
-        fn sfImage_createMaskFromColor(image : *sfImage, color : color::Color, alpha : u8) -> ();
-        fn sfImage_copyImage(image : *sfImage, source : *sfImage, destX : c_uint, destY : c_uint, sourceRect : IntRect, applyAlpha : sfBool) -> ();
-        fn sfImage_setPixel(image : *sfImage, x : c_uint, y : c_uint, color : color::Color) -> ();
-        fn sfImage_getPixel(image : *sfImage, x : c_uint, y : c_uint) -> color::Color;
-        fn sfImage_getPixelsPtr(image : *sfImage) -> *u8;
-        fn sfImage_flipHorizontally(image : *sfImage) -> ();
-        fn sfImage_flipVertically(image : *sfImage) -> ();
+        pub fn sfImage_copy(image : *sfImage) -> *sfImage;
+        pub fn sfImage_destroy(image : *sfImage) -> ();
+        pub fn sfImage_saveToFile(image : *sfImage, filename : *c_char) -> sfBool;
+        pub fn sfImage_getSize(image : *sfImage) -> vector2::Vector2u;
+        pub fn sfImage_createMaskFromColor(image : *sfImage, color : color::Color, alpha : u8) -> ();
+        pub fn sfImage_copyImage(image : *sfImage, source : *sfImage, destX : c_uint, destY : c_uint, sourceRect : IntRect, applyAlpha : sfBool) -> ();
+        pub fn sfImage_setPixel(image : *sfImage, x : c_uint, y : c_uint, color : color::Color) -> ();
+        pub fn sfImage_getPixel(image : *sfImage, x : c_uint, y : c_uint) -> color::Color;
+        pub fn sfImage_getPixelsPtr(image : *sfImage) -> *u8;
+        pub fn sfImage_flipHorizontally(image : *sfImage) -> ();
+        pub fn sfImage_flipVertically(image : *sfImage) -> ();
     }
 }
 

--- a/src/graphics/rect.rs
+++ b/src/graphics/rect.rs
@@ -39,11 +39,11 @@ pub mod ffi {
     use graphics::rect::IntRect;
     use graphics::rect::FloatRect;
 
-    pub extern "C" {
-        fn sfIntRect_contains(rect : *IntRect, x : c_int, y : c_int) -> sfBool;
-        fn sfIntRect_intersects(rect1 : *IntRect, rect2 : *IntRect, intersectons : *IntRect) -> sfBool;
-        fn sfFloatRect_intersects(rect1 : *FloatRect, rect2 : *FloatRect, intersectons : *FloatRect) -> sfBool;
-        fn sfFloatRect_contains(rect : *FloatRect, x : f32, y : f32) -> sfBool;
+    extern "C" {
+        pub fn sfIntRect_contains(rect : *IntRect, x : c_int, y : c_int) -> sfBool;
+        pub fn sfIntRect_intersects(rect1 : *IntRect, rect2 : *IntRect, intersectons : *IntRect) -> sfBool;
+        pub fn sfFloatRect_intersects(rect1 : *FloatRect, rect2 : *FloatRect, intersectons : *FloatRect) -> sfBool;
+        pub fn sfFloatRect_contains(rect : *FloatRect, x : f32, y : f32) -> sfBool;
     }
 }
 

--- a/src/graphics/rectangle_shape.rs
+++ b/src/graphics/rectangle_shape.rs
@@ -61,39 +61,39 @@ pub mod ffi {
         InverseTransform : Transform
     }
     
-    pub extern "C" {
-        fn sfRectangleShape_create() -> *sfRectangleShape;
-        fn sfRectangleShape_copy(shape : *sfRectangleShape) -> *sfRectangleShape;
-        fn sfRectangleShape_destroy(shape : *sfRectangleShape) -> ();
-        fn sfRectangleShape_setPosition(shape : *sfRectangleShape, position : Vector2f) -> ();
-        fn sfRectangleShape_setRotation(shape : *sfRectangleShape, angle : c_float) -> ();
-        fn sfRectangleShape_setScale(shape : *sfRectangleShape, scale : Vector2f) -> ();
-        fn sfRectangleShape_setOrigin(shape : *sfRectangleShape, origin : Vector2f) -> ();
-        fn sfRectangleShape_getPosition(shape : *sfRectangleShape) -> Vector2f;
-        fn sfRectangleShape_getRotation(shape : *sfRectangleShape) -> c_float;
-        fn sfRectangleShape_getScale(shape : *sfRectangleShape) -> Vector2f;
-        fn sfRectangleShape_getOrigin(shape : *sfRectangleShape) -> Vector2f;
-        fn sfRectangleShape_move(shape : *sfRectangleShape, offset : Vector2f) -> ();
-        fn sfRectangleShape_rotate(shape : *sfRectangleShape, angle : c_float) -> ();
-        fn sfRectangleShape_scale(shape : *sfRectangleShape, factors : Vector2f) -> ();
-        fn sfRectangleShape_getTransform(shape : *sfRectangleShape) -> Transform;
-        fn sfRectangleShape_getInverseTransform(shape : *sfRectangleShape) -> Transform;
-        fn sfRectangleShape_setTexture(shape : *sfRectangleShape, texture : *texture::ffi::sfTexture, resetRect : sfBool) -> ();
-        fn sfRectangleShape_setTextureRect(shape : *sfRectangleShape, rect : IntRect) -> ();
-        fn sfRectangleShape_setFillColor(shape : *sfRectangleShape, color : Color) -> ();
-        fn sfRectangleShape_setOutlineColor(shape : *sfRectangleShape, color : Color) -> ();
-        fn sfRectangleShape_setOutlineThickness(shape : *sfRectangleShape, thickness : c_float) -> ();
-        fn sfRectangleShape_getTexture(shape : *sfRectangleShape) -> *texture::ffi::sfTexture;
-        fn sfRectangleShape_getTextureRect(shape : *sfRectangleShape) -> IntRect;
-        fn sfRectangleShape_getFillColor(shape : *sfRectangleShape) -> Color;
-        fn sfRectangleShape_getOutlineColor(shape : *sfRectangleShape) -> Color;
-        fn sfRectangleShape_getOutlineThickness(shape : *sfRectangleShape) -> c_float;
-        fn sfRectangleShape_getPointCount(shape : *sfRectangleShape) -> c_uint;
-        fn sfRectangleShape_getPoint(shape : *sfRectangleShape, index : c_uint) -> Vector2f;
-        fn sfRectangleShape_setSize(shape : *sfRectangleShape, size : Vector2f) -> ();
-        fn sfRectangleShape_getSize(shape : *sfRectangleShape) -> Vector2f;
-        fn sfRectangleShape_getLocalBounds(shape : *sfRectangleShape) -> FloatRect;
-        fn sfRectangleShape_getGlobalBounds(shape : *sfRectangleShape) -> FloatRect;
+    extern "C" {
+        pub fn sfRectangleShape_create() -> *sfRectangleShape;
+        pub fn sfRectangleShape_copy(shape : *sfRectangleShape) -> *sfRectangleShape;
+        pub fn sfRectangleShape_destroy(shape : *sfRectangleShape) -> ();
+        pub fn sfRectangleShape_setPosition(shape : *sfRectangleShape, position : Vector2f) -> ();
+        pub fn sfRectangleShape_setRotation(shape : *sfRectangleShape, angle : c_float) -> ();
+        pub fn sfRectangleShape_setScale(shape : *sfRectangleShape, scale : Vector2f) -> ();
+        pub fn sfRectangleShape_setOrigin(shape : *sfRectangleShape, origin : Vector2f) -> ();
+        pub fn sfRectangleShape_getPosition(shape : *sfRectangleShape) -> Vector2f;
+        pub fn sfRectangleShape_getRotation(shape : *sfRectangleShape) -> c_float;
+        pub fn sfRectangleShape_getScale(shape : *sfRectangleShape) -> Vector2f;
+        pub fn sfRectangleShape_getOrigin(shape : *sfRectangleShape) -> Vector2f;
+        pub fn sfRectangleShape_move(shape : *sfRectangleShape, offset : Vector2f) -> ();
+        pub fn sfRectangleShape_rotate(shape : *sfRectangleShape, angle : c_float) -> ();
+        pub fn sfRectangleShape_scale(shape : *sfRectangleShape, factors : Vector2f) -> ();
+        pub fn sfRectangleShape_getTransform(shape : *sfRectangleShape) -> Transform;
+        pub fn sfRectangleShape_getInverseTransform(shape : *sfRectangleShape) -> Transform;
+        pub fn sfRectangleShape_setTexture(shape : *sfRectangleShape, texture : *texture::ffi::sfTexture, resetRect : sfBool) -> ();
+        pub fn sfRectangleShape_setTextureRect(shape : *sfRectangleShape, rect : IntRect) -> ();
+        pub fn sfRectangleShape_setFillColor(shape : *sfRectangleShape, color : Color) -> ();
+        pub fn sfRectangleShape_setOutlineColor(shape : *sfRectangleShape, color : Color) -> ();
+        pub fn sfRectangleShape_setOutlineThickness(shape : *sfRectangleShape, thickness : c_float) -> ();
+        pub fn sfRectangleShape_getTexture(shape : *sfRectangleShape) -> *texture::ffi::sfTexture;
+        pub fn sfRectangleShape_getTextureRect(shape : *sfRectangleShape) -> IntRect;
+        pub fn sfRectangleShape_getFillColor(shape : *sfRectangleShape) -> Color;
+        pub fn sfRectangleShape_getOutlineColor(shape : *sfRectangleShape) -> Color;
+        pub fn sfRectangleShape_getOutlineThickness(shape : *sfRectangleShape) -> c_float;
+        pub fn sfRectangleShape_getPointCount(shape : *sfRectangleShape) -> c_uint;
+        pub fn sfRectangleShape_getPoint(shape : *sfRectangleShape, index : c_uint) -> Vector2f;
+        pub fn sfRectangleShape_setSize(shape : *sfRectangleShape, size : Vector2f) -> ();
+        pub fn sfRectangleShape_getSize(shape : *sfRectangleShape) -> Vector2f;
+        pub fn sfRectangleShape_getLocalBounds(shape : *sfRectangleShape) -> FloatRect;
+        pub fn sfRectangleShape_getGlobalBounds(shape : *sfRectangleShape) -> FloatRect;
     }
 }
 

--- a/src/graphics/render_texture.rs
+++ b/src/graphics/render_texture.rs
@@ -74,33 +74,33 @@ pub mod ffi {
         CurrentView : view::ffi::sfView
     }
     
-    pub extern "C" {
-        fn sfRenderTexture_create(width : c_uint, height : c_uint, depthBuffer : sfBool) -> *sfRenderTexture;
-        fn sfRenderTexture_destroy(renderTexture : *sfRenderTexture) -> ();
-        fn sfRenderTexture_getSize(renderTexture : *sfRenderTexture) -> Vector2u;
-        fn sfRenderTexture_setActive(renderTexture : *sfRenderTexture, active : sfBool) -> sfBool;
-        fn sfRenderTexture_display(renderTexture : *sfRenderTexture) -> ();
-        fn sfRenderTexture_clear(renderTexture : *sfRenderTexture, color : Color) -> ();
-        fn sfRenderTexture_setView(renderTexture : *sfRenderTexture, view : *view::ffi::sfView) -> ();
-        fn sfRenderTexture_getView(renderTexture : *sfRenderTexture) -> *view::ffi::sfView;
-        fn sfRenderTexture_getDefaultView(renderTexture : *sfRenderTexture) -> *view::ffi::sfView;
-        fn sfRenderTexture_getViewport(renderTexture : *sfRenderTexture, view : *view::ffi::sfView) -> IntRect;
-        fn sfRenderTexture_mapPixelToCoords(renderTexture : *sfRenderTexture, point : Vector2i, view : *view::ffi::sfView) -> Vector2f;
-        fn sfRenderTexture_mapCoordsToPixel(renderTexture : *sfRenderTexture, point : Vector2f, view : *view::ffi::sfView) -> Vector2i;
-        fn sfRenderTexture_drawSprite(renderTexture : *sfRenderTexture, object : *sprite::ffi::sfSprite, states : *render_states::ffi::sfRenderStates) -> ();
-        fn sfRenderTexture_drawText(renderTexture : *sfRenderTexture, object : *text::ffi::sfText, states : *render_states::ffi::sfRenderStates) -> ();
+    extern "C" {
+        pub fn sfRenderTexture_create(width : c_uint, height : c_uint, depthBuffer : sfBool) -> *sfRenderTexture;
+        pub fn sfRenderTexture_destroy(renderTexture : *sfRenderTexture) -> ();
+        pub fn sfRenderTexture_getSize(renderTexture : *sfRenderTexture) -> Vector2u;
+        pub fn sfRenderTexture_setActive(renderTexture : *sfRenderTexture, active : sfBool) -> sfBool;
+        pub fn sfRenderTexture_display(renderTexture : *sfRenderTexture) -> ();
+        pub fn sfRenderTexture_clear(renderTexture : *sfRenderTexture, color : Color) -> ();
+        pub fn sfRenderTexture_setView(renderTexture : *sfRenderTexture, view : *view::ffi::sfView) -> ();
+        pub fn sfRenderTexture_getView(renderTexture : *sfRenderTexture) -> *view::ffi::sfView;
+        pub fn sfRenderTexture_getDefaultView(renderTexture : *sfRenderTexture) -> *view::ffi::sfView;
+        pub fn sfRenderTexture_getViewport(renderTexture : *sfRenderTexture, view : *view::ffi::sfView) -> IntRect;
+        pub fn sfRenderTexture_mapPixelToCoords(renderTexture : *sfRenderTexture, point : Vector2i, view : *view::ffi::sfView) -> Vector2f;
+        pub fn sfRenderTexture_mapCoordsToPixel(renderTexture : *sfRenderTexture, point : Vector2f, view : *view::ffi::sfView) -> Vector2i;
+        pub fn sfRenderTexture_drawSprite(renderTexture : *sfRenderTexture, object : *sprite::ffi::sfSprite, states : *render_states::ffi::sfRenderStates) -> ();
+        pub fn sfRenderTexture_drawText(renderTexture : *sfRenderTexture, object : *text::ffi::sfText, states : *render_states::ffi::sfRenderStates) -> ();
         //fn sfRenderTexture_drawShape(renderTexture : *sfRenderTexture, object : *sfShape, states : *render_states::ffi::sfRenderStates) -> ();
-        fn sfRenderTexture_drawCircleShape(renderTexture : *sfRenderTexture, object : *circle_shape::ffi::sfCircleShape, states : *render_states::ffi::sfRenderStates) -> ();
-        fn sfRenderTexture_drawConvexShape(renderTexture : *sfRenderTexture, object : *convex_shape::ffi::sfConvexShape, states : *render_states::ffi::sfRenderStates) -> ();
-        fn sfRenderTexture_drawRectangleShape(renderTexture : *sfRenderTexture, object : *rectangle_shape::ffi::sfRectangleShape, states : *render_states::ffi::sfRenderStates) -> ();
-        fn sfRenderTexture_drawVertexArray(renderTexture : *sfRenderTexture, object : *vertex_array::ffi::sfVertexArray, states : *render_states::ffi::sfRenderStates) -> ();
+        pub fn sfRenderTexture_drawCircleShape(renderTexture : *sfRenderTexture, object : *circle_shape::ffi::sfCircleShape, states : *render_states::ffi::sfRenderStates) -> ();
+        pub fn sfRenderTexture_drawConvexShape(renderTexture : *sfRenderTexture, object : *convex_shape::ffi::sfConvexShape, states : *render_states::ffi::sfRenderStates) -> ();
+        pub fn sfRenderTexture_drawRectangleShape(renderTexture : *sfRenderTexture, object : *rectangle_shape::ffi::sfRectangleShape, states : *render_states::ffi::sfRenderStates) -> ();
+        pub fn sfRenderTexture_drawVertexArray(renderTexture : *sfRenderTexture, object : *vertex_array::ffi::sfVertexArray, states : *render_states::ffi::sfRenderStates) -> ();
         //fn sfRenderTexture_drawPrimitives(renderTexture : *sfRenderTexture) -> (); // a modifier
-        fn sfRenderTexture_pushGLStates(renderTexture : *sfRenderTexture) -> ();
-        fn sfRenderTexture_popGLStates(renderTexture : *sfRenderTexture) -> ();
-        fn sfRenderTexture_resetGLStates(renderTexture : *sfRenderTexture) -> ();
-        fn sfRenderTexture_getTexture(renderTexture : *sfRenderTexture) -> *texture::ffi::sfTexture;
-        fn sfRenderTexture_setSmooth(renderTexture : *sfRenderTexture, smooth : sfBool) -> ();
-        fn sfRenderTexture_isSmooth(renderTexture : *sfRenderTexture) -> sfBool;
+        pub fn sfRenderTexture_pushGLStates(renderTexture : *sfRenderTexture) -> ();
+        pub fn sfRenderTexture_popGLStates(renderTexture : *sfRenderTexture) -> ();
+        pub fn sfRenderTexture_resetGLStates(renderTexture : *sfRenderTexture) -> ();
+        pub fn sfRenderTexture_getTexture(renderTexture : *sfRenderTexture) -> *texture::ffi::sfTexture;
+        pub fn sfRenderTexture_setSmooth(renderTexture : *sfRenderTexture, smooth : sfBool) -> ();
+        pub fn sfRenderTexture_isSmooth(renderTexture : *sfRenderTexture) -> sfBool;
     }
 }
 

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -94,53 +94,53 @@ pub mod ffi {
         p5 : c_uint
     }
 
-    pub extern "C" {
-        fn sfRenderWindow_create(mode : ffi::sfVideoMode, title : *c_char, style : c_uint, settings : *ContextSettings) -> *sfRenderWindow;
-        fn sfRenderWindow_createUnicode(mode : ffi::sfVideoMode, title : *u32, style : c_uint, settings : *ContextSettings) -> *sfRenderWindow;
+    extern "C" {
+        pub fn sfRenderWindow_create(mode : ffi::sfVideoMode, title : *c_char, style : c_uint, settings : *ContextSettings) -> *sfRenderWindow;
+        pub fn sfRenderWindow_createUnicode(mode : ffi::sfVideoMode, title : *u32, style : c_uint, settings : *ContextSettings) -> *sfRenderWindow;
         //fn sfRenderWindow_createFromHandle(handle : sfWindowHandle, settings : *sfContextSettings) -> *sfRenderWindow;
-        fn sfRenderWindow_destroy(renderWindow : *sfRenderWindow) -> ();
-        fn sfRenderWindow_close(renderWindow : *sfRenderWindow) -> ();
-        fn sfRenderWindow_isOpen(renderWindow : *sfRenderWindow) -> sfBool;
-        fn sfRenderWindow_getSettings(renderWindow : *sfRenderWindow) -> ContextSettings;
-        fn sfRenderWindow_pollEvent(renderWindow : *sfRenderWindow, event : *sfEvent) -> sfBool;
-        fn sfRenderWindow_waitEvent(renderWindow : *sfRenderWindow, event : *sfEvent) -> sfBool;
-        fn sfRenderWindow_getPosition(renderWindow : *sfRenderWindow) -> Vector2i;
-        fn sfRenderWindow_setPosition(renderWindow : *sfRenderWindow, position : Vector2i) -> ();
-        fn sfRenderWindow_getSize(renderWindow : *sfRenderWindow) -> Vector2u;
-        fn sfRenderWindow_setSize(renderWindow : *sfRenderWindow, size : Vector2u) -> ();
-        fn sfRenderWindow_setTitle(renderWindow : *sfRenderWindow, title : *c_char) -> ();
-        fn sfRenderWindow_setUnicodeTitle(renderWindow : *sfRenderWindow, title : *u32) -> ();
-        fn sfRenderWindow_setIcon(renderWindow : *sfRenderWindow, width : c_uint, height : c_uint, pixels : *u8) -> ();
-        fn sfRenderWindow_setVisible(renderWindow : *sfRenderWindow, visible : sfBool) -> ();
-        fn sfRenderWindow_setMouseCursorVisible(renderWindow : *sfRenderWindow, show : sfBool) -> ();
-        fn sfRenderWindow_setVerticalSyncEnabled(renderWindow : *sfRenderWindow, enabled : sfBool) -> ();
-        fn sfRenderWindow_setKeyRepeatEnabled(renderWindow : *sfRenderWindow, enabled : sfBool) -> ();
-        fn sfRenderWindow_setActive(renderWindow : *sfRenderWindow, active : sfBool) -> sfBool;
-        fn sfRenderWindow_display(renderWindow : *sfRenderWindow) -> ();
-        fn sfRenderWindow_setFramerateLimit(renderWindow : *sfRenderWindow, limit : c_uint) -> ();
-        fn sfRenderWindow_setJoystickThreshold(renderWindow : *sfRenderWindow, treshold : c_float) -> ();
+        pub fn sfRenderWindow_destroy(renderWindow : *sfRenderWindow) -> ();
+        pub fn sfRenderWindow_close(renderWindow : *sfRenderWindow) -> ();
+        pub fn sfRenderWindow_isOpen(renderWindow : *sfRenderWindow) -> sfBool;
+        pub fn sfRenderWindow_getSettings(renderWindow : *sfRenderWindow) -> ContextSettings;
+        pub fn sfRenderWindow_pollEvent(renderWindow : *sfRenderWindow, event : *sfEvent) -> sfBool;
+        pub fn sfRenderWindow_waitEvent(renderWindow : *sfRenderWindow, event : *sfEvent) -> sfBool;
+        pub fn sfRenderWindow_getPosition(renderWindow : *sfRenderWindow) -> Vector2i;
+        pub fn sfRenderWindow_setPosition(renderWindow : *sfRenderWindow, position : Vector2i) -> ();
+        pub fn sfRenderWindow_getSize(renderWindow : *sfRenderWindow) -> Vector2u;
+        pub fn sfRenderWindow_setSize(renderWindow : *sfRenderWindow, size : Vector2u) -> ();
+        pub fn sfRenderWindow_setTitle(renderWindow : *sfRenderWindow, title : *c_char) -> ();
+        pub fn sfRenderWindow_setUnicodeTitle(renderWindow : *sfRenderWindow, title : *u32) -> ();
+        pub fn sfRenderWindow_setIcon(renderWindow : *sfRenderWindow, width : c_uint, height : c_uint, pixels : *u8) -> ();
+        pub fn sfRenderWindow_setVisible(renderWindow : *sfRenderWindow, visible : sfBool) -> ();
+        pub fn sfRenderWindow_setMouseCursorVisible(renderWindow : *sfRenderWindow, show : sfBool) -> ();
+        pub fn sfRenderWindow_setVerticalSyncEnabled(renderWindow : *sfRenderWindow, enabled : sfBool) -> ();
+        pub fn sfRenderWindow_setKeyRepeatEnabled(renderWindow : *sfRenderWindow, enabled : sfBool) -> ();
+        pub fn sfRenderWindow_setActive(renderWindow : *sfRenderWindow, active : sfBool) -> sfBool;
+        pub fn sfRenderWindow_display(renderWindow : *sfRenderWindow) -> ();
+        pub fn sfRenderWindow_setFramerateLimit(renderWindow : *sfRenderWindow, limit : c_uint) -> ();
+        pub fn sfRenderWindow_setJoystickThreshold(renderWindow : *sfRenderWindow, treshold : c_float) -> ();
         // fn sfRenderWindow_getSystemHandle(renderWindow : *sfRenderWindow) -> sfWindowHandle;
-        fn sfRenderWindow_clear(renderWindow : *sfRenderWindow, color : Color) -> ();
-        fn sfRenderWindow_setView(renderWindow : *sfRenderWindow, view : *sfView) -> ();
-        fn sfRenderWindow_getView(renderWindow : *sfRenderWindow) -> *sfView;
-        fn sfRenderWindow_getDefaultView(renderWindow : *sfRenderWindow) -> *sfView;
-        fn sfRenderWindow_getViewport(renderWindow : *sfRenderWindow, view : *sfView) -> IntRect;
-        fn sfRenderWindow_mapPixelToCoords(renderWindow : *sfRenderWindow, point : Vector2i, view : *sfView) -> Vector2f;
-        fn sfRenderWindow_mapCoordsToPixel(renderWindow : *sfRenderWindow, point : Vector2f, view : *sfView) -> Vector2i;
-        fn sfRenderWindow_drawSprite(renderWindow : *sfRenderWindow, object : *sfSprite, states : *render_states::ffi::sfRenderStates) -> ();
-        fn sfRenderWindow_drawText(renderWindow : *sfRenderWindow, object : *sfText, states : *render_states::ffi::sfRenderStates) -> ();
+        pub fn sfRenderWindow_clear(renderWindow : *sfRenderWindow, color : Color) -> ();
+        pub fn sfRenderWindow_setView(renderWindow : *sfRenderWindow, view : *sfView) -> ();
+        pub fn sfRenderWindow_getView(renderWindow : *sfRenderWindow) -> *sfView;
+        pub fn sfRenderWindow_getDefaultView(renderWindow : *sfRenderWindow) -> *sfView;
+        pub fn sfRenderWindow_getViewport(renderWindow : *sfRenderWindow, view : *sfView) -> IntRect;
+        pub fn sfRenderWindow_mapPixelToCoords(renderWindow : *sfRenderWindow, point : Vector2i, view : *sfView) -> Vector2f;
+        pub fn sfRenderWindow_mapCoordsToPixel(renderWindow : *sfRenderWindow, point : Vector2f, view : *sfView) -> Vector2i;
+        pub fn sfRenderWindow_drawSprite(renderWindow : *sfRenderWindow, object : *sfSprite, states : *render_states::ffi::sfRenderStates) -> ();
+        pub fn sfRenderWindow_drawText(renderWindow : *sfRenderWindow, object : *sfText, states : *render_states::ffi::sfRenderStates) -> ();
         // fn sfRenderWindow_drawShape(renderWindow : *sfRenderWindow, object : *sfShape, states : *sfRenderStates) -> ();
-        fn sfRenderWindow_drawCircleShape(renderWindow : *sfRenderWindow, object : *sfCircleShape, states : *render_states::ffi::sfRenderStates) -> ();
-        fn sfRenderWindow_drawConvexShape(renderWindow : *sfRenderWindow, object : *sfConvexShape, states : *render_states::ffi::sfRenderStates) -> ();
-        fn sfRenderWindow_drawRectangleShape(renderWindow : *sfRenderWindow, object : *sfRectangleShape, states : *render_states::ffi::sfRenderStates) -> ();
-        fn sfRenderWindow_drawVertexArray(renderWindow : *sfRenderWindow, object : *sfVertexArray, states : *render_states::ffi::sfRenderStates) -> ();
+        pub fn sfRenderWindow_drawCircleShape(renderWindow : *sfRenderWindow, object : *sfCircleShape, states : *render_states::ffi::sfRenderStates) -> ();
+        pub fn sfRenderWindow_drawConvexShape(renderWindow : *sfRenderWindow, object : *sfConvexShape, states : *render_states::ffi::sfRenderStates) -> ();
+        pub fn sfRenderWindow_drawRectangleShape(renderWindow : *sfRenderWindow, object : *sfRectangleShape, states : *render_states::ffi::sfRenderStates) -> ();
+        pub fn sfRenderWindow_drawVertexArray(renderWindow : *sfRenderWindow, object : *sfVertexArray, states : *render_states::ffi::sfRenderStates) -> ();
         // fn sfRenderWindow_drawPrimitives(renderWindow : *sfRenderWindow, vertices : *sfVertex, vertexCount : c_uint, ttype : sfPrimitiveType, states : *sfRenderStates) -> ();  
-        fn sfRenderWindow_pushGLStates(renderWindow : *sfRenderWindow) -> ();
-        fn sfRenderWindow_popGLStates(renderWindow : *sfRenderWindow) -> ();
-        fn sfRenderWindow_resetGLStates(renderWindow : *sfRenderWindow) -> ();
-        fn sfRenderWindow_capture(renderWindow : *sfRenderWindow) -> *sfImage;
-        fn sfMouse_getPositionRenderWindow(relativeTo : *sfRenderWindow) -> Vector2i;
-        fn sfMouse_setPositionRenderWindow(position : Vector2i, relativeTo : *sfRenderWindow) -> ();
+        pub fn sfRenderWindow_pushGLStates(renderWindow : *sfRenderWindow) -> ();
+        pub fn sfRenderWindow_popGLStates(renderWindow : *sfRenderWindow) -> ();
+        pub fn sfRenderWindow_resetGLStates(renderWindow : *sfRenderWindow) -> ();
+        pub fn sfRenderWindow_capture(renderWindow : *sfRenderWindow) -> *sfImage;
+        pub fn sfMouse_getPositionRenderWindow(relativeTo : *sfRenderWindow) -> Vector2i;
+        pub fn sfMouse_setPositionRenderWindow(position : Vector2i, relativeTo : *sfRenderWindow) -> ();
     }    
 }
 

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -55,23 +55,23 @@ pub mod ffi {
         This : *c_void
     }
 
-    pub extern "C" {
-        fn sfShader_createFromFile(vertexShaderFilename : *c_char, fragmentShaderFilename : *c_char) -> *sfShader;
-        fn sfShader_createFromMemory(vertexShader : *c_char, fragmentShader : *c_char) -> *sfShader;
+    extern "C" {
+        pub fn sfShader_createFromFile(vertexShaderFilename : *c_char, fragmentShaderFilename : *c_char) -> *sfShader;
+        pub fn sfShader_createFromMemory(vertexShader : *c_char, fragmentShader : *c_char) -> *sfShader;
         //fn sfShader_createFromStream(vertexShaderStream : *sfInputStream, fragmentShaderStream : *sfInputStream) -> *sfShader;
-        fn sfShader_destroy(shader : *sfShader)-> ();
-        fn sfShader_setFloatParameter(shader : *sfShader, name : *c_char, x : c_float) -> ();
-        fn sfShader_setFloat2Parameter(shader : *sfShader, name : *c_char, x : c_float, y : c_float) -> ();
-        fn sfShader_setFloat3Parameter(shader : *sfShader, name : *c_char, x : c_float, y : c_float, z : c_float) -> ();
-        fn sfShader_setFloat4Parameter(shader : *sfShader, name : *c_char, x : c_float, y : c_float, z : c_float, w : c_float) -> ();
-        fn sfShader_setVector2Parameter(shader : *sfShader, name : *c_char, vector : Vector2f) -> ();
-        fn sfShader_setVector3Parameter(shader : *sfShader, name : *c_char, vector : Vector3f) -> ();
-        fn sfShader_setColorParameter(shader : *sfShader, name : *c_char, color : Color) -> (); 
-        fn sfShader_setTransformParameter(shader : *sfShader, name : *c_char, transform : transform::Transform) -> ();
-        fn sfShader_setTextureParameter(shader : *sfShader, name : *c_char, texture : *texture::ffi::sfTexture) -> ();
-        fn sfShader_setCurrentTextureParameter(shader : *sfShader, name : *c_char) -> ();
-        fn sfShader_bind(shader : *sfShader) -> ();
-        fn sfShader_isAvailable() -> sfBool;
+        pub fn sfShader_destroy(shader : *sfShader)-> ();
+        pub fn sfShader_setFloatParameter(shader : *sfShader, name : *c_char, x : c_float) -> ();
+        pub fn sfShader_setFloat2Parameter(shader : *sfShader, name : *c_char, x : c_float, y : c_float) -> ();
+        pub fn sfShader_setFloat3Parameter(shader : *sfShader, name : *c_char, x : c_float, y : c_float, z : c_float) -> ();
+        pub fn sfShader_setFloat4Parameter(shader : *sfShader, name : *c_char, x : c_float, y : c_float, z : c_float, w : c_float) -> ();
+        pub fn sfShader_setVector2Parameter(shader : *sfShader, name : *c_char, vector : Vector2f) -> ();
+        pub fn sfShader_setVector3Parameter(shader : *sfShader, name : *c_char, vector : Vector3f) -> ();
+        pub fn sfShader_setColorParameter(shader : *sfShader, name : *c_char, color : Color) -> (); 
+        pub fn sfShader_setTransformParameter(shader : *sfShader, name : *c_char, transform : transform::Transform) -> ();
+        pub fn sfShader_setTextureParameter(shader : *sfShader, name : *c_char, texture : *texture::ffi::sfTexture) -> ();
+        pub fn sfShader_setCurrentTextureParameter(shader : *sfShader, name : *c_char) -> ();
+        pub fn sfShader_bind(shader : *sfShader) -> ();
+        pub fn sfShader_isAvailable() -> sfBool;
    }
 }
 

--- a/src/graphics/sprite.rs
+++ b/src/graphics/sprite.rs
@@ -62,31 +62,31 @@ pub mod ffi {
         InverseTransform : Transform
     }
 
-    pub extern "C" {
-        fn sfSprite_create() -> *sfSprite;
-        fn sfSprite_copy(sprite : *sfSprite) -> *sfSprite;
-        fn sfSprite_destroy(sprite : *sfSprite) -> ();
-        fn sfSprite_setPosition(sprite : *sfSprite, position : Vector2f) -> ();
-        fn sfSprite_setRotation(sprite : *sfSprite, angle : c_float) -> ();
-        fn sfSprite_setScale(sprite : *sfSprite, scale : Vector2f) -> ();
-        fn sfSprite_setOrigin(sprite : *sfSprite, origin : Vector2f) -> ();
-        fn sfSprite_getPosition(sprite : *sfSprite) -> Vector2f;
-        fn sfSprite_getRotation(sprite : *sfSprite) -> c_float;
-        fn sfSprite_getScale(sprite : *sfSprite) -> Vector2f;
-        fn sfSprite_getOrigin(sprite : *sfSprite) -> Vector2f;
-        fn sfSprite_move(sprite : *sfSprite, offset : Vector2f) -> ();
-        fn sfSprite_rotate(sprite : *sfSprite, angle : c_float) -> ();
-        fn sfSprite_scale(sprite : *sfSprite, factors : Vector2f) -> ();
-        fn sfSprite_getTransform(sprite : *sfSprite) -> Transform;
-        fn sfSprite_getInverseTransform(sprite : *sfSprite) -> Transform;
-        fn sfSprite_setTexture(sprite : *sfSprite, texture : *texture::ffi::sfTexture, resetRect : sfBool) -> ();
-        fn sfSprite_setTextureRect(sprite : *sfSprite, rectangle : IntRect) -> ();
-        fn sfSprite_setColor(sprite : *sfSprite, color : Color) -> ();
-        fn sfSprite_getTexture(sprite : *sfSprite) -> *texture::ffi::sfTexture;
-        fn sfSprite_getTextureRect(sprite : *sfSprite) -> IntRect;
-        fn sfSprite_getColor(sprite : *sfSprite) -> Color;
-        fn sfSprite_getLocalBounds(sprite : *sfSprite) -> FloatRect;
-        fn sfSprite_getGlobalBounds(sprite : *sfSprite) -> FloatRect;
+    extern "C" {
+        pub fn sfSprite_create() -> *sfSprite;
+        pub fn sfSprite_copy(sprite : *sfSprite) -> *sfSprite;
+        pub fn sfSprite_destroy(sprite : *sfSprite) -> ();
+        pub fn sfSprite_setPosition(sprite : *sfSprite, position : Vector2f) -> ();
+        pub fn sfSprite_setRotation(sprite : *sfSprite, angle : c_float) -> ();
+        pub fn sfSprite_setScale(sprite : *sfSprite, scale : Vector2f) -> ();
+        pub fn sfSprite_setOrigin(sprite : *sfSprite, origin : Vector2f) -> ();
+        pub fn sfSprite_getPosition(sprite : *sfSprite) -> Vector2f;
+        pub fn sfSprite_getRotation(sprite : *sfSprite) -> c_float;
+        pub fn sfSprite_getScale(sprite : *sfSprite) -> Vector2f;
+        pub fn sfSprite_getOrigin(sprite : *sfSprite) -> Vector2f;
+        pub fn sfSprite_move(sprite : *sfSprite, offset : Vector2f) -> ();
+        pub fn sfSprite_rotate(sprite : *sfSprite, angle : c_float) -> ();
+        pub fn sfSprite_scale(sprite : *sfSprite, factors : Vector2f) -> ();
+        pub fn sfSprite_getTransform(sprite : *sfSprite) -> Transform;
+        pub fn sfSprite_getInverseTransform(sprite : *sfSprite) -> Transform;
+        pub fn sfSprite_setTexture(sprite : *sfSprite, texture : *texture::ffi::sfTexture, resetRect : sfBool) -> ();
+        pub fn sfSprite_setTextureRect(sprite : *sfSprite, rectangle : IntRect) -> ();
+        pub fn sfSprite_setColor(sprite : *sfSprite, color : Color) -> ();
+        pub fn sfSprite_getTexture(sprite : *sfSprite) -> *texture::ffi::sfTexture;
+        pub fn sfSprite_getTextureRect(sprite : *sfSprite) -> IntRect;
+        pub fn sfSprite_getColor(sprite : *sfSprite) -> Color;
+        pub fn sfSprite_getLocalBounds(sprite : *sfSprite) -> FloatRect;
+        pub fn sfSprite_getGlobalBounds(sprite : *sfSprite) -> FloatRect;
     }
 }
 

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -64,38 +64,38 @@ pub mod ffi {
         transform2 : transform::Transform
     }
 
-    pub extern "C" {
-        fn sfText_create() -> *sfText;
-        fn sfText_copy(text : *sfText) -> *sfText;
-        fn sfText_destroy(text : *sfText) -> ();
-        fn sfText_setPosition(text : *sfText, position : Vector2f) -> ();
-        fn sfText_setRotation(text : *sfText, angle : c_float) -> ();
-        fn sfText_setScale(text : *sfText, scale : Vector2f) -> ();
-        fn sfText_setOrigin(text : *sfText, origin : Vector2f) -> ();
-        fn sfText_getPosition(text : *sfText) -> Vector2f;
-        fn sfText_getRotation(text : *sfText) -> c_float;
-        fn sfText_getScale(text : *sfText) -> Vector2f;
-        fn sfText_getOrigin(text : *sfText) -> Vector2f;
-        fn sfText_move(text : *sfText, offset : Vector2f) -> ();
-        fn sfText_rotate(text : *sfText, angle : c_float) -> ();
-        fn sfText_scale(text : *sfText, factors : Vector2f) -> ();
-        fn sfText_getTransform(text : *sfText) -> Transform;
-        fn sfText_getInverseTransform(text : *sfText) -> Transform;
-        fn sfText_setString(text : *sfText, string : *c_char) -> ();
-        fn sfText_setUnicodeString(text : *sfText, string : *u32 ) -> ();
-        fn sfText_setFont(text : *sfText, font : *font::ffi::sfFont) -> ();
-        fn sfText_setCharacterSize(text : *sfText, size : c_uint) -> ();
-        fn sfText_setStyle(text : *sfText, style : u32) -> ();
-        fn sfText_setColor(text : *sfText, color : color::Color) -> ();
-        fn sfText_getString(text : *sfText) -> *c_char;
-        fn sfText_getUnicodeString(text : *sfText) -> *mut u32;
-        fn sfText_getFont(text : *sfText) -> *font::ffi::sfFont;
-        fn sfText_getCharacterSize(text : *sfText) -> c_uint;
-        fn sfText_getStyle(text : *sfText) -> u32;
-        fn sfText_getColor(text : *sfText) -> color::Color;
-        fn sfText_findCharacterPos(text : *sfText, index : size_t) -> Vector2f;
-        fn sfText_getLocalBounds(text : *sfText) -> FloatRect;
-        fn sfText_getGlobalBounds(text : *sfText) -> FloatRect;
+    extern "C" {
+        pub fn sfText_create() -> *sfText;
+        pub fn sfText_copy(text : *sfText) -> *sfText;
+        pub fn sfText_destroy(text : *sfText) -> ();
+        pub fn sfText_setPosition(text : *sfText, position : Vector2f) -> ();
+        pub fn sfText_setRotation(text : *sfText, angle : c_float) -> ();
+        pub fn sfText_setScale(text : *sfText, scale : Vector2f) -> ();
+        pub fn sfText_setOrigin(text : *sfText, origin : Vector2f) -> ();
+        pub fn sfText_getPosition(text : *sfText) -> Vector2f;
+        pub fn sfText_getRotation(text : *sfText) -> c_float;
+        pub fn sfText_getScale(text : *sfText) -> Vector2f;
+        pub fn sfText_getOrigin(text : *sfText) -> Vector2f;
+        pub fn sfText_move(text : *sfText, offset : Vector2f) -> ();
+        pub fn sfText_rotate(text : *sfText, angle : c_float) -> ();
+        pub fn sfText_scale(text : *sfText, factors : Vector2f) -> ();
+        pub fn sfText_getTransform(text : *sfText) -> Transform;
+        pub fn sfText_getInverseTransform(text : *sfText) -> Transform;
+        pub fn sfText_setString(text : *sfText, string : *c_char) -> ();
+        pub fn sfText_setUnicodeString(text : *sfText, string : *u32 ) -> ();
+        pub fn sfText_setFont(text : *sfText, font : *font::ffi::sfFont) -> ();
+        pub fn sfText_setCharacterSize(text : *sfText, size : c_uint) -> ();
+        pub fn sfText_setStyle(text : *sfText, style : u32) -> ();
+        pub fn sfText_setColor(text : *sfText, color : color::Color) -> ();
+        pub fn sfText_getString(text : *sfText) -> *c_char;
+        pub fn sfText_getUnicodeString(text : *sfText) -> *mut u32;
+        pub fn sfText_getFont(text : *sfText) -> *font::ffi::sfFont;
+        pub fn sfText_getCharacterSize(text : *sfText) -> c_uint;
+        pub fn sfText_getStyle(text : *sfText) -> u32;
+        pub fn sfText_getColor(text : *sfText) -> color::Color;
+        pub fn sfText_findCharacterPos(text : *sfText, index : size_t) -> Vector2f;
+        pub fn sfText_getLocalBounds(text : *sfText) -> FloatRect;
+        pub fn sfText_getGlobalBounds(text : *sfText) -> FloatRect;
     }
 }
 

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -57,26 +57,26 @@ pub mod ffi {
         this : *c_void
     }
 
-    pub extern "C" {
-        fn sfTexture_create(width : c_uint, height : c_uint) -> *sfTexture;
-        fn sfTexture_createFromFile(filename : *c_char, area : *IntRect) -> *sfTexture;
+    extern "C" {
+        pub fn sfTexture_create(width : c_uint, height : c_uint) -> *sfTexture;
+        pub fn sfTexture_createFromFile(filename : *c_char, area : *IntRect) -> *sfTexture;
         //fn sfTexture_createFromMemory(data : *c_void, sizeInBytes : size_t , area : *sfIntRect) -> *sfTexture;
         //fn sfTexture_createFromStream(strea; : *sfInputStream, area : *sfIntRect) -> *sfTexture;
-        fn sfTexture_createFromImage(image :*image::ffi::sfImage, area : *IntRect) -> *sfTexture;
-        fn sfTexture_copy(texture : *sfTexture) -> *sfTexture;
-        fn sfTexture_destroy(texture : *sfTexture) -> ();
-        fn sfTexture_getSize(texture : *sfTexture) -> Vector2u;
-        fn sfTexture_copyToImage(texture : *sfTexture) -> *image::ffi::sfImage;
-        fn sfTexture_updateFromPixels(texture : *sfTexture, pixels : *u8, width : c_uint, height : c_uint, x : c_uint, y : c_uint) -> ();
-        fn sfTexture_updateFromImage(texture : *sfTexture, image : *image::ffi::sfImage, x : c_uint, y : c_uint) -> ();
-        fn sfTexture_updateFromWindow(texture : *sfTexture, window : *sfWindow, x : c_uint, y : c_uint) -> ();
-        fn sfTexture_updateFromRenderWindow(texture : *sfTexture, renderWindow : *sfRenderWindow, x : c_uint, y : c_uint) -> ();
-        fn sfTexture_setSmooth(texture : *sfTexture, smooth : sfBool) -> ();
-        fn sfTexture_isSmooth(texture : *sfTexture) -> sfBool;
-        fn sfTexture_setRepeated(texture : *sfTexture, repeated : sfBool);
-        fn sfTexture_isRepeated(texture : *sfTexture) -> sfBool;
-        fn sfTexture_bind(texture : *sfTexture) -> ();
-        fn sfTexture_getMaximumSize() -> c_uint;
+        pub fn sfTexture_createFromImage(image :*image::ffi::sfImage, area : *IntRect) -> *sfTexture;
+        pub fn sfTexture_copy(texture : *sfTexture) -> *sfTexture;
+        pub fn sfTexture_destroy(texture : *sfTexture) -> ();
+        pub fn sfTexture_getSize(texture : *sfTexture) -> Vector2u;
+        pub fn sfTexture_copyToImage(texture : *sfTexture) -> *image::ffi::sfImage;
+        pub fn sfTexture_updateFromPixels(texture : *sfTexture, pixels : *u8, width : c_uint, height : c_uint, x : c_uint, y : c_uint) -> ();
+        pub fn sfTexture_updateFromImage(texture : *sfTexture, image : *image::ffi::sfImage, x : c_uint, y : c_uint) -> ();
+        pub fn sfTexture_updateFromWindow(texture : *sfTexture, window : *sfWindow, x : c_uint, y : c_uint) -> ();
+        pub fn sfTexture_updateFromRenderWindow(texture : *sfTexture, renderWindow : *sfRenderWindow, x : c_uint, y : c_uint) -> ();
+        pub fn sfTexture_setSmooth(texture : *sfTexture, smooth : sfBool) -> ();
+        pub fn sfTexture_isSmooth(texture : *sfTexture) -> sfBool;
+        pub fn sfTexture_setRepeated(texture : *sfTexture, repeated : sfBool);
+        pub fn sfTexture_isRepeated(texture : *sfTexture) -> sfBool;
+        pub fn sfTexture_bind(texture : *sfTexture) -> ();
+        pub fn sfTexture_getMaximumSize() -> c_uint;
     }
 }
 

--- a/src/graphics/transform.rs
+++ b/src/graphics/transform.rs
@@ -46,18 +46,18 @@ pub mod ffi {
     use graphics::rect::FloatRect;
     use graphics::transform::Transform;
 
-    pub extern "C" {
-        fn sfTransform_fromMatrix(a01 : f32, a02 : f32, a03 : f32, b01 : f32, b02 : f32, b03 : f32, c01 : f32, c02 : f32, c03 : f32) -> Transform;
-        fn sfTransform_getMatrix(tranform : *Transform, matrix : *f32) -> ();
-        fn sfTransform_getInverse(transform : *Transform) -> Transform;
-        fn sfTransform_transformPoint(transform : *Transform, point : Vector2f) -> Vector2f;
-        fn sfTransform_transformRect(transform : *Transform, rectangle : FloatRect) -> FloatRect;
-        fn sfTransform_combine(transform : *Transform, other : *Transform) -> ();
-        fn sfTransform_translate(transform : *Transform, x : c_float, y : c_float) -> ();
-        fn sfTransform_rotate(transform : *Transform, angle : c_float) -> ();
-        fn sfTransform_rotateWithCenter(transform : *Transform, angle : c_float, centerX : c_float, centerY : c_float) -> ();
-        fn sfTransform_scale(transform : *Transform, scaleX : c_float, scaleY : c_float) -> ();
-        fn sfTransform_scaleWithCenter(transform: *Transform, scaleX : c_float, scaleY : c_float, centerX : c_float, centerY : c_float) -> ();
+    extern "C" {
+        pub fn sfTransform_fromMatrix(a01 : f32, a02 : f32, a03 : f32, b01 : f32, b02 : f32, b03 : f32, c01 : f32, c02 : f32, c03 : f32) -> Transform;
+        pub fn sfTransform_getMatrix(tranform : *Transform, matrix : *f32) -> ();
+        pub fn sfTransform_getInverse(transform : *Transform) -> Transform;
+        pub fn sfTransform_transformPoint(transform : *Transform, point : Vector2f) -> Vector2f;
+        pub fn sfTransform_transformRect(transform : *Transform, rectangle : FloatRect) -> FloatRect;
+        pub fn sfTransform_combine(transform : *Transform, other : *Transform) -> ();
+        pub fn sfTransform_translate(transform : *Transform, x : c_float, y : c_float) -> ();
+        pub fn sfTransform_rotate(transform : *Transform, angle : c_float) -> ();
+        pub fn sfTransform_rotateWithCenter(transform : *Transform, angle : c_float, centerX : c_float, centerY : c_float) -> ();
+        pub fn sfTransform_scale(transform : *Transform, scaleX : c_float, scaleY : c_float) -> ();
+        pub fn sfTransform_scaleWithCenter(transform: *Transform, scaleX : c_float, scaleY : c_float, centerX : c_float, centerY : c_float) -> ();
     }
 }
 

--- a/src/graphics/transformable.rs
+++ b/src/graphics/transformable.rs
@@ -50,23 +50,23 @@ pub mod ffi {
         inverseTransform : Transform
     }
 
-    pub extern "C" {
-        fn sfTransformable_create() -> *sfTransformable;
-        fn sfTransformable_copy(transformable : *sfTransformable) -> *sfTransformable;
-        fn sfTransformable_destroy(transformable : *sfTransformable) -> ();
-        fn sfTransformable_setPosition(transformable : *sfTransformable, position : Vector2f) -> ();
-        fn sfTransformable_setRotation(transformable : *sfTransformable, angle : c_float) -> ();
-        fn sfTransformable_setScale(transformable : *sfTransformable, scale : Vector2f) -> ();
-        fn sfTransformable_setOrigin(transformable : *sfTransformable, origin : Vector2f) -> ();
-        fn sfTransformable_getPosition(transformable : *sfTransformable) -> Vector2f;
-        fn sfTransformable_getRotation(transformable : *sfTransformable) -> c_float;
-        fn sfTransformable_getScale(transformable : *sfTransformable) -> Vector2f;
-        fn sfTransformable_getOrigin(transformable : *sfTransformable) -> Vector2f;
-        fn sfTransformable_move(transformable : *sfTransformable, offset : Vector2f) -> ();
-        fn sfTransformable_rotate(transformable : *sfTransformable, angle : c_float) -> ();
-        fn sfTransformable_scale(transformable : *sfTransformable, factors : Vector2f) -> ();
-        fn sfTransformable_getTransform(transformable : *sfTransformable) -> Transform;
-        fn sfTransformable_getInverseTransform(transformable : *sfTransformable) -> Transform;
+    extern "C" {
+        pub fn sfTransformable_create() -> *sfTransformable;
+        pub fn sfTransformable_copy(transformable : *sfTransformable) -> *sfTransformable;
+        pub fn sfTransformable_destroy(transformable : *sfTransformable) -> ();
+        pub fn sfTransformable_setPosition(transformable : *sfTransformable, position : Vector2f) -> ();
+        pub fn sfTransformable_setRotation(transformable : *sfTransformable, angle : c_float) -> ();
+        pub fn sfTransformable_setScale(transformable : *sfTransformable, scale : Vector2f) -> ();
+        pub fn sfTransformable_setOrigin(transformable : *sfTransformable, origin : Vector2f) -> ();
+        pub fn sfTransformable_getPosition(transformable : *sfTransformable) -> Vector2f;
+        pub fn sfTransformable_getRotation(transformable : *sfTransformable) -> c_float;
+        pub fn sfTransformable_getScale(transformable : *sfTransformable) -> Vector2f;
+        pub fn sfTransformable_getOrigin(transformable : *sfTransformable) -> Vector2f;
+        pub fn sfTransformable_move(transformable : *sfTransformable, offset : Vector2f) -> ();
+        pub fn sfTransformable_rotate(transformable : *sfTransformable, angle : c_float) -> ();
+        pub fn sfTransformable_scale(transformable : *sfTransformable, factors : Vector2f) -> ();
+        pub fn sfTransformable_getTransform(transformable : *sfTransformable) -> Transform;
+        pub fn sfTransformable_getInverseTransform(transformable : *sfTransformable) -> Transform;
     }
 }
 

--- a/src/graphics/vertex_array.rs
+++ b/src/graphics/vertex_array.rs
@@ -63,18 +63,18 @@ pub mod ffi {
         This : *c_void
     }
 
-    pub extern "C" {
-        fn sfVertexArray_create() -> *sfVertexArray;
-        fn sfVertexArray_copy(vertexArray : *sfVertexArray) -> *sfVertexArray;
-        fn sfVertexArray_destroy(vertexArray : *sfVertexArray) -> ();
-        fn sfVertexArray_getVertexCount(vertexArray : *sfVertexArray) -> c_uint;
-        fn sfVertexArray_getVertex(vertexArray : *sfVertexArray, index : c_uint) -> *vertex::Vertex;
-        fn sfVertexArray_clear(vertexArray : *sfVertexArray) -> ();
-        fn sfVertexArray_resize(vertexArray : *sfVertexArray, vertexCount : c_uint) -> ();
-        fn sfVertexArray_append(vertexArray : *sfVertexArray, vertex : vertex::Vertex) -> ();
-        fn sfVertexArray_setPrimitiveType(vertexArray : *sfVertexArray, stype : sfPrimitiveType) -> ();
-        fn sfVertexArray_getPrimitiveType(vertexArray : *sfVertexArray) -> sfPrimitiveType;
-        fn sfVertexArray_getBounds(vertexArray : *sfVertexArray) -> FloatRect;
+    extern "C" {
+        pub fn sfVertexArray_create() -> *sfVertexArray;
+        pub fn sfVertexArray_copy(vertexArray : *sfVertexArray) -> *sfVertexArray;
+        pub fn sfVertexArray_destroy(vertexArray : *sfVertexArray) -> ();
+        pub fn sfVertexArray_getVertexCount(vertexArray : *sfVertexArray) -> c_uint;
+        pub fn sfVertexArray_getVertex(vertexArray : *sfVertexArray, index : c_uint) -> *vertex::Vertex;
+        pub fn sfVertexArray_clear(vertexArray : *sfVertexArray) -> ();
+        pub fn sfVertexArray_resize(vertexArray : *sfVertexArray, vertexCount : c_uint) -> ();
+        pub fn sfVertexArray_append(vertexArray : *sfVertexArray, vertex : vertex::Vertex) -> ();
+        pub fn sfVertexArray_setPrimitiveType(vertexArray : *sfVertexArray, stype : sfPrimitiveType) -> ();
+        pub fn sfVertexArray_getPrimitiveType(vertexArray : *sfVertexArray) -> sfPrimitiveType;
+        pub fn sfVertexArray_getBounds(vertexArray : *sfVertexArray) -> FloatRect;
     }
 }
 

--- a/src/graphics/view.rs
+++ b/src/graphics/view.rs
@@ -48,23 +48,23 @@ pub mod ffi {
         This : *c_void
     }
 
-    pub extern "C" {
-        fn sfView_create() -> *sfView;
-        fn sfView_createFromRect(rectangle : FloatRect) -> *sfView;
-        fn sfView_copy(view : *sfView) -> *sfView;
-        fn sfView_destroy(view : *sfView) -> ();
-        fn sfView_setCenter(view : *sfView, center : Vector2f) -> ();
-        fn sfView_setSize(view : *sfView, size : Vector2f) -> ();
-        fn sfView_setRotation(view : *sfView, angle : c_float) -> ();
-        fn sfView_setViewport(view : *sfView, viewport : FloatRect) -> ();
-        fn sfView_reset(view : *sfView, rectangle : FloatRect) -> ();
-        fn sfView_getCenter(view : *sfView) -> Vector2f;
-        fn sfView_getSize(view : *sfView) -> Vector2f;
-        fn sfView_getRotation(view : *sfView) -> c_float;
-        fn sfView_getViewport(view : *sfView) -> FloatRect;
-        fn sfView_move(view : *sfView, offset : Vector2f) -> ();
-        fn sfView_rotate(view : *sfView, angle : c_float) -> ();
-        fn sfView_zoom(view : *sfView, factor : c_float) -> ();
+    extern "C" {
+        pub fn sfView_create() -> *sfView;
+        pub fn sfView_createFromRect(rectangle : FloatRect) -> *sfView;
+        pub fn sfView_copy(view : *sfView) -> *sfView;
+        pub fn sfView_destroy(view : *sfView) -> ();
+        pub fn sfView_setCenter(view : *sfView, center : Vector2f) -> ();
+        pub fn sfView_setSize(view : *sfView, size : Vector2f) -> ();
+        pub fn sfView_setRotation(view : *sfView, angle : c_float) -> ();
+        pub fn sfView_setViewport(view : *sfView, viewport : FloatRect) -> ();
+        pub fn sfView_reset(view : *sfView, rectangle : FloatRect) -> ();
+        pub fn sfView_getCenter(view : *sfView) -> Vector2f;
+        pub fn sfView_getSize(view : *sfView) -> Vector2f;
+        pub fn sfView_getRotation(view : *sfView) -> c_float;
+        pub fn sfView_getViewport(view : *sfView) -> FloatRect;
+        pub fn sfView_move(view : *sfView, offset : Vector2f) -> ();
+        pub fn sfView_rotate(view : *sfView, angle : c_float) -> ();
+        pub fn sfView_zoom(view : *sfView, factor : c_float) -> ();
     }
 }
 

--- a/src/network/ftp.rs
+++ b/src/network/ftp.rs
@@ -63,39 +63,39 @@ pub mod ffi {
         This : *c_void
     }
     
-    pub extern "C" {
-        fn sfFtpListingResponse_destroy(ftpListingResponse : *sfFtpListingResponse) -> ();
-        fn sfFtpListingResponse_isOk(ftpListingResponse : *sfFtpListingResponse) -> sfBool;
-        fn sfFtpListingResponse_getStatus(ftpListingResponse : *sfFtpListingResponse) -> Status;
-        fn sfFtpListingResponse_getMessage(ftpListingResponse : *sfFtpListingResponse) -> *c_char;
-        fn sfFtpListingResponse_getCount(ftpListingResponse : *sfFtpListingResponse) -> size_t;
-        fn sfFtpListingResponse_getName(ftpListingResponse : *sfFtpListingResponse, index : size_t) -> *c_char;
-        fn sfFtpDirectoryResponse_destroy(ftpDirectoryResponse : *sfFtpDirectoryResponse) -> ();
-        fn sfFtpDirectoryResponse_isOk(ftpDirectoryResponse : *sfFtpDirectoryResponse) -> sfBool;
-        fn sfFtpDirectoryResponse_getStatus(ftpDirectoryResponse : *sfFtpDirectoryResponse) -> Status;
-        fn sfFtpDirectoryResponse_getMessage(ftpDirectoryResponse : *sfFtpDirectoryResponse) -> *c_char;
-        fn sfFtpDirectoryResponse_getDirectory(ftpDirectoryResponse : *sfFtpDirectoryResponse) -> *c_char;
-        fn sfFtpResponse_destroy(ftpResponse : *sfFtpResponse) -> ();
-        fn sfFtpResponse_isOk(ftpResponse : *sfFtpResponse) -> sfBool;
-        fn sfFtpResponse_getStatus(ftpResponse : *sfFtpResponse) -> Status;
-        fn sfFtpResponse_getMessage(ftpResponse : *sfFtpResponse) -> *c_char;
-        fn sfFtp_create() -> *sfFtp;
-        fn sfFtp_destroy(ftp : *sfFtp) -> ();
-        fn sfFtp_connect(ftp : *sfFtp, server : sfIpAddress, port : u16, timeout : time::ffi::sfTime) -> *sfFtpResponse;
-        fn sfFtp_loginAnonymous(ftp : *sfFtp) -> *sfFtpResponse;
-        fn sfFtp_login(ftp : *sfFtp, userName : *c_char, password : *c_char) -> *sfFtpResponse;
-        fn sfFtp_disconnect(ftp : *sfFtp) -> *sfFtpResponse;
-        fn sfFtp_keepAlive(ftp : *sfFtp) -> *sfFtpResponse;
-        fn sfFtp_getWorkingDirectory(ftp : *sfFtp) -> *sfFtpDirectoryResponse;
-        fn sfFtp_getDirectoryListing(ftp : *sfFtp, directory : *c_char) -> *sfFtpListingResponse;
-        fn sfFtp_changeDirectory(ftp : *sfFtp, directory : *c_char) -> *sfFtpResponse;
-        fn sfFtp_parentDirectory(ftp : *sfFtp) -> *sfFtpResponse;
-        fn sfFtp_createDirectory(ftp : *sfFtp, name : *c_char) -> *sfFtpResponse;
-        fn sfFtp_deleteDirectory(ftp : *sfFtp, name : *c_char) -> *sfFtpResponse;
-        fn sfFtp_renameFile(ftp : *sfFtp, file : *c_char, newName : *c_char) -> *sfFtpResponse;
-        fn sfFtp_deleteFile(ftp : *sfFtp, name : *c_char) -> *sfFtpResponse;
-        fn sfFtp_download(ftp : *sfFtp, distantFile : *c_char, destPath : *c_char, mode : TransferMode) -> *sfFtpResponse;
-        fn sfFtp_upload(ftp : *sfFtp, localFile : *c_char, destPath : *c_char, mode : TransferMode) -> *sfFtpResponse;
+    extern "C" {
+        pub fn sfFtpListingResponse_destroy(ftpListingResponse : *sfFtpListingResponse) -> ();
+        pub fn sfFtpListingResponse_isOk(ftpListingResponse : *sfFtpListingResponse) -> sfBool;
+        pub fn sfFtpListingResponse_getStatus(ftpListingResponse : *sfFtpListingResponse) -> Status;
+        pub fn sfFtpListingResponse_getMessage(ftpListingResponse : *sfFtpListingResponse) -> *c_char;
+        pub fn sfFtpListingResponse_getCount(ftpListingResponse : *sfFtpListingResponse) -> size_t;
+        pub fn sfFtpListingResponse_getName(ftpListingResponse : *sfFtpListingResponse, index : size_t) -> *c_char;
+        pub fn sfFtpDirectoryResponse_destroy(ftpDirectoryResponse : *sfFtpDirectoryResponse) -> ();
+        pub fn sfFtpDirectoryResponse_isOk(ftpDirectoryResponse : *sfFtpDirectoryResponse) -> sfBool;
+        pub fn sfFtpDirectoryResponse_getStatus(ftpDirectoryResponse : *sfFtpDirectoryResponse) -> Status;
+        pub fn sfFtpDirectoryResponse_getMessage(ftpDirectoryResponse : *sfFtpDirectoryResponse) -> *c_char;
+        pub fn sfFtpDirectoryResponse_getDirectory(ftpDirectoryResponse : *sfFtpDirectoryResponse) -> *c_char;
+        pub fn sfFtpResponse_destroy(ftpResponse : *sfFtpResponse) -> ();
+        pub fn sfFtpResponse_isOk(ftpResponse : *sfFtpResponse) -> sfBool;
+        pub fn sfFtpResponse_getStatus(ftpResponse : *sfFtpResponse) -> Status;
+        pub fn sfFtpResponse_getMessage(ftpResponse : *sfFtpResponse) -> *c_char;
+        pub fn sfFtp_create() -> *sfFtp;
+        pub fn sfFtp_destroy(ftp : *sfFtp) -> ();
+        pub fn sfFtp_connect(ftp : *sfFtp, server : sfIpAddress, port : u16, timeout : time::ffi::sfTime) -> *sfFtpResponse;
+        pub fn sfFtp_loginAnonymous(ftp : *sfFtp) -> *sfFtpResponse;
+        pub fn sfFtp_login(ftp : *sfFtp, userName : *c_char, password : *c_char) -> *sfFtpResponse;
+        pub fn sfFtp_disconnect(ftp : *sfFtp) -> *sfFtpResponse;
+        pub fn sfFtp_keepAlive(ftp : *sfFtp) -> *sfFtpResponse;
+        pub fn sfFtp_getWorkingDirectory(ftp : *sfFtp) -> *sfFtpDirectoryResponse;
+        pub fn sfFtp_getDirectoryListing(ftp : *sfFtp, directory : *c_char) -> *sfFtpListingResponse;
+        pub fn sfFtp_changeDirectory(ftp : *sfFtp, directory : *c_char) -> *sfFtpResponse;
+        pub fn sfFtp_parentDirectory(ftp : *sfFtp) -> *sfFtpResponse;
+        pub fn sfFtp_createDirectory(ftp : *sfFtp, name : *c_char) -> *sfFtpResponse;
+        pub fn sfFtp_deleteDirectory(ftp : *sfFtp, name : *c_char) -> *sfFtpResponse;
+        pub fn sfFtp_renameFile(ftp : *sfFtp, file : *c_char, newName : *c_char) -> *sfFtpResponse;
+        pub fn sfFtp_deleteFile(ftp : *sfFtp, name : *c_char) -> *sfFtpResponse;
+        pub fn sfFtp_download(ftp : *sfFtp, distantFile : *c_char, destPath : *c_char, mode : TransferMode) -> *sfFtpResponse;
+        pub fn sfFtp_upload(ftp : *sfFtp, localFile : *c_char, destPath : *c_char, mode : TransferMode) -> *sfFtpResponse;
     }
 }
 

--- a/src/network/http.rs
+++ b/src/network/http.rs
@@ -56,24 +56,24 @@ pub mod ffi {
         This : *c_void
     }
 
-    pub extern "C" {
-        fn sfHttpRequest_create() -> *sfHttpRequest;
-        fn sfHttpRequest_destroy(httpRequest : *sfHttpRequest) -> ();
-        fn sfHttpRequest_setField(httpRequest : *sfHttpRequest, field : *c_char, value : *c_char) -> ();
-        fn sfHttpRequest_setMethod(httpRequest : *sfHttpRequest, method : Method) -> ();
-        fn sfHttpRequest_setUri(httpRequest : *sfHttpRequest, uri : *c_char) -> ();
-        fn sfHttpRequest_setHttpVersion(httpRequest : *sfHttpRequest, major : u32, minor : u32) -> ();
-        fn sfHttpRequest_setBody(httpRequest : *sfHttpRequest, body : *c_char) -> ();
-        fn sfHttpResponse_destroy(httpResponse : *sfHttpResponse) -> ();
-        fn sfHttpResponse_getField(httpResponse : *sfHttpResponse, field : *c_char) -> *c_char;
-        fn sfHttpResponse_getStatus(httpResponse : *sfHttpResponse) -> Status;
-        fn sfHttpResponse_getMajorVersion(httpResponse : *sfHttpResponse) -> u32;
-        fn sfHttpResponse_getMinorVersion(httpResponse : *sfHttpResponse) -> u32;
-        fn sfHttpResponse_getBody(httpResponse : *sfHttpResponse) -> *c_char;
-        fn sfHttp_create() -> *sfHttp;
-        fn sfHttp_destroy(http : *sfHttp) -> ();
-        fn sfHttp_setHost(http : *sfHttp, host : *c_char, port : u16) -> ();
-        fn sfHttp_sendRequest(http : *sfHttp, httpRequest : *sfHttpRequest, timeout : time::ffi::sfTime) -> *sfHttpResponse;
+    extern "C" {
+        pub fn sfHttpRequest_create() -> *sfHttpRequest;
+        pub fn sfHttpRequest_destroy(httpRequest : *sfHttpRequest) -> ();
+        pub fn sfHttpRequest_setField(httpRequest : *sfHttpRequest, field : *c_char, value : *c_char) -> ();
+        pub fn sfHttpRequest_setMethod(httpRequest : *sfHttpRequest, method : Method) -> ();
+        pub fn sfHttpRequest_setUri(httpRequest : *sfHttpRequest, uri : *c_char) -> ();
+        pub fn sfHttpRequest_setHttpVersion(httpRequest : *sfHttpRequest, major : u32, minor : u32) -> ();
+        pub fn sfHttpRequest_setBody(httpRequest : *sfHttpRequest, body : *c_char) -> ();
+        pub fn sfHttpResponse_destroy(httpResponse : *sfHttpResponse) -> ();
+        pub fn sfHttpResponse_getField(httpResponse : *sfHttpResponse, field : *c_char) -> *c_char;
+        pub fn sfHttpResponse_getStatus(httpResponse : *sfHttpResponse) -> Status;
+        pub fn sfHttpResponse_getMajorVersion(httpResponse : *sfHttpResponse) -> u32;
+        pub fn sfHttpResponse_getMinorVersion(httpResponse : *sfHttpResponse) -> u32;
+        pub fn sfHttpResponse_getBody(httpResponse : *sfHttpResponse) -> *c_char;
+        pub fn sfHttp_create() -> *sfHttp;
+        pub fn sfHttp_destroy(http : *sfHttp) -> ();
+        pub fn sfHttp_setHost(http : *sfHttp, host : *c_char, port : u16) -> ();
+        pub fn sfHttp_sendRequest(http : *sfHttp, httpRequest : *sfHttpRequest, timeout : time::ffi::sfTime) -> *sfHttpResponse;
     }
 }
 

--- a/src/network/ip_address.rs
+++ b/src/network/ip_address.rs
@@ -61,14 +61,14 @@ pub mod ffi{
         c16 : c_char
     }
 
-    pub extern "C" {
-        fn sfIpAddress_fromString(address : *c_char) -> sfIpAddress;
-        fn sfIpAddress_fromBytes(byte0 : u8, byte1 : u8, byte2 : u8, byte3 : u8) -> sfIpAddress;
-        fn sfIpAddress_fromInteger(address : u32) -> sfIpAddress;
-        fn sfIpAddress_toString(address : sfIpAddress, string : *c_char) -> ();
-        fn sfIpAddress_toInteger(address : sfIpAddress) -> u32;
-        fn sfIpAddress_getLocalAddress() -> sfIpAddress;
-        fn sfIpAddress_getPublicAddress(timeout : time::ffi::sfTime) -> sfIpAddress;
+    extern "C" {
+        pub fn sfIpAddress_fromString(address : *c_char) -> sfIpAddress;
+        pub fn sfIpAddress_fromBytes(byte0 : u8, byte1 : u8, byte2 : u8, byte3 : u8) -> sfIpAddress;
+        pub fn sfIpAddress_fromInteger(address : u32) -> sfIpAddress;
+        pub fn sfIpAddress_toString(address : sfIpAddress, string : *c_char) -> ();
+        pub fn sfIpAddress_toInteger(address : sfIpAddress) -> u32;
+        pub fn sfIpAddress_getLocalAddress() -> sfIpAddress;
+        pub fn sfIpAddress_getPublicAddress(timeout : time::ffi::sfTime) -> sfIpAddress;
     }
 }
 

--- a/src/network/packet.rs
+++ b/src/network/packet.rs
@@ -45,37 +45,37 @@ pub mod ffi {
         This : *c_void
     }
 
-    pub extern "C" {
-        fn sfPacket_create() -> *sfPacket;
-        fn sfPacket_copy(pack : *sfPacket) -> *sfPacket;
-        fn sfPacket_destroy(pack : *sfPacket) -> ();
+    extern "C" {
+        pub fn sfPacket_create() -> *sfPacket;
+        pub fn sfPacket_copy(pack : *sfPacket) -> *sfPacket;
+        pub fn sfPacket_destroy(pack : *sfPacket) -> ();
         //fn sfPacket_append(pack : *sfPacket, data : *c_void, sizeInBytes : size_t) -> ();
-        fn sfPacket_clear(pack : *sfPacket) -> ();
+        pub fn sfPacket_clear(pack : *sfPacket) -> ();
         //fn sfPacket_getData(pack : *sfPacket) -> *c_void;
-        fn sfPacket_getDataSize(pack : *sfPacket) -> size_t;
-        fn sfPacket_endOfPacket(pack : *sfPacket) -> sfBool;
-        fn sfPacket_canRead(pack : *sfPacket) -> sfBool;
-        fn sfPacket_readBool(pack : *sfPacket) -> sfBool;
-        fn sfPacket_readInt8(pack : *sfPacket) -> i8;
-        fn sfPacket_readUint8(pack : *sfPacket) -> u8;
-        fn sfPacket_readInt16(pack : *sfPacket) -> i16;
-        fn sfPacket_readUint16(pack : *sfPacket) -> u16;
-        fn sfPacket_readInt32(pack : *sfPacket) -> i32;
-        fn sfPacket_readUint32(pack : *sfPacket) -> u32;
-        fn sfPacket_readFloat(pack : *sfPacket) -> c_float;
-        fn sfPacket_readDouble(pack : *sfPacket) -> c_double;
-        fn sfPacket_readString(pack : *sfPacket, string : *c_char) -> ();
+        pub fn sfPacket_getDataSize(pack : *sfPacket) -> size_t;
+        pub fn sfPacket_endOfPacket(pack : *sfPacket) -> sfBool;
+        pub fn sfPacket_canRead(pack : *sfPacket) -> sfBool;
+        pub fn sfPacket_readBool(pack : *sfPacket) -> sfBool;
+        pub fn sfPacket_readInt8(pack : *sfPacket) -> i8;
+        pub fn sfPacket_readUint8(pack : *sfPacket) -> u8;
+        pub fn sfPacket_readInt16(pack : *sfPacket) -> i16;
+        pub fn sfPacket_readUint16(pack : *sfPacket) -> u16;
+        pub fn sfPacket_readInt32(pack : *sfPacket) -> i32;
+        pub fn sfPacket_readUint32(pack : *sfPacket) -> u32;
+        pub fn sfPacket_readFloat(pack : *sfPacket) -> c_float;
+        pub fn sfPacket_readDouble(pack : *sfPacket) -> c_double;
+        pub fn sfPacket_readString(pack : *sfPacket, string : *c_char) -> ();
         //fn sfPacket_readWideString(pack : *sfPacket, string : *wchar_t) -> ();
-        fn sfPacket_writeBool(pack : *sfPacket, data : sfBool) -> ();
-        fn sfPacket_writeInt8(pack : *sfPacket, data : i8) -> ();
-        fn sfPacket_writeUint8(pack : *sfPacket, data : u8) -> ();
-        fn sfPacket_writeInt16(pack : *sfPacket, data : i16) -> ();
-        fn sfPacket_writeUint16(pack : *sfPacket, data : u16) -> ();
-        fn sfPacket_writeInt32(pack : *sfPacket, data : i32) -> ();
-        fn sfPacket_writeUint32(pack : *sfPacket, data : u32) -> ();
-        fn sfPacket_writeFloat(pack : *sfPacket, data : c_float) -> ();
-        fn sfPacket_writeDouble(pack : *sfPacket, data : c_double) -> ();
-        fn sfPacket_writeString(pack : *sfPacket, string : *c_char) -> ();
+        pub fn sfPacket_writeBool(pack : *sfPacket, data : sfBool) -> ();
+        pub fn sfPacket_writeInt8(pack : *sfPacket, data : i8) -> ();
+        pub fn sfPacket_writeUint8(pack : *sfPacket, data : u8) -> ();
+        pub fn sfPacket_writeInt16(pack : *sfPacket, data : i16) -> ();
+        pub fn sfPacket_writeUint16(pack : *sfPacket, data : u16) -> ();
+        pub fn sfPacket_writeInt32(pack : *sfPacket, data : i32) -> ();
+        pub fn sfPacket_writeUint32(pack : *sfPacket, data : u32) -> ();
+        pub fn sfPacket_writeFloat(pack : *sfPacket, data : c_float) -> ();
+        pub fn sfPacket_writeDouble(pack : *sfPacket, data : c_double) -> ();
+        pub fn sfPacket_writeString(pack : *sfPacket, string : *c_char) -> ();
         //fn sfPacket_writeWideString(pack : *sfPacket, string : *wchar_t) -> ();
     }
 }

--- a/src/network/tcp_listener.rs
+++ b/src/network/tcp_listener.rs
@@ -50,14 +50,14 @@ pub mod ffi {
         This : *c_void
     }
     
-    pub extern "C" {
-        fn sfTcpListener_create() -> *sfTcpListener;
-        fn sfTcpListener_destroy(listener : *sfTcpListener) -> ();
-        fn sfTcpListener_setBlocking(listener : *sfTcpListener, blocking : sfBool) -> ();
-        fn sfTcpListener_isBlocking(listener : *sfTcpListener) -> sfBool;
-        fn sfTcpListener_getLocalPort(listener : *sfTcpListener) -> u16;
-        fn sfTcpListener_listen(listener : *sfTcpListener, port : u16) -> SocketStatus;
-        fn sfTcpListener_accept(listener : *sfTcpListener, connected : **tcp_socket::ffi::sfTcpSocket) -> SocketStatus;
+    extern "C" {
+        pub fn sfTcpListener_create() -> *sfTcpListener;
+        pub fn sfTcpListener_destroy(listener : *sfTcpListener) -> ();
+        pub fn sfTcpListener_setBlocking(listener : *sfTcpListener, blocking : sfBool) -> ();
+        pub fn sfTcpListener_isBlocking(listener : *sfTcpListener) -> sfBool;
+        pub fn sfTcpListener_getLocalPort(listener : *sfTcpListener) -> u16;
+        pub fn sfTcpListener_listen(listener : *sfTcpListener, port : u16) -> SocketStatus;
+        pub fn sfTcpListener_accept(listener : *sfTcpListener, connected : **tcp_socket::ffi::sfTcpSocket) -> SocketStatus;
     }
 }
 

--- a/src/network/tcp_socket.rs
+++ b/src/network/tcp_socket.rs
@@ -54,20 +54,20 @@ pub mod ffi {
         This : *c_void
     }
 
-    pub extern "C" {
-        fn sfTcpSocket_create() -> *sfTcpSocket;
-        fn sfTcpSocket_destroy(socket : *sfTcpSocket) -> ();
-        fn sfTcpSocket_setBlocking(socket : *sfTcpSocket, blocking : sfBool) -> ();
-        fn sfTcpSocket_isBlocking(socket : *sfTcpSocket) -> sfBool;
-        fn sfTcpSocket_getLocalPort(socket : *sfTcpSocket) -> u16;
-        fn sfTcpSocket_getRemoteAddress(socket : *sfTcpSocket) -> ip_address::ffi::sfIpAddress;
-        fn sfTcpSocket_getRemotePort(socket : *sfTcpSocket) -> u16;
-        fn sfTcpSocket_connect(socket : *sfTcpSocket, host : ip_address::ffi::sfIpAddress, port : u16,  timeout : time::ffi::sfTime) -> SocketStatus;
-        fn sfTcpSocket_disconnect(socket : *sfTcpSocket) -> ();
-        fn sfTcpSocket_send(socket : *sfTcpSocket, data : *i8, size : size_t) -> SocketStatus;
-        fn sfTcpSocket_receive(socket : *sfTcpSocket, data : *i8, maxSize : size_t, sizeReceived : *size_t) -> SocketStatus;
-        fn sfTcpSocket_sendPacket(socket : *sfTcpSocket, packet : *packet::ffi::sfPacket) -> SocketStatus;
-        fn sfTcpSocket_receivePacket(socket : *sfTcpSocket, packet : *packet::ffi::sfPacket) -> SocketStatus;
+    extern "C" {
+        pub fn sfTcpSocket_create() -> *sfTcpSocket;
+        pub fn sfTcpSocket_destroy(socket : *sfTcpSocket) -> ();
+        pub fn sfTcpSocket_setBlocking(socket : *sfTcpSocket, blocking : sfBool) -> ();
+        pub fn sfTcpSocket_isBlocking(socket : *sfTcpSocket) -> sfBool;
+        pub fn sfTcpSocket_getLocalPort(socket : *sfTcpSocket) -> u16;
+        pub fn sfTcpSocket_getRemoteAddress(socket : *sfTcpSocket) -> ip_address::ffi::sfIpAddress;
+        pub fn sfTcpSocket_getRemotePort(socket : *sfTcpSocket) -> u16;
+        pub fn sfTcpSocket_connect(socket : *sfTcpSocket, host : ip_address::ffi::sfIpAddress, port : u16,  timeout : time::ffi::sfTime) -> SocketStatus;
+        pub fn sfTcpSocket_disconnect(socket : *sfTcpSocket) -> ();
+        pub fn sfTcpSocket_send(socket : *sfTcpSocket, data : *i8, size : size_t) -> SocketStatus;
+        pub fn sfTcpSocket_receive(socket : *sfTcpSocket, data : *i8, maxSize : size_t, sizeReceived : *size_t) -> SocketStatus;
+        pub fn sfTcpSocket_sendPacket(socket : *sfTcpSocket, packet : *packet::ffi::sfPacket) -> SocketStatus;
+        pub fn sfTcpSocket_receivePacket(socket : *sfTcpSocket, packet : *packet::ffi::sfPacket) -> SocketStatus;
     }
 
 }

--- a/src/network/udp_socket.rs
+++ b/src/network/udp_socket.rs
@@ -53,19 +53,19 @@ pub mod ffi {
         This : *c_void
     }
 
-    pub extern "C" {
-        fn sfUdpSocket_create() -> *sfUdpSocket;
-        fn sfUdpSocket_destroy(socket : *sfUdpSocket) -> ();
-        fn sfUdpSocket_setBlocking(socket : *sfUdpSocket, blocking : sfBool) -> ();
-        fn sfUdpSocket_isBlocking(socket : *sfUdpSocket) -> sfBool;
-        fn sfUdpSocket_getLocalPort(socket : *sfUdpSocket) -> u16;
-        fn sfUdpSocket_bind(socket : *sfUdpSocket, port : u16) -> SocketStatus;
-        fn sfUdpSocket_unbind(socket : *sfUdpSocket) -> ();
-        fn sfUdpSocket_send(socket : *sfUdpSocket, data : *i8, size : size_t, address : ip_address::ffi::sfIpAddress, port : u16) -> SocketStatus;
-        fn sfUdpSocket_receive(socket : *sfUdpSocket, data : *i8, maxSize : size_t, sizeReceived : *size_t, address : *ip_address::ffi::sfIpAddress, port : *u16) -> SocketStatus;
-        fn sfUdpSocket_sendPacket(socket : *sfUdpSocket, packet : *packet::ffi::sfPacket, address : ip_address::ffi::sfIpAddress, port : u16) -> SocketStatus;
-        fn sfUdpSocket_receivePacket(socket : *sfUdpSocket, packet : *packet::ffi::sfPacket, address : *ip_address::ffi::sfIpAddress, port : *u16) -> SocketStatus;
-        fn sfUdpSocket_maxDatagramSize() -> u32;
+    extern "C" {
+        pub fn sfUdpSocket_create() -> *sfUdpSocket;
+        pub fn sfUdpSocket_destroy(socket : *sfUdpSocket) -> ();
+        pub fn sfUdpSocket_setBlocking(socket : *sfUdpSocket, blocking : sfBool) -> ();
+        pub fn sfUdpSocket_isBlocking(socket : *sfUdpSocket) -> sfBool;
+        pub fn sfUdpSocket_getLocalPort(socket : *sfUdpSocket) -> u16;
+        pub fn sfUdpSocket_bind(socket : *sfUdpSocket, port : u16) -> SocketStatus;
+        pub fn sfUdpSocket_unbind(socket : *sfUdpSocket) -> ();
+        pub fn sfUdpSocket_send(socket : *sfUdpSocket, data : *i8, size : size_t, address : ip_address::ffi::sfIpAddress, port : u16) -> SocketStatus;
+        pub fn sfUdpSocket_receive(socket : *sfUdpSocket, data : *i8, maxSize : size_t, sizeReceived : *size_t, address : *ip_address::ffi::sfIpAddress, port : *u16) -> SocketStatus;
+        pub fn sfUdpSocket_sendPacket(socket : *sfUdpSocket, packet : *packet::ffi::sfPacket, address : ip_address::ffi::sfIpAddress, port : u16) -> SocketStatus;
+        pub fn sfUdpSocket_receivePacket(socket : *sfUdpSocket, packet : *packet::ffi::sfPacket, address : *ip_address::ffi::sfIpAddress, port : *u16) -> SocketStatus;
+        pub fn sfUdpSocket_maxDatagramSize() -> u32;
     }
 }
 

--- a/src/system/clock.rs
+++ b/src/system/clock.rs
@@ -42,12 +42,12 @@ pub mod ffi {
         This : *c_void
     }
 
-    pub extern "C" {
-        fn sfClock_create() -> *sfClock;
-        fn sfClock_copy(clock : *sfClock) -> *sfClock;
-        fn sfClock_destroy(clock : *sfClock) -> ();
-        fn sfClock_getElapsedTime(clock : *sfClock) -> ffi::sfTime;
-        fn sfClock_restart(clock : *sfClock) -> ffi::sfTime;
+    extern "C" {
+        pub fn sfClock_create() -> *sfClock;
+        pub fn sfClock_copy(clock : *sfClock) -> *sfClock;
+        pub fn sfClock_destroy(clock : *sfClock) -> ();
+        pub fn sfClock_getElapsedTime(clock : *sfClock) -> ffi::sfTime;
+        pub fn sfClock_restart(clock : *sfClock) -> ffi::sfTime;
     }
 }
 

--- a/src/system/sleep.rs
+++ b/src/system/sleep.rs
@@ -34,8 +34,8 @@ pub mod ffi {
     
     use system::time::*;
 
-    pub extern "C" {
-        fn sfSleep(duration : ffi::sfTime) -> ();
+    extern "C" {
+        pub fn sfSleep(duration : ffi::sfTime) -> ();
     }
 }
 

--- a/src/system/time.rs
+++ b/src/system/time.rs
@@ -42,13 +42,13 @@ pub mod ffi {
         microseconds : c_long
     }
     
-    pub extern "C" {
-        fn sfTime_asSeconds(time : sfTime) -> c_float;
-        fn sfTime_asMilliseconds(time : sfTime) -> c_int;
-        fn sfTime_asMicroseconds(time : sfTime) -> c_long;
-        fn sfSeconds(amount : c_float) -> sfTime;
-        fn sfMilliseconds(amount : c_int) -> sfTime;
-        fn sfMicroseconds(amount : c_long) -> sfTime;
+    extern "C" {
+        pub fn sfTime_asSeconds(time : sfTime) -> c_float;
+        pub fn sfTime_asMilliseconds(time : sfTime) -> c_int;
+        pub fn sfTime_asMicroseconds(time : sfTime) -> c_long;
+        pub fn sfSeconds(amount : c_float) -> sfTime;
+        pub fn sfMilliseconds(amount : c_int) -> sfTime;
+        pub fn sfMicroseconds(amount : c_long) -> sfTime;
     }
 }
 

--- a/src/window/context.rs
+++ b/src/window/context.rs
@@ -38,10 +38,10 @@ pub mod ffi {
         This: *c_void
     }
 
-    pub extern "C" {
-        fn sfContext_create() -> *sfContext;
-        fn sfContext_destroy(context : *sfContext) -> ();
-        fn sfContext_setActive(context : *sfContext, active : sfBool) -> ();
+    extern "C" {
+        pub fn sfContext_create() -> *sfContext;
+        pub fn sfContext_destroy(context : *sfContext) -> ();
+        pub fn sfContext_setActive(context : *sfContext, active : sfBool) -> ();
     }
 }
 

--- a/src/window/joystick.rs
+++ b/src/window/joystick.rs
@@ -61,13 +61,13 @@ pub mod ffi {
         PovY
     }
 
-    pub extern "C" {
-        fn sfJoystick_isConnected(joystick : c_uint) -> sfBool;
-        fn sfJoystick_getButtonCount(joystick : c_uint) -> c_uint;
-        fn sfJoystick_hasAxis(joystick : c_uint, axis : c_uint) -> sfBool;
-        fn sfJoystick_isButtonPressed(joystick : c_uint, button : c_uint) -> sfBool;
-        fn sfJoystick_getAxisPosition(joystick : c_uint, axis : c_uint) -> c_float;
-        fn sfJoystick_update() -> ();
+    extern "C" {
+        pub fn sfJoystick_isConnected(joystick : c_uint) -> sfBool;
+        pub fn sfJoystick_getButtonCount(joystick : c_uint) -> c_uint;
+        pub fn sfJoystick_hasAxis(joystick : c_uint, axis : c_uint) -> sfBool;
+        pub fn sfJoystick_isButtonPressed(joystick : c_uint, button : c_uint) -> sfBool;
+        pub fn sfJoystick_getAxisPosition(joystick : c_uint, axis : c_uint) -> c_float;
+        pub fn sfJoystick_update() -> ();
     }
 }
 

--- a/src/window/keyboard.rs
+++ b/src/window/keyboard.rs
@@ -144,8 +144,8 @@ pub mod ffi {
     pub use std::libc::{c_int};
     use rsfml::sfTypes::{sfBool};
 
-    pub extern "C" {
-        fn sfKeyboard_isKeyPressed(key : c_int) -> sfBool;
+    extern "C" {
+        pub fn sfKeyboard_isKeyPressed(key : c_int) -> sfBool;
     }
 }
 

--- a/src/window/mouse.rs
+++ b/src/window/mouse.rs
@@ -50,10 +50,10 @@ pub mod ffi {
     use window::window::*;
     use system::vector2::Vector2i;
 
-    pub extern "C" {
-        fn sfMouse_isButtonPressed(button : c_uint) -> sfBool;
-        fn sfMouse_getPosition(relativeTo : *ffi::sfWindow) -> Vector2i;
-        fn sfMouse_setPosition(position : Vector2i, relativeTo : *ffi::sfWindow) -> ();
+    extern "C" {
+        pub fn sfMouse_isButtonPressed(button : c_uint) -> sfBool;
+        pub fn sfMouse_getPosition(relativeTo : *ffi::sfWindow) -> Vector2i;
+        pub fn sfMouse_setPosition(position : Vector2i, relativeTo : *ffi::sfWindow) -> ();
     }
 }
 

--- a/src/window/video_mode.rs
+++ b/src/window/video_mode.rs
@@ -64,10 +64,10 @@ pub mod ffi {
 	 }
     }
     
-    pub extern "C" {
-        fn sfVideoMode_getDesktopMode() -> sfVideoMode;
-        fn sfVideoMode_getFullscreenModes(Count : *size_t) -> *sfVideoMode;
-        fn sfVideoMode_isValid(mode : sfVideoMode) -> sfBool;
+    extern "C" {
+        pub fn sfVideoMode_getDesktopMode() -> sfVideoMode;
+        pub fn sfVideoMode_getFullscreenModes(Count : *size_t) -> *sfVideoMode;
+        pub fn sfVideoMode_isValid(mode : sfVideoMode) -> sfBool;
     }
 }
 

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -87,31 +87,31 @@ pub mod ffi {
         sfEvtJoystickDisconnected // 17
     }
 
-    pub extern "C" {
-        fn sfWindow_create(mode : ffi::sfVideoMode, title : *c_char, style : c_uint, settings : *ContextSettings) -> *sfWindow;
-        fn sfWindow_createUnicode(mode : ffi::sfVideoMode, title : *u32, style : c_uint, setting : *ContextSettings) -> *sfWindow;
+    extern "C" {
+        pub fn sfWindow_create(mode : ffi::sfVideoMode, title : *c_char, style : c_uint, settings : *ContextSettings) -> *sfWindow;
+        pub fn sfWindow_createUnicode(mode : ffi::sfVideoMode, title : *u32, style : c_uint, setting : *ContextSettings) -> *sfWindow;
         //fn sfWindow_createFromHandle(handle : sfWindowHandle, settings : *sfContextSettings) -> *sfWindow;
-        fn sfWindow_close(window : *sfWindow) -> ();
-        fn sfWindow_destroy(window : *sfWindow) -> ();
-        fn sfWindow_isOpen(window : *sfWindow) -> sfBool;
-        fn sfWindow_getSettings(window : *sfWindow) -> ContextSettings;
-        fn sfWindow_setTitle(window : *sfWindow, title : *c_char) -> ();
-        fn sfWindow_setUnicodeTitle(window : *sfWindow, title : *u32) -> ();
-        fn sfWindow_setIcon(window : *sfWindow, width : c_uint, height : c_uint, pixel : *u8) -> (); 
-        fn sfWindow_setVisible(window : *sfWindow, visible : sfBool) -> ();
-        fn sfWindow_setMouseCursorVisible(window : *sfWindow, visible : sfBool) -> ();
-        fn sfWindow_setVerticalSyncEnabled(window : *sfWindow, enabled : sfBool) -> ();
-        fn sfWindow_setKeyRepeatEnabled(window : *sfWindow, enabled : sfBool) -> ();
-        fn sfWindow_setActive(window : *sfWindow, active : sfBool) -> sfBool;
-        fn sfWindow_display(window : *sfWindow) -> ();
-        fn sfWindow_setFramerateLimit(window : *sfWindow, limit : c_uint) -> ();
-        fn sfWindow_setJoystickThreshold(window : *sfWindow, threshold : c_float) -> ();
-        fn sfWindow_getPosition(window : *sfWindow) -> Vector2i;
-        fn sfWindow_setPosition(window : *sfWindow, position : Vector2i) -> ();
-        fn sfWindow_getSize(window : *sfWindow) -> Vector2u;
-        fn sfWindow_setSize(window : *sfWindow, size : Vector2u) -> ();
-        fn sfWindow_pollEvent(window : *sfWindow, event : *sfEvent) -> sfBool;
-        fn sfWindow_waitEvent(window : *sfWindow, event : *sfEvent) -> sfBool;
+        pub fn sfWindow_close(window : *sfWindow) -> ();
+        pub fn sfWindow_destroy(window : *sfWindow) -> ();
+        pub fn sfWindow_isOpen(window : *sfWindow) -> sfBool;
+        pub fn sfWindow_getSettings(window : *sfWindow) -> ContextSettings;
+        pub fn sfWindow_setTitle(window : *sfWindow, title : *c_char) -> ();
+        pub fn sfWindow_setUnicodeTitle(window : *sfWindow, title : *u32) -> ();
+        pub fn sfWindow_setIcon(window : *sfWindow, width : c_uint, height : c_uint, pixel : *u8) -> (); 
+        pub fn sfWindow_setVisible(window : *sfWindow, visible : sfBool) -> ();
+        pub fn sfWindow_setMouseCursorVisible(window : *sfWindow, visible : sfBool) -> ();
+        pub fn sfWindow_setVerticalSyncEnabled(window : *sfWindow, enabled : sfBool) -> ();
+        pub fn sfWindow_setKeyRepeatEnabled(window : *sfWindow, enabled : sfBool) -> ();
+        pub fn sfWindow_setActive(window : *sfWindow, active : sfBool) -> sfBool;
+        pub fn sfWindow_display(window : *sfWindow) -> ();
+        pub fn sfWindow_setFramerateLimit(window : *sfWindow, limit : c_uint) -> ();
+        pub fn sfWindow_setJoystickThreshold(window : *sfWindow, threshold : c_float) -> ();
+        pub fn sfWindow_getPosition(window : *sfWindow) -> Vector2i;
+        pub fn sfWindow_setPosition(window : *sfWindow, position : Vector2i) -> ();
+        pub fn sfWindow_getSize(window : *sfWindow) -> Vector2u;
+        pub fn sfWindow_setSize(window : *sfWindow, size : Vector2u) -> ();
+        pub fn sfWindow_pollEvent(window : *sfWindow, event : *sfEvent) -> sfBool;
+        pub fn sfWindow_waitEvent(window : *sfWindow, event : *sfEvent) -> sfBool;
         //fn sfWindow_getSystemHandle(window : *sfWindow) -> sfWindowHandle;
     }
 }


### PR DESCRIPTION
`pub extern` is now obsolete. The `pub` modifier must be specified for each individual items.
