### PR TITLE
Update several things so lib works with latest master.

### DIFF
--- a/src/audio/sound_status.rs
+++ b/src/audio/sound_status.rs
@@ -24,8 +24,6 @@
 
 //! Sound and musics statues
 
-use libc::c_int;
-
 use ffi = ffi::audio::sound_status;
 
 /// Enumeration of statuses for sounds and musics
@@ -33,9 +31,9 @@ use ffi = ffi::audio::sound_status;
 #[repr(C)]
 pub enum Status {
     /// Sound is not playing.
-    Stopped =   ffi::SFSTOPPED as c_int,
+    Stopped =   ffi::SFSTOPPED as int,
     /// Sound is paused.
-    Paused =    ffi::SFPAUSED as c_int,
+    Paused =    ffi::SFPAUSED as int,
     /// Sound is playing.
-    Playing =   ffi::SFPLAYING as c_int
+    Playing =   ffi::SFPLAYING as int
 }

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -115,7 +115,7 @@ impl RenderWindow {
             typeEvent : 0,
             p1 :        0,
             p2 :        0,
-            p3 :        0 as c_float,
+            p3 :        0f32 as c_float,
             p4 :        0,
             p5 :        0
         };
@@ -176,7 +176,7 @@ impl RenderWindow {
             typeEvent : 0,
             p1 :        0,
             p2 :        0,
-            p3 :        0 as c_float,
+            p3 :        0f32 as c_float,
             p4 :        0,
             p5 :        0
         };
@@ -243,7 +243,7 @@ impl RenderWindow {
                 typeEvent : 0,
                 p1 :        0,
                 p2 :        0,
-                p3 :        0 as c_float,
+                p3 :        0f32 as c_float,
                 p4 :        0,
                 p5 :        0
             }

--- a/src/network/ftp.rs
+++ b/src/network/ftp.rs
@@ -26,7 +26,7 @@ e* Permission is granted to anyone to use this software for any purpose,
 
 use std::mem;
 use std::c_str::CString;
-use libc::{size_t, c_int};
+use libc::size_t;
 
 use traits::Wrappable;
 use network::IpAddress;
