### PR TITLE
Update CString to convert to string instead of strbuf

### DIFF
--- a/src/graphics/text/mod.rs
+++ b/src/graphics/text/mod.rs
@@ -154,7 +154,7 @@ impl<'s> Text<'s> {
      */
     pub fn get_string(&self) -> String {
         unsafe {
-            CString::new(ffi::sfText_getString(self.text), false).as_str().unwrap().to_strbuf()
+            CString::new(ffi::sfText_getString(self.text), false).as_str().unwrap().to_string()
         }
     }
 

--- a/src/graphics/text/rc.rs
+++ b/src/graphics/text/rc.rs
@@ -154,7 +154,7 @@ impl Text {
      */
     pub fn get_string(&self) -> String {
         unsafe {
-            CString::new(ffi::sfText_getString(self.text), false).as_str().unwrap().to_strbuf()
+            CString::new(ffi::sfText_getString(self.text), false).as_str().unwrap().to_string()
         }
     }
 

--- a/src/network/ftp.rs
+++ b/src/network/ftp.rs
@@ -214,7 +214,7 @@ impl ListingResponse {
     pub fn get_message(&self) -> String {
         unsafe {
             CString::new(ffi::sfFtpListingResponse_getMessage(self.listing_response),
-                         false).as_str().unwrap().to_strbuf()
+                         false).as_str().unwrap().to_string()
         }
     }
 
@@ -240,7 +240,7 @@ impl ListingResponse {
     pub fn get_name(&self, index : u64) -> String {
         unsafe {
             CString::new(ffi::sfFtpListingResponse_getName(self.listing_response, index as size_t),
-                         false).as_str().unwrap().to_strbuf()
+                         false).as_str().unwrap().to_string()
         }
     }
 }
@@ -288,7 +288,7 @@ impl DirectoryResponse {
     pub fn get_message(&self) -> String {
         unsafe {
             CString::new(ffi::sfFtpDirectoryResponse_getMessage(self.directory_response),
-                         false).as_str().unwrap().to_strbuf()
+                         false).as_str().unwrap().to_string()
         }
     }
 
@@ -300,7 +300,7 @@ impl DirectoryResponse {
     pub fn get_directory(&self) -> String {
         unsafe {
             CString::new(ffi::sfFtpDirectoryResponse_getDirectory(self.directory_response),
-                         false).as_str().unwrap().to_strbuf()
+                         false).as_str().unwrap().to_string()
         }
     }
 }
@@ -348,7 +348,7 @@ impl Response {
     pub fn get_message(&self) -> String {
         unsafe {
             CString::new(ffi::sfFtpResponse_getMessage(self.response),
-                         false).as_str().unwrap().to_strbuf()
+                         false).as_str().unwrap().to_string()
         }
     }
 }

--- a/src/network/http.rs
+++ b/src/network/http.rs
@@ -255,7 +255,7 @@ impl Response {
         let c_field = field.to_c_str();
         unsafe {
             CString::new(ffi::sfHttpResponse_getField(self.response, c_field.unwrap()),
-                         false).as_str().unwrap().to_strbuf()
+                         false).as_str().unwrap().to_string()
         }
     }
 
@@ -311,7 +311,7 @@ impl Response {
     pub fn get_body(&self) -> String {
         unsafe {
             CString::new(ffi::sfHttpResponse_getBody(self.response),
-                         false).as_str().unwrap().to_strbuf()
+                         false).as_str().unwrap().to_string()
         }
     }
 }

--- a/src/network/ip_address.rs
+++ b/src/network/ip_address.rs
@@ -111,7 +111,7 @@ impl IpAddress {
         unsafe {
             let string : *u8 = ptr::null();
             ffi::sfIpAddress_toString(self.ip, string);
-            CString::new(string as *i8, false).as_str().unwrap().to_strbuf()
+            CString::new(string as *i8, false).as_str().unwrap().to_string()
         }
     }
 

--- a/src/network/packet.rs
+++ b/src/network/packet.rs
@@ -221,7 +221,7 @@ impl Packet {
         unsafe {
             let string : *u8 = ptr::null();
             ffi::sfPacket_readString(self.packet, string);
-            CString::new(string as *i8, false).as_str().unwrap().to_strbuf()
+            CString::new(string as *i8, false).as_str().unwrap().to_string()
         }
     }
 


### PR DESCRIPTION
Another breaking change was introduced as StrBuf is removed in favor of String. This PR changes `to_strbuf()` to `to_string()` where it's used on converting CStrings.
