### PR TITLE
Second implementation of rsfml with both rc / borrow to manages resource

### DIFF
--- a/src/examples/mix_borrow_rc/main.rs
+++ b/src/examples/mix_borrow_rc/main.rs
@@ -1,0 +1,68 @@
+/*!
+* Example from SFML : Mix borrow / rc CircleShape
+*/
+
+#[crate_id = "shape"]
+#[desc = "Shape example for rsfml"]
+#[crate_type = "bin"]
+
+extern mod native;
+extern mod rsfml;
+
+use rsfml::graphics::{RenderWindow, Color, RcCircleShape, CircleShape};
+use rsfml::window::{VideoMode, ContextSettings, event, keyboard, Close};
+use rsfml::system::Vector2f;
+
+#[cfg(target_os="macos")]
+#[start]
+fn start(argc: int, argv: **u8) -> int {
+    native::start(argc, argv, main)
+}
+
+
+fn main () -> () {
+    // Create the window of the application
+    let setting : ContextSettings = ContextSettings::default();
+    let mut window : RenderWindow = match RenderWindow::new(VideoMode::new_init(800, 600, 32), "Use Rc / Borrow CircleShape", Close, &setting) {
+        Some(window) => window,
+        None => fail!("Cannot create a new Render Window.")
+    };
+    window.set_vertical_sync_enabled(true);
+
+
+    let mut borrow: CircleShape = CircleShape::new().expect("Error, cannot create a borrow CircleShape");
+   	borrow.set_fill_color(&Color::red());
+    borrow.set_outline_color(&Color::green());
+    borrow.set_outline_thickness(3.);
+    borrow.set_position(&Vector2f {x: 100., y: 100.});
+    borrow.set_radius(50.);
+
+
+    let mut rc: RcCircleShape = RcCircleShape::new().expect("Error, cannot create an rc CircleShape");
+    rc.set_fill_color(&Color::blue());
+    rc.set_outline_color(&Color::green());
+    rc.set_outline_thickness(3.);
+    rc.set_position(&Vector2f {x: 200., y: 200.});
+    rc.set_radius(20.);
+
+    while window.is_open() {
+        loop {
+            match window.poll_event() {
+                event::Closed 				=> window.close(),
+                event::KeyPressed{code, ..} => match code {
+                    keyboard::Escape	=> {window.close(); break},
+                    _                   => {}
+                },
+                event::NoEvent 				=> break,
+                _ 							=> {}
+            }
+        }
+        // Clear the window
+        window.clear(&Color::black());
+        window.draw(&borrow);
+        window.draw(&rc);
+        // Display things on screen
+        window.display()
+
+    }
+}

--- a/src/rsfml/graphics/circle_shape.rs
+++ b/src/rsfml/graphics/circle_shape.rs
@@ -102,33 +102,33 @@ pub mod ffi {
     }
 }
 