@@ -53,106 +53,106 @@ pub enum Status {
     // expect another reply before proceeding with a new command
 
     /// Restart marker reply
-    RestartMarkerReply          = ffi::RESTARTMARKERREPLY,
+    RestartMarkerReply          = ffi::RESTARTMARKERREPLY as int,
     /// Service ready in N minutes
-    ServiceReadySoon            = ffi::SERVICEREADYSOON,
+    ServiceReadySoon            = ffi::SERVICEREADYSOON as int,
     /// Data connection already opened, transfer starting
-    DataConnectionAlreadyOpened = ffi::DATACONNECTIONALREADYOPENED,
+    DataConnectionAlreadyOpened = ffi::DATACONNECTIONALREADYOPENED as int,
     /// File status ok, about to open data connection
-    OpeningDataConnection       = ffi::OPENINGDATACONNECTION,
+    OpeningDataConnection       = ffi::OPENINGDATACONNECTION as int,
 
     // 2xx: the requested action has been successfully completed
 
     /// Command ok
-    Ok                          = ffi::OK as c_int,
+    Ok                          = ffi::OK as int,
     /// Command not implemented
-    PointlessCommand            = ffi::POINTLESSCOMMAND as c_int,
+    PointlessCommand            = ffi::POINTLESSCOMMAND as int,
     /// System status, or system help reply
-    SystemStatus                = ffi::SYSTEMSTATUS as c_int,
+    SystemStatus                = ffi::SYSTEMSTATUS as int,
     /// Directory status
-    DirectoryStatus             = ffi::DIRECTORYSTATUS as c_int,
+    DirectoryStatus             = ffi::DIRECTORYSTATUS as int,
     /// File status
-    FileStatus                  = ffi::FILESTATUS as c_int,
+    FileStatus                  = ffi::FILESTATUS as int,
     /// Help message
-    HelpMessage                 = ffi::HELPMESSAGE as c_int,
+    HelpMessage                 = ffi::HELPMESSAGE as int,
     /// NAME system type, where NAME is an official system name from the list in the Assigned Numbers document
-    SystemType                  = ffi::SYSTEMTYPE as c_int,
+    SystemType                  = ffi::SYSTEMTYPE as int,
     /// Service ready for new user
-    ServiceReady                = ffi::SERVICEREADY as c_int,
+    ServiceReady                = ffi::SERVICEREADY as int,
     /// Service closing control connection
-    ClosingConnection           = ffi::CLOSINGCONNECTION as c_int,
+    ClosingConnection           = ffi::CLOSINGCONNECTION as int,
     /// Data connection open, no transfer in progress
-    DataConnectionOpened        = ffi::DATACONNECTIONOPENED as c_int,
+    DataConnectionOpened        = ffi::DATACONNECTIONOPENED as int,
     /// Closing data connection, requested file action successful
-    ClosingDataConnection       = ffi::CLOSINGDATACONNECTION as c_int,
+    ClosingDataConnection       = ffi::CLOSINGDATACONNECTION as int,
     /// Entering passive mode
-    EnteringPassiveMode         = ffi::ENTERINGPASSIVEMODE as c_int,
+    EnteringPassiveMode         = ffi::ENTERINGPASSIVEMODE as int,
     /// User logged in, proceed. Logged out if appropriate
-    LoggedIn                    = ffi::LOGGEDIN as c_int,
+    LoggedIn                    = ffi::LOGGEDIN as int,
     /// Requested file action ok
-    FileActionOk                = ffi::FILEACTIONOK as c_int,
+    FileActionOk                = ffi::FILEACTIONOK as int,
     /// PATHNAME created
-    DirectoryOk                 = ffi::DIRECTORYOK as c_int,
+    DirectoryOk                 = ffi::DIRECTORYOK as int,
 
     // 3xx: the command has been accepted, but the requested action
     // is dormant, pending receipt of further information
     /// User name ok, need password
-    NeedPassword                = ffi::NEEDPASSWORD as c_int,
+    NeedPassword                = ffi::NEEDPASSWORD as int,
     /// Need account for login
-    NeedAccountToLogIn          = ffi::NEEDACCOUNTTOLOGIN as c_int,
+    NeedAccountToLogIn          = ffi::NEEDACCOUNTTOLOGIN as int,
     /// Requested file action pending further information
-    NeedInformation             = ffi::NEEDINFORMATION as c_int,
+    NeedInformation             = ffi::NEEDINFORMATION as int,
 
     // 4xx: the command was not accepted and the requested action did not take place,
     // but the error condition is temporary and the action may be requested again
 
     /// Service not available, closing control connection
-    ServiceUnavailable          = ffi::SERVICEUNAVAILABLE as c_int,
+    ServiceUnavailable          = ffi::SERVICEUNAVAILABLE as int,
     /// Can't open data connection
-    DataConnectionUnavailable   = ffi::DATACONNECTIONUNAVAILABLE as c_int,
+    DataConnectionUnavailable   = ffi::DATACONNECTIONUNAVAILABLE as int,
     /// Connection closed, transfer aborted
-    TransferAborted             = ffi::TRANSFERABORTED as c_int,
+    TransferAborted             = ffi::TRANSFERABORTED as int,
     /// Requested file action not taken
-    FileActionAborted           = ffi::FILEACTIONABORTED as c_int,
+    FileActionAborted           = ffi::FILEACTIONABORTED as int,
     /// Requested action aborted, local error in processing
-    LocalError                  = ffi::LOCALERROR as c_int,
+    LocalError                  = ffi::LOCALERROR as int,
     /// Requested action not taken; insufficient storage space in system, file unavailable
-    InsufficientStorageSpace    = ffi::INSUFFICIENTSTORAGESPACE as c_int,
+    InsufficientStorageSpace    = ffi::INSUFFICIENTSTORAGESPACE as int,
 
     // 5xx: the command was not accepted and
     // the requested action did not take place
     /// Syntax error, command unrecognized
-    CommandUnknown              = ffi::COMMANDUNKNOWN as c_int,
+    CommandUnknown              = ffi::COMMANDUNKNOWN as int,
     /// Syntax error in parameters or arguments
-    ParametersUnknown           = ffi::PARAMETERSUNKNOWN as c_int,
+    ParametersUnknown           = ffi::PARAMETERSUNKNOWN as int,
     /// Command not implemented
-    CommandNotImplemented       = ffi::COMMANDNOTIMPLEMENTED as c_int,
+    CommandNotImplemented       = ffi::COMMANDNOTIMPLEMENTED as int,
     /// Bad sequence of commands
-    BadCommandSequence          = ffi::BADCOMMANDSEQUENCE as c_int,
+    BadCommandSequence          = ffi::BADCOMMANDSEQUENCE as int,
     /// Command not implemented for that parameter
-    ParameterNotImplemented     = ffi::PARAMETERNOTIMPLEMENTED as c_int,
+    ParameterNotImplemented     = ffi::PARAMETERNOTIMPLEMENTED as int,
     /// Not logged in
-    NotLoggedIn                 = ffi::NOTLOGGEDIN as c_int,
+    NotLoggedIn                 = ffi::NOTLOGGEDIN as int,
     /// Need account for storing files
-    NeedAccountToStore          = ffi::NEEDACCOUNTTOSTORE as c_int,
+    NeedAccountToStore          = ffi::NEEDACCOUNTTOSTORE as int,
     /// Requested action not taken, file unavailable
-    FileUnavailable             = ffi::FILEUNAVAILABLE as c_int,
+    FileUnavailable             = ffi::FILEUNAVAILABLE as int,
     /// Requested action aborted, page type unknown
-    PageTypeUnknown             = ffi::PAGETYPEUNKNOWN as c_int,
+    PageTypeUnknown             = ffi::PAGETYPEUNKNOWN as int,
     /// Requested file action aborted, exceeded storage allocation
-    NotEnoughMemory             = ffi::NOTENOUGHMEMORY as c_int,
+    NotEnoughMemory             = ffi::NOTENOUGHMEMORY as int,
     /// Requested action not taken, file name not allowed
-    FilenameNotAllowed          = ffi::FILENAMENOTALLOWED as c_int,
+    FilenameNotAllowed          = ffi::FILENAMENOTALLOWED as int,
 
     // 10xx: SFML custom codes
     /// Response is not a valid FTP one
-    InvalidResponse             = ffi::INVALIDRESPONSE as c_int,
+    InvalidResponse             = ffi::INVALIDRESPONSE as int,
     /// Connection with server failed
-    ConnectionFailed            = ffi::CONNECTIONFAILED as c_int,
+    ConnectionFailed            = ffi::CONNECTIONFAILED as int,
     /// Connection with server closed
-    ConnectionClosed            = ffi::CONNECTIONCLOSED as c_int,
+    ConnectionClosed            = ffi::CONNECTIONCLOSED as int,
     /// Invalid file to upload / download
-    InvalidFile                 = ffi::INVALIDFILE as c_int
+    InvalidFile                 = ffi::INVALIDFILE as int
 }
 
 /// The FTP client

