### PR TITLE
Change tcp_socket.rs and udp_socket.rs so that they no longer get linted

### DIFF
--- a/src/rsfml/network/tcp_socket.rs
+++ b/src/rsfml/network/tcp_socket.rs
@@ -26,8 +26,6 @@
 * Specialized socket using the TCP protocol
 */
 
-#[allow(deprecated_owned_vector)];
-
 use std::libc::size_t;
 use std::{vec, ptr, cast};
 use std::vec_ng::Vec;
@@ -204,7 +202,7 @@ impl TcpSocket {
             let s : size_t = 0;
             let datas : *i8 = ptr::null();
             let stat : SocketStatus = cast::transmute(ffi::sfTcpSocket_receive(self.socket, datas, max_size, &s) as i8);
-            (Vec::from_slice(vec::raw::from_buf_raw(datas, s as uint)), stat, s)
+            (vec::raw::buf_as_slice(datas, s as uint, Vec::from_slice), stat, s)
         }
     }
 

--- a/src/rsfml/network/udp_socket.rs
+++ b/src/rsfml/network/udp_socket.rs
@@ -26,8 +26,6 @@
 * Specialized socket using the UDP protocol.
 */
 
-#[allow(deprecated_owned_vector)];
-
 use std::{ptr, vec, cast};
 use std::libc::size_t;
 use std::vec_ng::Vec;
@@ -183,7 +181,7 @@ impl UdpSocket {
             let addr : *::ffi::network::ip_address::sfIpAddress = ptr::null();
             let port : u16 = 0;
             let stat : SocketStatus = cast::transmute(ffi::sfUdpSocket_receive(self.socket, datas, max_size, &s, addr, &port) as i8);
-            (Vec::from_slice(vec::raw::from_buf_raw(datas, s as uint)), stat, s, Wrappable::wrap(*addr), port)
+            (vec::raw::buf_as_slice(datas, s as uint, Vec::from_slice), stat, s, Wrappable::wrap(*addr), port)
         }
     }
 


### PR DESCRIPTION
The lint for ~[T] was warning about a couple of lines, leading to the need for `#[allow(deprecated_owned_vector)]`.  This uses a different method to wrap up raw pointers as vectors, so the lint doesn't complain any more.