-pub struct CircleShape {
+pub struct RcCircleShape {
     #[doc(hidden)]
     priv circle_shape : *ffi::sfCircleShape,
     #[doc(hidden)]
     priv texture :      Option<Rc<RefCell<Texture>>>
 }
 
-impl CircleShape {
+impl RcCircleShape {
     /**
     * Create a new circle shape
     *
     * Return a new option to CircleShape object or None
     */
-    pub fn new() -> Option<CircleShape> {
+    pub fn new() -> Option<RcCircleShape> {
         let circle = unsafe { ffi::sfCircleShape_create() };
         if ptr::is_null(circle) {
             None
         }
         else {
-            Some(CircleShape {
+            Some(RcCircleShape {
                 circle_shape :  circle,
                 texture :       None
             })
         }
     }
     
-    pub fn new_with_texture(texture : Rc<RefCell<Texture>>) -> Option<CircleShape> {
+    pub fn new_with_texture(texture : Rc<RefCell<Texture>>) -> Option<RcCircleShape> {
         let circle = unsafe { ffi::sfCircleShape_create() };
         if ptr::is_null(circle) {
             None
@@ -137,7 +137,7 @@ impl CircleShape {
             unsafe {
                 ffi::sfCircleShape_setTexture(circle, texture.borrow().with(|t| t.unwrap()), SFTRUE);
             }
-            Some(CircleShape {
+            Some(RcCircleShape {
                 circle_shape :  circle,
                 texture :       Some(texture)
             })
@@ -152,7 +152,7 @@ impl CircleShape {
     *
     * Return a new initialized option to CircleShape or None
     */
-    pub fn new_init(radius : f32, point_count : uint) -> Option<CircleShape> {
+    pub fn new_init(radius : f32, point_count : uint) -> Option<RcCircleShape> {
         let circle = unsafe { ffi::sfCircleShape_create() };
         if ptr::is_null(circle) {
            None
@@ -162,7 +162,7 @@ impl CircleShape {
                 ffi::sfCircleShape_setRadius(circle, radius as c_float);
                 ffi::sfCircleShape_setPointCount(circle, point_count as c_uint);
             }
-            Some(CircleShape {
+            Some(RcCircleShape {
                 circle_shape :  circle,
                 texture :       None
             })
@@ -177,13 +177,13 @@ impl CircleShape {
     * 
     * Return the copied object on option or None
     */
-    pub fn clone(&self) -> Option<CircleShape> {
+    pub fn clone(&self) -> Option<RcCircleShape> {
         let circle = unsafe { ffi::sfCircleShape_copy(self.circle_shape) };
         if ptr::is_null(circle) {
             None
         }
         else {
-            Some(CircleShape {
+            Some(RcCircleShape {
                 circle_shape :  circle,
                 texture :       self.texture.clone()
             })
@@ -714,7 +714,664 @@ impl CircleShape {
 
 }
 
-impl Wrappable<*ffi::sfCircleShape> for CircleShape {
+impl Wrappable<*ffi::sfCircleShape> for RcCircleShape {
+    #[doc(hidden)]
+    fn wrap(circle_shape : *ffi::sfCircleShape) -> RcCircleShape {
+        RcCircleShape {
+            circle_shape :  circle_shape,
+            texture :       None
+        }
+    }
+
+    #[doc(hidden)]
+    fn unwrap(&self) -> *ffi::sfCircleShape {
+        self.circle_shape
+    }
+}
+
+impl Drawable for RcCircleShape {
+    fn draw_in_render_window(&self, render_window : &RenderWindow) -> () {
+        render_window.draw_circle_shape_rc(self)
+    }
+
+    fn draw_in_render_window_rs(&self, render_window : &RenderWindow, render_states : &mut RenderStates) -> () {
+        render_window.draw_circle_shape_rs_rc(self, render_states)
+    }
+    
+    fn draw_in_render_texture(&self, render_texture : &RenderTexture) -> () {
+        render_texture.draw_circle_shape_rc(self)
+    }
+
+    fn draw_in_render_texture_rs(&self, render_texture : &RenderTexture, render_states : &mut RenderStates) -> () {
+        render_texture.draw_circle_shape_rs_rc(self, render_states)
+    }
+}
+
+#[unsafe_destructor]
+impl Drop for RcCircleShape {
+    /**
+    * Destroy an existing CircleShape
+    */
+    fn drop(&mut self) {
+        unsafe {
+            ffi::sfCircleShape_destroy(self.circle_shape)
+        }
+    }
+}
+
+pub struct CircleShape<'s> {
+    #[doc(hidden)]
+    priv circle_shape : *ffi::sfCircleShape,
+    #[doc(hidden)]
+    priv texture :      Option<&'s Texture>
+}
+
+impl<'s> CircleShape<'s> {
+    /**
+    * Create a new circle shape
+    *
+    * Return a new option to CircleShape object or None
+    */
+    pub fn new() -> Option<CircleShape<'s>> {
+        let circle = unsafe { ffi::sfCircleShape_create() };
+        if ptr::is_null(circle) {
+            None
+        }
+        else {
+            Some(CircleShape {
+                circle_shape :  circle,
+                texture :       None
+            })
+        }
+    }
+    
+    pub fn new_with_texture(texture : &'s Texture) -> Option<CircleShape<'s>> {
+        let circle = unsafe { ffi::sfCircleShape_create() };
+        if ptr::is_null(circle) {
+            None
+        }
+        else {
+            unsafe {
+                ffi::sfCircleShape_setTexture(circle, texture.unwrap(), SFTRUE);
+            }
+            Some(CircleShape {
+                circle_shape :  circle,
+                texture :       Some(texture)
+            })
+        }
+
+    }
+
+    /**
+    * Create a new CircleShape and initialize it.
+    *
+    * Default value on SFML are radius = 0 / pointCount = 30
+    *
+    * Return a new initialized option to CircleShape or None
+    */
+    pub fn new_init(radius : f32, point_count : uint) -> Option<CircleShape<'s>> {
+        let circle = unsafe { ffi::sfCircleShape_create() };
+        if ptr::is_null(circle) {
+           None
+        }
+        else {
+            unsafe {
+                ffi::sfCircleShape_setRadius(circle, radius as c_float);
+                ffi::sfCircleShape_setPointCount(circle, point_count as c_uint);
+            }
+            Some(CircleShape {
+                circle_shape :  circle,
+                texture :       None
+            })
+        }
+    }
+
+    /**
+    * Copy an existing circle shape
+    *
+    * # Arguments
+    * * shape - Shape to copy
+    * 
+    * Return the copied object on option or None
+    */
+    pub fn clone(&self) -> Option<CircleShape<'s>> {
+        let circle = unsafe { ffi::sfCircleShape_copy(self.circle_shape) };
+        if ptr::is_null(circle) {
+            None
+        }
+        else {
+            Some(CircleShape {
+                circle_shape :  circle,
+                texture :       self.texture
+            })
+        }
+    }
+
+    /**
+    * Set the orientation of a circle shape
+    *
+    * This function completely overwrites the previous rotation.
+    * See rotate to add an angle based on the previous rotation instead.
+    * The default rotation of a circle Shape object is 0.
+    *
+    * # Arguments
+    * * rotation - New rotation
+    */
+    pub fn set_rotation(&mut self, angle : f32) -> () {
+        unsafe {
+            ffi::sfCircleShape_setRotation(self.circle_shape, angle as c_float)
+        }
+    }
+
+    /**
+    * Get the orientation of a circle shape
+    *
+    * The rotation is always in the range [0, 360].
+    *
+    * Return the current rotation, in degrees
+    */
+    pub fn get_rotation(&self) -> f32 {
+        unsafe {
+            ffi::sfCircleShape_getRotation(self.circle_shape) as f32
+        }
+    } 
+
+    /**
+    * Rotate a circle shape
+    *
+    * This function adds to the current rotation of the object,
+    * unlike set_rotation which overwrites it.
+    *
+    * # Arguments
+    * * angle - Angle of rotation, in degrees
+    */
+    pub fn rotate(&mut self, angle : f32) -> () {
+        unsafe {
+            ffi::sfCircleShape_rotate(self.circle_shape, angle as c_float)
+        }
+    }
+
+    /**
+    * Change the source texture of a circle shape
+    *
+    * The texture argument refers to a texture that must
+    * exist as long as the shape uses it. Indeed, the shape
+    * doesn't store its own copy of the texture, but rather keeps
+    * a pointer to the one that you passed to this function.
+    * If the source texture is destroyed and the shape tries to
+    * use it, the behaviour is undefined.
+    * If reset_rect is true, the TextureRect property of
+    * the shape is automatically adjusted to the size of the new
+    * texture. If it is false, the texture rect is left unchanged.
+    *
+    * # Arguments
+    * * texture - New texture
+    * * reset_rect - Should the texture rect be reset to the size of the new texture?
+    */
+    pub fn set_texture(&mut self, texture : &'s Texture, reset_rect : bool) -> () {
+        self.texture = Some(texture);
+        unsafe {
+            match reset_rect {
+                true        => ffi::sfCircleShape_setTexture(self.circle_shape, texture.unwrap(), SFTRUE),
+                false       => ffi::sfCircleShape_setTexture(self.circle_shape, texture.unwrap(), SFFALSE),
+            }
+        }
+    }
+
+    /**
+    * Disable Texturing
+    *
+    * Disable the current texture and reset the texture rect
+    */
+    pub fn disable_texture(&mut self) -> () {
+        self.texture = None;
+        unsafe {
+            ffi::sfCircleShape_setTexture(self.circle_shape, ptr::null(), SFTRUE)
+        }
+    }
+
+    /**
+    * Set the sub-rectangle of the texture that a circle shape will display
+    *
+    * The texture rect is useful when you don't want to display
+    * the whole texture, but rather a part of it.
+    * By default, the texture rect covers the entire texture.
+    *
+    * # Arguments
+    * * rec - Rectangle defining the region of the texture to display
+    */
+    pub fn set_texture_rect(&mut self, rect : &IntRect) -> () {
+        unsafe {
+            ffi::sfCircleShape_setTextureRect(self.circle_shape, *rect)
+        }
+    }
+    
+    /**
+    * Set the fill color of a circle shape
+    *
+    * This color is modulated (multiplied) with the shape's
+    * texture if any. It can be used to colorize the shape,
+    * or change its global opacity.
+    * You can use sfTransparent to make the inside of
+    * the shape transparent, and have the outline alone.
+    * By default, the shape's fill color is opaque white.
+    *
+    * # Arguments
+    * * color - New color of the shape
+    */
+    pub fn set_fill_color(&mut self, color : &Color) -> () {
+        unsafe {
+            ffi::sfCircleShape_setFillColor(self.circle_shape, *color)
+        }
+    }
+
+    /**
+    * Set the outline color of a circle shape
+    *
+    * You can use Transparent to disable the outline.
+    * By default, the shape's outline color is opaque white.
+    *
+    * # Arguments
+    * * color - New outline color of the shape
+    */
+    pub fn set_outline_color(&mut self, color : &Color) -> () {
+        unsafe {
+            ffi::sfCircleShape_setOutlineColor(self.circle_shape, *color)
+        }
+    }
+
+    /**
+    * Set the thickness of a circle shape's outline
+    *
+    * This number cannot be negative. Using zero disables
+    * the outline.
+    * By default, the outline thickness is 0.
+    *
+    * # Arguments
+    * * thickness - New outline thickness
+    */
+    pub fn set_outline_thickness(&mut self, thickness : f32) -> () {
+        unsafe {
+            ffi::sfCircleShape_setOutlineThickness(self.circle_shape, thickness as c_float)
+        }
+    }
+
+    /**
+    * Get the source texture of a circle shape
+    *
+    * You can't modify the texture when you retrieve it with this function.
+    * 
+    * Return the shape's texture
+    */
+    pub fn get_texture(&self) -> Option<&'s Texture> {
+        self.texture
+    }
+
+    /**
+    * Get the sub-rectangle of the texture displayed by a circle shape
+    *
+    * Return the texture rectangle of the shape
+    */
+    pub fn get_texture_rect(&self) -> IntRect {
+        unsafe {
+            ffi::sfCircleShape_getTextureRect(self.circle_shape)
+        }
+    }
+    
+    /**
+    * Get the fill color of a circle shape
+    *
+    * Return the fill color of the shape
+    */
+    pub fn get_fill_color(&self) -> Color {
+        unsafe {
+            ffi::sfCircleShape_getFillColor(self.circle_shape)
+        }
+    }
+
+    /**
+    * Get the outline color of a circle shape
+    *
+    * Return the outline color of the shape
+    */
+    pub fn get_outline_color(&self) -> Color {
+        unsafe {
+            ffi::sfCircleShape_getOutlineColor(self.circle_shape)
+        }
+    }
+
+    /**
+    * Get the outline thickness of a circle shape
+    *
+    * Return the outline thickness of the shape
+    */
+    pub fn get_outline_thickness(&self) -> f32 {
+        unsafe {
+            ffi::sfCircleShape_getOutlineThickness(self.circle_shape) as f32
+        }
+    }
+
+    /**
+    * Get the total number of points of a circle shape
+    *
+    * Return the number of points of the shape
+    */
+    pub fn get_point_count(&self) -> uint {
+        unsafe {
+            ffi::sfCircleShape_getPointCount(self.circle_shape) as uint
+        }
+    }
+
+    /**
+    * Get a point of a circle shape
+    *
+    * The result is undefined if index is out of the valid range.
+    *
+    * # Arguments
+    * * index- Index of the point to get, in range [0 .. getPointCount() - 1]
+    *
+    * Return the index-th point of the shape
+    */
+    pub fn get_point(&self, index : uint) -> () {
+        unsafe {
+            ffi::sfCircleShape_getPoint(self.circle_shape, index as c_uint)
+        }
+    }
+    
+    /**
+    * Set the radius of a circle
+    *
+    * # Arguments
+    * * radius - New radius of the circle
+    */
+    pub fn set_radius(&self, radius : f32) -> () {
+        unsafe {
+            ffi::sfCircleShape_setRadius(self.circle_shape, radius as c_float)
+        }
+    }
+
+    /**
+    * Set the radius of a circle
+    *
+    * Return the radius of the circle
+    */
+    pub fn get_radius(&self) -> f32 {
+        unsafe {
+            ffi::sfCircleShape_getRadius(self.circle_shape) as f32
+        }
+    }
+    
+    /**
+    * Set the number of points of a circle
+    *
+    * # Arguments
+    * * count - New number of points of the circle
+    */
+    pub fn set_point_count(&mut self, count : uint) -> () {
+        unsafe {
+            ffi::sfCircleShape_setPointCount(self.circle_shape, count as c_uint)
+        }
+    }
+
+    /**
+    * Get the position of a circle shape
+    *
+    * Return the current position
+    */
+    pub fn get_position(&self) -> Vector2f {
+        unsafe {
+            ffi::sfCircleShape_getPosition(self.circle_shape)
+        }
+    }
+
+    /**
+    * Get the current scale of a circle shape
+    *
+    * Return the current scale factors
+    */
+    pub fn get_scale(&self) -> Vector2f {
+        unsafe {
+            ffi::sfCircleShape_getScale(self.circle_shape)
+        }
+    }
+
+    /**
+    * Get the local origin of a circle shape
+    *
+    * return the current origin
+    */
+    pub fn get_origin(&self) -> Vector2f {
+        unsafe {
+            ffi::sfCircleShape_getOrigin(self.circle_shape)
+        }
+    }
+
+    /**
+    * Move a circle shape by a given offset
+    *
+    * This function adds to the current position of the object,
+    * unlike sset_position which overwrites it.
+    *
+    * # Arguments
+    * * offset - Offset
+    */
+    pub fn move(&mut self, offset : &Vector2f) -> () {
+        unsafe {
+            ffi::sfCircleShape_move(self.circle_shape, *offset)
+        }
+    }
+
+    /**
+    * Move a circle shape by a given offset
+    *
+    * This function adds to the current position of the object,
+    * unlike sset_position which overwrites it.
+    *
+    * # Arguments
+    * * offsetX - Offset x
+    * * offsetY - Offset y
+    */
+    pub fn move2f(&mut self, offset_x : f32, offset_y : f32) -> () {
+        unsafe {
+            ffi::sfCircleShape_move(self.circle_shape, Vector2f::new(offset_x, offset_y))
+        }
+    }
+
+    /**
+    * Scale a circle shape
+    *
+    * This function multiplies the current scale of the object,
+    * unlike sfCircleShape_setScale which overwrites it.
+    *
+    * # Arguments
+    * * factors - Scale factors
+    */
+    pub fn scale(&mut self, factors : &Vector2f) -> () {
+        unsafe {
+            ffi::sfCircleShape_scale(self.circle_shape, *factors)
+        }
+    }
+
+    /**
+    * Scale a circle shape
+    *
+    * This function multiplies the current scale of the object,
+    * unlike sfCircleShape_setScale which overwrites it.
+    *
+    * # Arguments
+    * * factor_x - Scale x factor
+    * * factor_y - Scale y factor
+    */
+    pub fn scale2f(&mut self, factor_x : f32, factor_y : f32) -> () {
+        unsafe {
+            ffi::sfCircleShape_scale(self.circle_shape, Vector2f::new(factor_x, factor_y))
+        }
+    }
+
+    /**
+    * Set the position of a circle shape
+    *
+    * This function completely overwrites the previous position.
+    * See move to apply an offset based on the previous position instead.
+    * The default position of a circle Shape object is (0, 0).
+    *
+    * # Arguments
+    * * position - New position
+    */
+    pub fn set_position(&mut self, position : &Vector2f) -> () {
+        unsafe {
+            ffi::sfCircleShape_setPosition(self.circle_shape, *position)
+        }
+    }
+
+    /**
+    * Set the position of a circle shape
+    *
+    * This function completely overwrites the previous position.
+    * See move to apply an offset based on the previous position instead.
+    * The default position of a circle Shape object is (0, 0).
+    *
+    * # Arguments
+    * * x - New x coordinate
+    * * y - New y coordinate
+    */
+    pub fn set_position2f(&mut self, x : f32, y : f32) -> () {
+        unsafe {
+            ffi::sfCircleShape_setPosition(self.circle_shape, Vector2f::new(x, y))
+        }
+    }
+
+    /**
+    * Set the scale factors of a circle shape
+    *
+    * This function completely overwrites the previous scale.
+    * See scale to add a factor based on the previous scale instead.
+    * The default scale of a circle Shape object is (1, 1).
+    *
+    * # Arguments
+    * * scale - New scale factors
+    */
+    pub fn set_scale(&mut self, scale : &Vector2f) -> () {
+        unsafe {
+            ffi::sfCircleShape_setScale(self.circle_shape, *scale)
+        }
+    }
+    
+    /**
+    * Set the scale factors of a circle shape
+    *
+    * This function completely overwrites the previous scale.
+    * See scale to add a factor based on the previous scale instead.
+    * The default scale of a circle Shape object is (1, 1).
+    *
+    * # Arguments
+    * * scale_x - New x scale factor
+    * * scale_y - New y scale factor
+    */
+    pub fn set_scale2f(&mut self, scale_x : f32, scale_y : f32) -> () {
+        unsafe {
+            ffi::sfCircleShape_setScale(self.circle_shape, Vector2f::new(scale_x, scale_y))
+        }
+    }
+    
+    /**
+    * Set the local origin of a circle shape
+    *
+    * The origin of an object defines the center point for
+    * all transformations (position, scale, rotation).
+    * The coordinates of this point must be relative to the
+    * top-left corner of the object, and ignore all
+    * transformations (position, scale, rotation).
+    * The default origin of a circle Shape object is (0, 0).
+    *
+    * # Arguments
+    * * origin - New origin
+    */
+    pub fn set_origin(&mut self, origin : &Vector2f) -> () {
+        unsafe {
+            ffi::sfCircleShape_setOrigin(self.circle_shape, *origin)
+        }
+    }
+
+    /**
+    * Set the local origin of a circle shape
+    *
+    * The origin of an object defines the center point for
+    * all transformations (position, scale, rotation).
+    * The coordinates of this point must be relative to the
+    * top-left corner of the object, and ignore all
+    * transformations (position, scale, rotation).
+    * The default origin of a circle Shape object is (0, 0).
+    *
+    * # Arguments
+    * * x - New x origin coordinate
+    * * y - New y origin coordinate
+    */
+    pub fn set_origin2f(&mut self, x : f32, y : f32) -> () {
+        unsafe {
+            ffi::sfCircleShape_setOrigin(self.circle_shape, Vector2f::new(x, y))
+        }
+    }
+
+    /**
+    * Get the local bounding rectangle of a circle shape
+    *
+    * The returned rectangle is in local coordinates, which means
+    * that it ignores the transformations (translation, rotation,
+    * scale, ...) that are applied to the entity.
+    * In other words, this function returns the bounds of the
+    * entity in the entity's coordinate system.
+    *
+    * Return the local bounding rectangle of the entity
+    */
+    pub fn get_local_bounds(&self) -> FloatRect {
+        unsafe {
+            ffi::sfCircleShape_getLocalBounds(self.circle_shape)
+        }
+    }
+    
+    /**
+    * Get the global bounding rectangle of a circle shape
+    *
+    * The returned rectangle is in global coordinates, which means
+    * that it takes in account the transformations (translation,
+    * rotation, scale, ...) that are applied to the entity.
+    * In other words, this function returns the bounds of the
+    * sprite in the global 2D world's coordinate system.
+    *
+    * Return the global bounding rectangle of the entity
+    */
+    pub fn get_global_bounds(&self) -> FloatRect {
+        unsafe {
+            ffi::sfCircleShape_getGlobalBounds(self.circle_shape)
+        }
+    }
+
+    /**
+    * Get the combined transform of a circle shape
+    *
+    * Return transform combining the position/rotation/scale/origin of the object
+    */
+    pub fn get_transform(&self) -> Transform {
+        unsafe {
+            ffi::sfCircleShape_getTransform(self.circle_shape)
+        }
+    }
+
+    /**
+    * Get the inverse of the combined transform of a circle shape
+    *
+    * Return inverse of the combined transformations applied to the object
+    */
+    pub fn get_inverse_transform(&self) -> Transform {
+        unsafe {
+            ffi::sfCircleShape_getInverseTransform(self.circle_shape)
+        }
+    }
+
+}
+
+impl<'s> Wrappable<*ffi::sfCircleShape> for CircleShape<'s> {
     #[doc(hidden)]
     fn wrap(circle_shape : *ffi::sfCircleShape) -> CircleShape {
         CircleShape {
@@ -729,26 +1386,26 @@ impl Wrappable<*ffi::sfCircleShape> for CircleShape {
     }
 }
 
-impl Drawable for CircleShape {
+impl<'s> Drawable for CircleShape<'s> {
     fn draw_in_render_window(&self, render_window : &RenderWindow) -> () {
-        render_window.draw_circle_shape(self)
+        render_window.draw_circle_shape_borrow(self)
     }
 
     fn draw_in_render_window_rs(&self, render_window : &RenderWindow, render_states : &mut RenderStates) -> () {
-        render_window.draw_circle_shape_rs(self, render_states)
+        render_window.draw_circle_shape_rs_borrow(self, render_states)
     }
     
     fn draw_in_render_texture(&self, render_texture : &RenderTexture) -> () {
-        render_texture.draw_circle_shape(self)
+        render_texture.draw_circle_shape_borrow(self)
     }
 
     fn draw_in_render_texture_rs(&self, render_texture : &RenderTexture, render_states : &mut RenderStates) -> () {
-        render_texture.draw_circle_shape_rs(self, render_states)
+        render_texture.draw_circle_shape_rs_borrow(self, render_states)
     }
 }
 
 #[unsafe_destructor]
-impl Drop for CircleShape {
+impl<'s> Drop for CircleShape<'s> {
     /**
     * Destroy an existing CircleShape
     */

--- a/src/rsfml/graphics/mod.rs
+++ b/src/rsfml/graphics/mod.rs
@@ -42,6 +42,7 @@ pub use self::font::Font;
 pub use self::view::View;
 pub use self::image::Image;
 pub use self::sprite::Sprite;
+pub use self::circle_shape::RcCircleShape;
 pub use self::circle_shape::CircleShape;
 pub use self::rectangle_shape::RectangleShape;
 pub use self::convex_shape::ConvexShape;

--- a/src/rsfml/graphics/render_texture.rs
+++ b/src/rsfml/graphics/render_texture.rs
@@ -42,6 +42,7 @@ use graphics::color::Color;
 use graphics::rect::IntRect;
 use graphics::texture::Texture;
 use graphics::text::Text;
+use graphics::circle_shape::RcCircleShape;
 use graphics::circle_shape::CircleShape;
 use graphics::rectangle_shape::RectangleShape;
 use graphics::vertex_array::VertexArray;
@@ -397,7 +398,14 @@ impl RenderTexture {
     }
 
     /// Draw CircleShape
-    pub fn draw_circle_shape(&self, circle_shape : &CircleShape) -> () {
+    pub fn draw_circle_shape_borrow(&self, circle_shape : &CircleShape) -> () {
+        unsafe {
+            ffi::sfRenderTexture_drawCircleShape(self.render_texture, circle_shape.unwrap(), ptr::null())
+        }
+    }
+
+    /// Draw CircleShape
+    pub fn draw_circle_shape_rc(&self, circle_shape : &RcCircleShape) -> () {
         unsafe {
             ffi::sfRenderTexture_drawCircleShape(self.render_texture, circle_shape.unwrap(), ptr::null())
         }
@@ -446,7 +454,14 @@ impl RenderTexture {
     }
 
     /// Draw CircleShape
-    pub fn draw_circle_shape_rs(&self, circle_shape : &CircleShape, rs : &mut RenderStates) -> () {
+    pub fn draw_circle_shape_rs_borrow(&self, circle_shape : &CircleShape, rs : &mut RenderStates) -> () {
+        unsafe {
+            ffi::sfRenderTexture_drawCircleShape(self.render_texture, circle_shape.unwrap(), rs.unwrap())
+        }
+    }
+
+    /// Draw CircleShape
+    pub fn draw_circle_shape_rs_rc(&self, circle_shape : &RcCircleShape, rs : &mut RenderStates) -> () {
         unsafe {
             ffi::sfRenderTexture_drawCircleShape(self.render_texture, circle_shape.unwrap(), rs.unwrap())
         }

--- a/src/rsfml/graphics/render_window.rs
+++ b/src/rsfml/graphics/render_window.rs
@@ -45,6 +45,7 @@ use system::vector2::{Vector2f, Vector2i, Vector2u};
 use graphics::text::Text;
 use graphics::color::Color;
 use graphics::sprite::Sprite;
+use graphics::circle_shape::RcCircleShape;
 use graphics::circle_shape::CircleShape;
 use graphics::rectangle_shape::RectangleShape;
 use graphics::convex_shape::ConvexShape;
@@ -878,7 +879,14 @@ impl RenderWindow {
     }
 
     /// Draw a CircleShape
-    pub fn draw_circle_shape(&self, circle_shape : &CircleShape) -> () {
+    pub fn draw_circle_shape_borrow(&self, circle_shape : &CircleShape) -> () {
+        unsafe {
+            ffi::sfRenderWindow_drawCircleShape(self.render_window, circle_shape.unwrap(), ptr::null())
+        }
+    }
+
+    /// Draw a CircleShape
+    pub fn draw_circle_shape_rc(&self, circle_shape : &RcCircleShape) -> () {
         unsafe {
             ffi::sfRenderWindow_drawCircleShape(self.render_window, circle_shape.unwrap(), ptr::null())
         }
@@ -927,7 +935,14 @@ impl RenderWindow {
     }
 
     /// Draw a CircleShape with a RenderStates
-    pub fn draw_circle_shape_rs(&self, circle_shape : &CircleShape, render_states : &mut RenderStates) -> () {
+    pub fn draw_circle_shape_rs_borrow(&self, circle_shape : &CircleShape, render_states : &mut RenderStates) -> () {
+        unsafe {
+            ffi::sfRenderWindow_drawCircleShape(self.render_window, circle_shape.unwrap(), render_states.unwrap())
+        }
+    }
+
+    /// Draw a CircleShape with a RenderStates
+    pub fn draw_circle_shape_rs_rc(&self, circle_shape : &RcCircleShape, render_states : &mut RenderStates) -> () {
         unsafe {
             ffi::sfRenderWindow_drawCircleShape(self.render_window, circle_shape.unwrap(), render_states.unwrap())
         }


### PR DESCRIPTION
Again, only CircleShape is implemented to provide both rc / borrow for resource management.
Both implementation lives inside `rsfml::graphics::circle_shape`
the first one `rsfml::graphics::circle_shape::RcCircleShape`, using internally the ref counter,
the second one `rsfml::graphics::circle_shape::CircleShape`, using internally borrow pointer.

Both are reexported on `rsfml::graphics`.
So you can access them as with the current version of rsfml : 

``` Rust
use rsfml::graphics::{RcCircleShape, CircleShape};
```

I'm not really fan of this implementation, i don't like to have different name for the same thing. I prefer the first way who use inner module, so you can import the module that you want.

Any opinion about this?