--- a/src/network/http.rs
+++ b/src/network/http.rs
@@ -26,7 +26,6 @@
 
 use std::mem;
 use std::c_str::CString;
-use libc::c_int;
 
 use traits::Wrappable;
 use system::Time;
@@ -37,11 +36,11 @@ use ffi = ffi::network::http;
 #[deriving(Clone, PartialEq, Eq, PartialOrd, Ord, Show)]
 pub enum Method {
     /// Request in get mode, standard method to retrieve a page
-    Get = ffi::GET as c_int,
+    Get = ffi::GET as int,
     /// Request in post mode, usually to send data to a page
-    Post = ffi::POST as c_int,
+    Post = ffi::POST as int,
     /// Request a page's header only
-    Head = ffi::HEAD as c_int
+    Head = ffi::HEAD as int
 }
 
 /// Status code returned by a serveur.
@@ -49,59 +48,59 @@ pub enum Method {
 pub enum Status {
     // 2xx: success
     /// Most common code returned when operation was successful
-    Ok                  = ffi::OK as c_int,
+    Ok                  = ffi::OK as int,
     /// The resource has successfully been created
-    Created             = ffi::CREATED as c_int,
+    Created             = ffi::CREATED as int,
     /// The request has been accepted, but will be processed later by the server
-    Accepted            = ffi::ACCEPTED as c_int,
+    Accepted            = ffi::ACCEPTED as int,
     /// Sent when the server didn't send any data in return
-    NoContent           = ffi::NOCONTENT as c_int,
+    NoContent           = ffi::NOCONTENT as int,
     /// The server informs the client that it should clear the view (form) that caused the request to be sent
-    ResetContent        = ffi::RESETCONTENT as c_int,
+    ResetContent        = ffi::RESETCONTENT as int,
     /// The server has sent a part of the resource, as a response to a partial GET request
-    PartialContent      = ffi::PARTIALCONTENT as c_int,
+    PartialContent      = ffi::PARTIALCONTENT as int,
 
     // 3xx: redirection
     /// The requested page can be accessed from several locations
-    MultipleChoices     = ffi::MULTIPLECHOICES as c_int,
+    MultipleChoices     = ffi::MULTIPLECHOICES as int,
     /// The requested page has permanently moved to a new location
-    MovedPermanently    = ffi::MOVEDPERMANENTLY as c_int,
+    MovedPermanently    = ffi::MOVEDPERMANENTLY as int,
     /// The requested page has temporarily moved to a new location
-    MovedTemporarily    = ffi::MOVEDTEMPORARILY as c_int,
+    MovedTemporarily    = ffi::MOVEDTEMPORARILY as int,
     /// For conditionnal requests, means the requested page hasn't changed and doesn't need to be refreshed
-    NotModified         = ffi::NOTMODIFIED as c_int,
+    NotModified         = ffi::NOTMODIFIED as int,
 
     // 4xx: client error
     /// The server couldn't understand the request (syntax error)
-    BadRequest          = ffi::BADREQUEST as c_int,
+    BadRequest          = ffi::BADREQUEST as int,
     /// The requested page needs an authentification to be accessed
-    Unauthorized        = ffi::UNAUTHORIZED as c_int,
+    Unauthorized        = ffi::UNAUTHORIZED as int,
     /// The requested page cannot be accessed at all, even with authentification
-    Forbidden           = ffi::FORBIDDEN as c_int,
+    Forbidden           = ffi::FORBIDDEN as int,
     /// The requested page doesn't exist
-    NotFound            = ffi::NOTFOUND as c_int,
+    NotFound            = ffi::NOTFOUND as int,
     /// The server can't satisfy the partial GET request (with a "Range" header field)
-    RangeNotSatisfiable = ffi::RANGENOTSATISFIABLE as c_int,
+    RangeNotSatisfiable = ffi::RANGENOTSATISFIABLE as int,
 
     // 5xx: server error
     /// The server encountered an unexpected error
-    InternalServerError = ffi::INTERNALSERVERERROR as c_int,
+    InternalServerError = ffi::INTERNALSERVERERROR as int,
     /// The server doesn't implement a requested feature
-    NotImplemented      = ffi::NOTIMPLEMENTED as c_int,
+    NotImplemented      = ffi::NOTIMPLEMENTED as int,
     /// The gateway server has received an error from the source server
-    BadGateway          = ffi::BADGATEWAY as c_int,
+    BadGateway          = ffi::BADGATEWAY as int,
     /// The server is temporarily unavailable (overloaded, in maintenance, ...)
-    ServiceNotAvailable = ffi::SERVICENOTAVAILABLE as c_int,
+    ServiceNotAvailable = ffi::SERVICENOTAVAILABLE as int,
     /// The gateway server couldn't receive a response from the source server
-    GatewayTimeout      = ffi::GATEWAYTIMEOUT as c_int,
+    GatewayTimeout      = ffi::GATEWAYTIMEOUT as int,
     /// The server doesn't support the requested HTTP version
-    VersionNotSupported = ffi::VERSIONNOTSUPPORTED as c_int,
+    VersionNotSupported = ffi::VERSIONNOTSUPPORTED as int,
 
     // 10xx: SFML custom codes
     /// Response is not a valid HTTP one
-    InvalidResponse     = ffi::INVALIDRESPONSE as c_int,
+    InvalidResponse     = ffi::INVALIDRESPONSE as int,
     /// Connection with server failed
-    ConnectionFailed    = ffi::CONNECTIONFAILED as c_int
+    ConnectionFailed    = ffi::CONNECTIONFAILED as int
 }
 
 /// Encapsulation of an HTTP request

--- a/src/network/socket_status.rs
+++ b/src/network/socket_status.rs
@@ -24,19 +24,17 @@
 
 //! Status codes that may be returned by socket functions.
 
-use libc::c_int;
-
 use ffi = ffi::network::socket_status;
 
 /// Status codes that may be returned by socket functions.
 #[deriving(Clone, PartialEq, Eq, PartialOrd, Ord, Show)]
 pub enum SocketStatus {
     /// The socket has sent / received the data.
-    SocketNone =            ffi::SOCKETNONE as c_int,
+    SocketNone =            ffi::SOCKETNONE as int,
     /// The socket is not ready to send / receive data yet.
-    SocketNotReady =        ffi::SOCKETNOTREADY as c_int,
+    SocketNotReady =        ffi::SOCKETNOTREADY as int,
     /// The TCP socket has been disconnected.
-    SocketDisconnected =    ffi::SOCKETDISCONNECTED as c_int,
+    SocketDisconnected =    ffi::SOCKETDISCONNECTED as int,
     /// An unexpected error happened.
-    SocketError =           ffi::SOCKETERROR as c_int
+    SocketError =           ffi::SOCKETERROR as int
 }

--- a/src/system/time.rs
+++ b/src/system/time.rs
@@ -99,20 +99,8 @@ impl PartialEq for Time {
 }
 
 impl PartialOrd for Time {
-    fn lt(&self, other: &Time) -> bool {
-        self.as_microseconds() < other.as_microseconds()
-    }
-
-    fn le(&self, other: &Time) -> bool {
-        self.as_microseconds() <= other.as_microseconds()
-    }
-
-    fn gt(&self, other: &Time) -> bool {
-        self.as_microseconds() > other.as_microseconds()
-    }
-
-    fn ge(&self, other: &Time) -> bool {
-        self.as_microseconds() >= other.as_microseconds()
+    fn partial_cmp(&self, other: &Time) -> Option<Ordering> {
+        self.as_microseconds().partial_cmp(&other.as_microseconds())
     }
 }
 

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -93,7 +93,7 @@ impl Window {
             typeEvent : 0,
             p1 :        0,
             p2 :        0,
-            p3 :        0 as c_float,
+            p3 :        0f32 as c_float,
             p4 :        0,
             p5 :        0
         };
@@ -142,7 +142,7 @@ impl Window {
             typeEvent : 0,
             p1 :        0,
             p2 :        0,
-            p3 :        0 as c_float,
+            p3 :        0f32 as c_float,
             p4 :        0,
             p5 :        0
         };


### PR DESCRIPTION
Quick and dirty fix to get things working again.  Details:

Updated several things to use int rather than `c_int`, since rustc complained about mismatched types (expected int, got i32 kind of errors).  Not sure a lot of the casts that I left in are necessary, I just didn't bother removing them.

See rust-lang/rust#15270 for details about the enum representation change/bug that made most of this necessary.  Not sure the way I fixed things is really best, but unfortunately changing to `#[repr(i32)]` brought a bunch of errors about differently sized types in transmute calls, so I decided to go with casts to int.

Also fixed the PartialOrd implementation in system/time.rs - looks like PartialOrd got changed to have a partial_cmp method instead of just lt/gt etc.

Finally, `p3 : 0 as c_float` is apparently invalid now, as the type of the `0` can't be immediately determined. So that got changed to `0f32 as c_float`.  Definitely doesn't need the cast on most/all platforms, but I left it in for clarity.

Seems to work on windows, don't have the ability to test elsewhere at the moment.
