### PR TITLE
Make examples depend on rsfml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ docs:
 	mkdir -p doc
 	rustdoc -o doc src/rsfml/lib.rs
 
-examples:
+examples: rsfml
 	rustc -o bin/pong -L ./lib src/examples/pong/main.rs
 	rustc -o bin/shape -L ./lib src/examples/shape/main.rs
 	rustc -o bin/custom_drawable -L ./lib src/examples/custom_drawable/main.rs


### PR DESCRIPTION
This caused problems, when invoking make with multiple build processes, because it would try to build the examples before the rsfml build had been finished.
