### PR TITLE
Update transmute and forget to use std::mem instead of std::cast

### DIFF
--- a/src/audio/music.rs
+++ b/src/audio/music.rs
@@ -31,7 +31,7 @@
 */
 
 use libc::c_float;
-use std::{ptr, cast};
+use std::{ptr, mem};
 
 use audio::Status;
 use system::Time;
@@ -198,7 +198,7 @@ impl Music {
      * Return current status
      */
     pub fn get_status(&self) -> Status {
-        unsafe { cast::transmute(ffi::sfMusic_getStatus(self.music))}
+        unsafe { mem::transmute(ffi::sfMusic_getStatus(self.music))}
     }
 
     /**

--- a/src/audio/sound/mod.rs
+++ b/src/audio/sound/mod.rs
@@ -29,7 +29,7 @@
  */
 
 use libc::c_float;
-use std::cast;
+use std::mem;
 
 use audio::{Status, SoundBuffer};
 use system::Time;
@@ -180,7 +180,7 @@ impl<'s> Sound<'s> {
      * Return current status
      */
     pub fn get_status(&self) -> Status {
-        unsafe { cast::transmute(ffi::sfSound_getStatus(self.sound)) }
+        unsafe { mem::transmute(ffi::sfSound_getStatus(self.sound)) }
     }
 
     /**

--- a/src/audio/sound/rc.rs
+++ b/src/audio/sound/rc.rs
@@ -29,7 +29,7 @@
  */
 
 use libc::c_float;
-use std::cast;
+use std::mem;
 use std::rc::Rc;
 use std::cell::RefCell;
 
@@ -183,7 +183,7 @@ impl Sound {
      * Return current status
      */
     pub fn get_status(&self) -> Status {
-        unsafe { cast::transmute(ffi::sfSound_getStatus(self.sound)) }
+        unsafe { mem::transmute(ffi::sfSound_getStatus(self.sound)) }
     }
 
     /**

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -33,7 +33,7 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 use libc::{c_float, c_uint, c_int};
-use std::{ptr, cast};
+use std::{ptr, mem};
 use std::vec::Vec;
 
 use traits::{Drawable, Wrappable};
@@ -1206,7 +1206,7 @@ fn get_wrapped_event(event: &ffi::sfEvent) ->event::Event {
                 0 => false,
                 _ => true
             };
-            let k : keyboard::Key = unsafe { cast::transmute(event.p1 as i64) };
+            let k : keyboard::Key = unsafe { mem::transmute(event.p1 as i64) };
             event::KeyPressed{
                 code : k,
                 alt : al,
@@ -1232,7 +1232,7 @@ fn get_wrapped_event(event: &ffi::sfEvent) ->event::Event {
                 0 => false,
                 _ => true
             };
-            let k : keyboard::Key = unsafe { cast::transmute(event.p1 as i64) };
+            let k : keyboard::Key = unsafe { mem::transmute(event.p1 as i64) };
             event::KeyReleased {
                 code : k,
                 alt : al,
@@ -1243,31 +1243,31 @@ fn get_wrapped_event(event: &ffi::sfEvent) ->event::Event {
         },
         7   => {
             event::MouseWheelMoved{
-                delta : unsafe { cast::transmute::<c_uint, c_int>(event.p1) }  as int,
-                x :     unsafe { cast::transmute::<c_uint, c_int>(event.p2) }  as int,
-                y :     unsafe { cast::transmute::<c_float, c_int>(event.p3) } as int
+                delta : unsafe { mem::transmute::<c_uint, c_int>(event.p1) }  as int,
+                x :     unsafe { mem::transmute::<c_uint, c_int>(event.p2) }  as int,
+                y :     unsafe { mem::transmute::<c_float, c_int>(event.p3) } as int
             }
         },
         8   => {
-            let button : mouse::MouseButton = unsafe {cast::transmute(event.p1 as i8)};
+            let button : mouse::MouseButton = unsafe {mem::transmute(event.p1 as i8)};
             event::MouseButtonPressed{
                 button : button,
-                x :      unsafe { cast::transmute::<c_uint, c_int>(event.p2) as int },
-                y :      unsafe { cast::transmute::<c_float, c_int>(event.p3) as int }
+                x :      unsafe { mem::transmute::<c_uint, c_int>(event.p2) as int },
+                y :      unsafe { mem::transmute::<c_float, c_int>(event.p3) as int }
             }
         },
         9   => {
-            let button : mouse::MouseButton = unsafe { cast::transmute(event.p1 as i8) };
+            let button : mouse::MouseButton = unsafe { mem::transmute(event.p1 as i8) };
             event::MouseButtonReleased{
                 button : button,
-                x :      unsafe { cast::transmute::<c_uint, c_int>(event.p2) as int },
-                y :      unsafe { cast::transmute::<c_float, c_int>(event.p3) as int }
+                x :      unsafe { mem::transmute::<c_uint, c_int>(event.p2) as int },
+                y :      unsafe { mem::transmute::<c_float, c_int>(event.p3) as int }
             }
         },
         10  => {
             event::MouseMoved {
-                x : unsafe { cast::transmute::<c_uint, c_int>(event.p1) } as int,
-                y : unsafe { cast::transmute::<c_uint, c_int>(event.p2) } as int
+                x : unsafe { mem::transmute::<c_uint, c_int>(event.p1) } as int,
+                y : unsafe { mem::transmute::<c_uint, c_int>(event.p2) } as int
             }
         },
         11  => event::MouseEntered,
@@ -1285,7 +1285,7 @@ fn get_wrapped_event(event: &ffi::sfEvent) ->event::Event {
             }
         },
         15  => {
-            let ax : joystick::Axis = unsafe { cast::transmute(event.p2 as i8) };
+            let ax : joystick::Axis = unsafe { mem::transmute(event.p2 as i8) };
             event::JoystickMoved{
                 joystickid : event.p1 as uint,
                 axis : ax,

--- a/src/graphics/shape/mod.rs
+++ b/src/graphics/shape/mod.rs
@@ -27,7 +27,7 @@
 */
 
 use libc::{c_void, c_float, c_uint};
-use std::{ptr, cast};
+use std::{ptr, mem};
 
 use traits::{Drawable, ShapeImpl, Wrappable};
 use graphics::{RenderWindow, RenderTexture, RenderStates, Texture, Color,
@@ -54,17 +54,17 @@ pub struct Shape<'s> {
 
 #[doc(hidden)]
 extern fn get_point_count_callback(obj : *c_void) -> u32 {
-    let shape = unsafe { cast::transmute::<*c_void, Box<Box<WrapObj>>>(obj) };
+    let shape = unsafe { mem::transmute::<*c_void, Box<Box<WrapObj>>>(obj) };
     let ret = shape.shape_impl.get_point_count();
-    unsafe { cast::forget(shape) };
+    unsafe { mem::forget(shape) };
     ret
 }
 
 #[doc(hidden)]
 extern fn get_point_callback(point : u32, obj : *c_void) -> Vector2f {
-    let shape = unsafe { cast::transmute::<*c_void, Box<Box<WrapObj>>>(obj) };
+    let shape = unsafe { mem::transmute::<*c_void, Box<Box<WrapObj>>>(obj) };
     let ret = shape.shape_impl.get_point(point);
-    unsafe { cast::forget(shape) };
+    unsafe { mem::forget(shape) };
     ret
 }
 
@@ -82,7 +82,7 @@ impl<'s> Shape<'s> {
         let w_o = box WrapObj { shape_impl : shape_impl};
         let sp = unsafe { ffi::sfShape_create(get_point_count_callback,
                                               get_point_callback,
-                                              cast::transmute::<Box<Box<WrapObj>>, *c_void>(box w_o)) };
+                                              mem::transmute::<Box<Box<WrapObj>>, *c_void>(box w_o)) };
         if sp.is_null() {
             None
         } else {
@@ -107,7 +107,7 @@ impl<'s> Shape<'s> {
         let w_o = box WrapObj { shape_impl : shape_impl };
         let sp = unsafe { ffi::sfShape_create(get_point_count_callback,
                                               get_point_callback,
-                                              cast::transmute::<Box<Box<WrapObj>>, *c_void>(box w_o)) };
+                                              mem::transmute::<Box<Box<WrapObj>>, *c_void>(box w_o)) };
         if sp.is_null() {
             None
         } else {

--- a/src/graphics/shape/rc.rs
+++ b/src/graphics/shape/rc.rs
@@ -27,7 +27,7 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 use libc::{c_void, c_float, c_uint};
-use std::{ptr, cast};
+use std::{ptr, mem};
 
 use traits::{Drawable, ShapeImpl, Wrappable};
 use graphics::{RenderWindow, RenderTexture, rc, Texture, Color, Transform,
@@ -52,17 +52,17 @@ pub struct Shape {
 
 #[doc(hidden)]
 extern fn get_point_count_callback(obj : *c_void) -> u32 {
-    let shape = unsafe { cast::transmute::<*c_void, Box<Box<WrapObj>>>(obj) };
+    let shape = unsafe { mem::transmute::<*c_void, Box<Box<WrapObj>>>(obj) };
     let ret = shape.shape_impl.get_point_count();
-    unsafe { cast::forget(shape) };
+    unsafe { mem::forget(shape) };
     ret
 }
 
 #[doc(hidden)]
 extern fn get_point_callback(point : u32, obj : *c_void) -> Vector2f {
-    let shape = unsafe { cast::transmute::<*c_void, Box<Box<WrapObj>>>(obj) };
+    let shape = unsafe { mem::transmute::<*c_void, Box<Box<WrapObj>>>(obj) };
     let ret = shape.shape_impl.get_point(point);
-    unsafe { cast::forget(shape) };
+    unsafe { mem::forget(shape) };
     ret
 }
 
@@ -80,7 +80,7 @@ impl Shape {
         let w_o = box WrapObj { shape_impl : shape_impl};
         let sp = unsafe { ffi::sfShape_create(get_point_count_callback,
                                               get_point_callback,
-                                              cast::transmute::<Box<Box<WrapObj>>, *c_void>(box w_o)) };
+                                              mem::transmute::<Box<Box<WrapObj>>, *c_void>(box w_o)) };
         if sp.is_null() {
             None
         } else {
@@ -105,7 +105,7 @@ impl Shape {
         let w_o = box WrapObj { shape_impl : shape_impl };
         let sp = unsafe { ffi::sfShape_create(get_point_count_callback,
                                               get_point_callback,
-                                              cast::transmute::<Box<Box<WrapObj>>, *c_void>(box w_o)) };
+                                              mem::transmute::<Box<Box<WrapObj>>, *c_void>(box w_o)) };
         if sp.is_null() {
             None
         } else {

--- a/src/graphics/text/mod.rs
+++ b/src/graphics/text/mod.rs
@@ -30,7 +30,7 @@
  */
 
 use libc::{c_float, c_uint, size_t};
-use std::{str, cast};
+use std::{str, mem};
 use std::vec::Vec;
 use std::c_vec::CVec;
 
@@ -288,7 +288,7 @@ impl<'s> Text<'s> {
      * Return the current string style (see Style enum)
      */
     pub fn get_style(&self) -> TextStyle {
-        unsafe { cast::transmute(ffi::sfText_getStyle(self.text)) }
+        unsafe { mem::transmute(ffi::sfText_getStyle(self.text)) }
     }
 
     /**

--- a/src/graphics/text/rc.rs
+++ b/src/graphics/text/rc.rs
@@ -32,7 +32,7 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 use libc::{c_float, c_uint, size_t};
-use std::{str, cast};
+use std::{str, mem};
 use std::vec::Vec;
 use std::c_vec::CVec;
 
@@ -288,7 +288,7 @@ impl Text {
      * Return the current string style (see Style enum)
      */
     pub fn get_style(&self) -> TextStyle {
-        unsafe { cast::transmute(ffi::sfText_getStyle(self.text)) }
+        unsafe { mem::transmute(ffi::sfText_getStyle(self.text)) }
     }
 
     /**

--- a/src/graphics/vertex_array.rs
+++ b/src/graphics/vertex_array.rs
@@ -25,7 +25,7 @@
 //! Define a set of one or more 2D primitives
 
 use libc::c_uint;
-use std::cast;
+use std::mem;
 
 use traits::{Drawable, Wrappable};
 use graphics::{Vertex, FloatRect, primitive_type, PrimitiveType, RenderWindow,
@@ -250,7 +250,7 @@ impl VertexArray {
      */
     pub fn get_vertex(&self, index : uint) -> &mut Vertex {
         unsafe {
-            cast::transmute(ffi::sfVertexArray_getVertex(self.vertex_array,
+            mem::transmute(ffi::sfVertexArray_getVertex(self.vertex_array,
                                                          index as c_uint))
         }
     }
@@ -287,7 +287,7 @@ impl<'s> Iterator<&'s Vertex> for Vertices<'s> {
         } else {
             self.pos += 1;
             unsafe {
-                cast::transmute(ffi::sfVertexArray_getVertex(self.vertex_array,
+                mem::transmute(ffi::sfVertexArray_getVertex(self.vertex_array,
                                                              self.pos as c_uint))
             }
         }
@@ -297,7 +297,7 @@ impl<'s> Iterator<&'s Vertex> for Vertices<'s> {
 impl<'s> Index<uint, &'s Vertex> for VertexArray {
     fn index(&self, _rhs: &uint) -> &'s Vertex {
         unsafe {
-            cast::transmute::<*Vertex, &'s Vertex>
+            mem::transmute::<*Vertex, &'s Vertex>
                 (ffi::sfVertexArray_getVertex(self.vertex_array,
                                               *_rhs as c_uint))
         }

--- a/src/network/ftp.rs
+++ b/src/network/ftp.rs
@@ -25,7 +25,7 @@ e* Permission is granted to anyone to use this software for any purpose,
 //! A FTP client.
 
 use libc::{size_t, c_int};
-use std::{str, cast};
+use std::{str, mem};
 
 use traits::Wrappable;
 use network::IpAddress;
@@ -201,7 +201,7 @@ impl ListingResponse {
     */
     pub fn get_status(&self) -> Status {
         unsafe {
-            cast::transmute(ffi::sfFtpListingResponse_getStatus(self.listing_response) as i16)
+            mem::transmute(ffi::sfFtpListingResponse_getStatus(self.listing_response) as i16)
         }
     }
 
@@ -273,7 +273,7 @@ impl DirectoryResponse {
     */
     pub fn get_status(&self) -> Status {
         unsafe {
-            cast::transmute(ffi::sfFtpDirectoryResponse_getStatus(self.directory_response) as i16)
+            mem::transmute(ffi::sfFtpDirectoryResponse_getStatus(self.directory_response) as i16)
         }
     }
 
@@ -331,7 +331,7 @@ impl Response {
     */
     pub fn get_status(&self) -> Status {
         unsafe {
-            cast::transmute(ffi::sfFtpResponse_getStatus(self.response) as i16)
+            mem::transmute(ffi::sfFtpResponse_getStatus(self.response) as i16)
         }
     }
 

--- a/src/network/http.rs
+++ b/src/network/http.rs
@@ -24,7 +24,7 @@
 
 //! A HTTP client
 
-use std::{str, cast};
+use std::{str, mem};
 use libc::c_int;
 
 use traits::Wrappable;
@@ -269,7 +269,7 @@ impl Response {
     */
     pub fn get_status(&self) -> Status {
         unsafe {
-            cast::transmute(ffi::sfHttpResponse_getStatus(self.response) as i16)
+            mem::transmute(ffi::sfHttpResponse_getStatus(self.response) as i16)
         }
     }
 

--- a/src/network/tcp_listener.rs
+++ b/src/network/tcp_listener.rs
@@ -24,7 +24,7 @@
 
 //! Socket that listens to new TCP connections
 
-use std::cast;
+use std::mem;
 
 use traits::Wrappable;
 use network::{TcpSocket, SocketStatus};
@@ -121,7 +121,7 @@ impl TcpListener {
     */
     pub fn listen(&self, port : u16) -> SocketStatus {
         unsafe {
-            cast::transmute(ffi::sfTcpListener_listen(self.listener, port) as i8)
+            mem::transmute(ffi::sfTcpListener_listen(self.listener, port) as i8)
         }
     }
 
@@ -138,7 +138,7 @@ impl TcpListener {
     */
     pub fn accept(&self, connected : &TcpSocket) -> SocketStatus {
         unsafe {
-            cast::transmute(ffi::sfTcpListener_accept(self.listener, &connected.unwrap()) as i8)
+            mem::transmute(ffi::sfTcpListener_accept(self.listener, &connected.unwrap()) as i8)
         }
     }
 }

--- a/src/network/tcp_socket.rs
+++ b/src/network/tcp_socket.rs
@@ -25,7 +25,7 @@
 //! Specialized socket using the TCP protocol
 
 use libc::size_t;
-use std::{slice, ptr, cast};
+use std::{slice, ptr, mem};
 use std::vec::Vec;
 
 use traits::Wrappable;
@@ -152,7 +152,7 @@ impl TcpSocket {
     */
     pub fn connect(&self, host : &IpAddress, port : u16, timeout : Time) -> SocketStatus {
         unsafe {
-            cast::transmute(ffi::sfTcpSocket_connect(self.socket, host.unwrap(), port, timeout.unwrap()) as i8)
+            mem::transmute(ffi::sfTcpSocket_connect(self.socket, host.unwrap(), port, timeout.unwrap()) as i8)
         }
     }
 
@@ -179,7 +179,7 @@ impl TcpSocket {
     */
     pub fn send(&self, data : Vec<i8>) -> SocketStatus {
         unsafe {
-            cast::transmute(ffi::sfTcpSocket_send(self.socket, data.as_ptr(), data.len() as size_t) as i8)
+            mem::transmute(ffi::sfTcpSocket_send(self.socket, data.as_ptr(), data.len() as size_t) as i8)
         }
     }
 
@@ -199,7 +199,7 @@ impl TcpSocket {
         unsafe {
             let s : size_t = 0;
             let datas : *i8 = ptr::null();
-            let stat : SocketStatus = cast::transmute(ffi::sfTcpSocket_receive(self.socket, datas, max_size, &s) as i8);
+            let stat : SocketStatus = mem::transmute(ffi::sfTcpSocket_receive(self.socket, datas, max_size, &s) as i8);
             (slice::raw::buf_as_slice(datas, s as uint, Vec::from_slice), stat, s)
         }
     }
@@ -214,7 +214,7 @@ impl TcpSocket {
     */
     pub fn send_packet(&self, packet : &Packet) -> SocketStatus {
         unsafe {
-            cast::transmute(ffi::sfTcpSocket_sendPacket(self.socket, packet.unwrap()) as i8)
+            mem::transmute(ffi::sfTcpSocket_sendPacket(self.socket, packet.unwrap()) as i8)
         }
     }
 
@@ -230,7 +230,7 @@ impl TcpSocket {
     pub fn receive_packet(&self) -> (Packet, SocketStatus) {
         unsafe {
             let pack : *::ffi::network::packet::sfPacket = ptr::null();
-            let stat : SocketStatus = cast::transmute(ffi::sfTcpSocket_receivePacket(self.socket, pack) as i8);
+            let stat : SocketStatus = mem::transmute(ffi::sfTcpSocket_receivePacket(self.socket, pack) as i8);
             (Wrappable::wrap(pack), stat)
         }
     }

--- a/src/network/udp_socket.rs
+++ b/src/network/udp_socket.rs
@@ -24,7 +24,7 @@
 
 //! Specialized socket using the UDP protocol
 
-use std::{ptr, slice, cast};
+use std::{ptr, slice, mem};
 use libc::size_t;
 use std::vec::Vec;
 
@@ -124,7 +124,7 @@ impl UdpSocket {
     */
     pub fn bind(&self, port : u16) -> SocketStatus {
         unsafe {
-            cast::transmute(ffi::sfUdpSocket_bind(self.socket, port) as i8)
+            mem::transmute(ffi::sfUdpSocket_bind(self.socket, port) as i8)
         }
     }
 
@@ -155,7 +155,7 @@ impl UdpSocket {
     */
     pub fn send(&self, data : Vec<i8>, address : &IpAddress, port : u16) -> SocketStatus {
         unsafe {
-            cast::transmute(ffi::sfUdpSocket_send(self.socket, data.as_ptr(), data.len() as size_t, address.unwrap(), port) as i8)
+            mem::transmute(ffi::sfUdpSocket_send(self.socket, data.as_ptr(), data.len() as size_t, address.unwrap(), port) as i8)
         }
     }
 
@@ -178,7 +178,7 @@ impl UdpSocket {
             let datas : *i8 = ptr::null();
             let addr : *::ffi::network::ip_address::sfIpAddress = ptr::null();
             let port : u16 = 0;
-            let stat : SocketStatus = cast::transmute(ffi::sfUdpSocket_receive(self.socket, datas, max_size, &s, addr, &port) as i8);
+            let stat : SocketStatus = mem::transmute(ffi::sfUdpSocket_receive(self.socket, datas, max_size, &s, addr, &port) as i8);
             (slice::raw::buf_as_slice(datas, s as uint, Vec::from_slice), stat, s, Wrappable::wrap(*addr), port)
         }
     }
@@ -198,7 +198,7 @@ impl UdpSocket {
     */
     pub fn send_packet(&self, packet : &Packet, address : &IpAddress, port : u16) -> SocketStatus {
         unsafe {
-            cast::transmute(ffi::sfUdpSocket_sendPacket(self.socket, packet.unwrap(), address.unwrap(), port) as i8)
+            mem::transmute(ffi::sfUdpSocket_sendPacket(self.socket, packet.unwrap(), address.unwrap(), port) as i8)
         }
     }
 
@@ -214,7 +214,7 @@ impl UdpSocket {
             let pack : *::ffi::network::packet::sfPacket = ptr::null();
             let addr : *::ffi::network::ip_address::sfIpAddress = ptr::null();
             let port : u16 = 0;
-            let stat : SocketStatus = cast::transmute(ffi::sfUdpSocket_receivePacket(self.socket, pack, addr, &port) as i8);
+            let stat : SocketStatus = mem::transmute(ffi::sfUdpSocket_receivePacket(self.socket, pack, addr, &port) as i8);
             (Wrappable::wrap(pack), stat, Wrappable::wrap(*addr), port)
         }
     }

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -30,7 +30,7 @@
  */
 
 use libc::{c_uint, c_float, c_int};
-use std::{ptr, cast};
+use std::{ptr, mem};
 use std::vec::Vec;
 
 use traits::Wrappable;
@@ -191,7 +191,7 @@ impl Window {
                     0 => false,
                     _ => true
                 };
-                let k : keyboard::Key = unsafe { cast::transmute(self.event.p1 as i64) };
+                let k : keyboard::Key = unsafe { mem::transmute(self.event.p1 as i64) };
                 event::KeyPressed{
                     code : k,
                     alt : al,
@@ -217,7 +217,7 @@ impl Window {
                     0 => false,
                     _ => true
                 };
-                let k : keyboard::Key = unsafe { cast::transmute(self.event.p1 as i64) };
+                let k : keyboard::Key = unsafe { mem::transmute(self.event.p1 as i64) };
                 event::KeyReleased{
                     code : k,
                     alt : al,
@@ -227,29 +227,29 @@ impl Window {
                 }
             },
             7   =>  event::MouseWheelMoved{
-                delta : unsafe { cast::transmute::<c_uint, c_int>(self.event.p1) }  as int,
-                x :     unsafe { cast::transmute::<c_uint, c_int>(self.event.p2) }  as int,
-                y :     unsafe { cast::transmute::<c_float, c_int>(self.event.p3) } as int
+                delta : unsafe { mem::transmute::<c_uint, c_int>(self.event.p1) }  as int,
+                x :     unsafe { mem::transmute::<c_uint, c_int>(self.event.p2) }  as int,
+                y :     unsafe { mem::transmute::<c_float, c_int>(self.event.p3) } as int
             },
             8   => {
-                let button : mouse::MouseButton = unsafe {cast::transmute(self.event.p1 as i8)};
+                let button : mouse::MouseButton = unsafe {mem::transmute(self.event.p1 as i8)};
                 event::MouseButtonPressed{
                     button : button,
-                    x :      unsafe { cast::transmute::<c_uint, c_int>(self.event.p2) as int },
-                    y :      unsafe { cast::transmute::<c_float, c_int>(self.event.p3) as int }
+                    x :      unsafe { mem::transmute::<c_uint, c_int>(self.event.p2) as int },
+                    y :      unsafe { mem::transmute::<c_float, c_int>(self.event.p3) as int }
                 }
             },
             9   => {
-                let button : mouse::MouseButton = unsafe {cast::transmute(self.event.p1 as i8)};
+                let button : mouse::MouseButton = unsafe {mem::transmute(self.event.p1 as i8)};
                 event::MouseButtonReleased{
                     button : button,
-                    x :      unsafe { cast::transmute::<c_uint, c_int>(self.event.p2) as int },
-                    y :      unsafe { cast::transmute::<c_float, c_int>(self.event.p3) as int }
+                    x :      unsafe { mem::transmute::<c_uint, c_int>(self.event.p2) as int },
+                    y :      unsafe { mem::transmute::<c_float, c_int>(self.event.p3) as int }
                 }
             },
             10  => event::MouseMoved{
-                x : unsafe { cast::transmute::<c_uint, c_int>(self.event.p1) } as int,
-                y : unsafe { cast::transmute::<c_uint, c_int>(self.event.p2) } as int
+                x : unsafe { mem::transmute::<c_uint, c_int>(self.event.p1) } as int,
+                y : unsafe { mem::transmute::<c_uint, c_int>(self.event.p2) } as int
             },
             11  => event::MouseEntered,
             12  => event::MouseLeft,
@@ -266,7 +266,7 @@ impl Window {
                 }
             },
             15  => {
-                let ax : joystick::Axis = unsafe {cast::transmute(self.event.p2 as i8)};
+                let ax : joystick::Axis = unsafe {mem::transmute(self.event.p2 as i8)};
                 event::JoystickMoved{
                     joystickid : self.event.p1 as uint,
                     axis : ax,


### PR DESCRIPTION
Rust recently removed the `cast` and shifted its methods to the `mem` module. (mozilla/rust@f94d671bfae5d8e9a4a4add310b1c40af0ab62a6) This PR updates those references so rust-sfml builds again.
