### PR TITLE
Make several functions take &[T] instead of Vec[T]

### DIFF
--- a/src/ffi/graphics.rs
+++ b/src/ffi/graphics.rs
@@ -93,7 +93,7 @@ pub mod render_window {
         pub fn sfRenderWindow_drawConvexShape(renderWindow : *mut sfRenderWindow, object : *mut sfConvexShape, states : *mut sfRenderStates) -> ();
         pub fn sfRenderWindow_drawRectangleShape(renderWindow : *mut sfRenderWindow, object : *mut sfRectangleShape, states : *mut sfRenderStates) -> ();
         pub fn sfRenderWindow_drawVertexArray(renderWindow : *mut sfRenderWindow, object : *mut sfVertexArray, states : *mut sfRenderStates) -> ();
-        // fn sfRenderWindow_drawPrimitives(renderWindow : *mut sfRenderWindow, vertices : *mut sfVertex, vertexCount : c_uint, ttype : sfPrimitiveType, states : *mut sfRenderStates) -> ();  
+        // fn sfRenderWindow_drawPrimitives(renderWindow : *mut sfRenderWindow, vertices : *mut sfVertex, vertexCount : c_uint, ttype : sfPrimitiveType, states : *mut sfRenderStates) -> ();
         pub fn sfRenderWindow_pushGLStates(renderWindow : *mut sfRenderWindow) -> ();
         pub fn sfRenderWindow_popGLStates(renderWindow : *mut sfRenderWindow) -> ();
         pub fn sfRenderWindow_resetGLStates(renderWindow : *mut sfRenderWindow) -> ();
@@ -623,7 +623,7 @@ pub mod texture {
         pub fn sfTexture_destroy(texture : *mut sfTexture) -> ();
         pub fn sfTexture_getSize(texture : *mut sfTexture) -> Vector2u;
         pub fn sfTexture_copyToImage(texture : *mut sfTexture) -> *mut sfImage;
-        pub fn sfTexture_updateFromPixels(texture : *mut sfTexture, pixels : *mut u8, width : c_uint, height : c_uint, x : c_uint, y : c_uint) -> ();
+        pub fn sfTexture_updateFromPixels(texture : *mut sfTexture, pixels : *const u8, width : c_uint, height : c_uint, x : c_uint, y : c_uint) -> ();
         pub fn sfTexture_updateFromImage(texture : *mut sfTexture, image : *mut sfImage, x : c_uint, y : c_uint) -> ();
         pub fn sfTexture_updateFromWindow(texture : *mut sfTexture, window : *mut sfWindow, x : c_uint, y : c_uint) -> ();
         pub fn sfTexture_updateFromRenderWindow(texture : *mut sfTexture, renderWindow : *mut sfRenderWindow, x : c_uint, y : c_uint) -> ();

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -25,7 +25,6 @@
 //! Loading, manipulating and saving images.
 
 use libc::c_uint;
-use std::vec::Vec;
 
 use traits::Wrappable;
 use system::vector2::Vector2u;
@@ -148,7 +147,7 @@ impl Image {
      */
     pub fn create_from_pixels(width : uint,
                               height : uint,
-                              pixels : Vec<u8>) -> Option<Image> {
+                              pixels : &[u8]) -> Option<Image> {
         let image =
             unsafe { ffi::sfImage_createFromPixels(width as c_uint,
                                                    height as c_uint,

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -226,7 +226,7 @@ impl RenderWindow {
     pub fn set_icon(&mut self,
                     width : uint,
                     height : uint,
-                    pixels : Vec<u8>) -> () {
+                    pixels : &[u8]) -> () {
         unsafe {
             ffi::sfRenderWindow_setIcon(self.render_window,
                                         width as c_uint,

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -30,7 +30,6 @@
 
 use libc::c_uint;
 use std::ptr;
-use std::vec::Vec;
 
 use traits::Wrappable;
 use graphics::{RenderWindow, Image, IntRect};
@@ -271,14 +270,14 @@ impl Texture {
      * * y - Y offset in the texture where to copy the source pixels
      */
     pub fn update_from_pixels(&mut self,
-                              pixels : Vec<u8>,
+                              pixels : &[u8],
                               width : uint,
                               height : uint,
                               x : uint,
                               y : uint) -> () {
         unsafe {
             ffi::sfTexture_updateFromPixels(self.texture,
-                                            pixels.as_ptr() as *mut u8,
+                                            pixels.as_ptr(),
                                             width as c_uint,
                                             height as c_uint,
                                             x as c_uint,

--- a/src/network/tcp_socket.rs
+++ b/src/network/tcp_socket.rs
@@ -177,7 +177,7 @@ impl TcpSocket {
     *
     * Return the status code
     */
-    pub fn send(&self, data : Vec<i8>) -> SocketStatus {
+    pub fn send(&self, data : &[i8]) -> SocketStatus {
         unsafe {
             mem::transmute(ffi::sfTcpSocket_send(self.socket, data.as_ptr(), data.len() as size_t) as i8)
         }

--- a/src/network/udp_socket.rs
+++ b/src/network/udp_socket.rs
@@ -153,7 +153,7 @@ impl UdpSocket {
     * * remoteAddress - Address of the receiver
     * * remotePort - Port of the receiver to send the data to
     */
-    pub fn send(&self, data : Vec<i8>, address : &IpAddress, port : u16) -> SocketStatus {
+    pub fn send(&self, data : &[i8], address : &IpAddress, port : u16) -> SocketStatus {
         unsafe {
             mem::transmute(ffi::sfUdpSocket_send(self.socket, data.as_ptr() as *mut i8, data.len() as size_t, address.unwrap(), port) as i8)
         }


### PR DESCRIPTION
The CSFML functions all copy the data given to them and do not take
ownership, so taking `Vec<T>` is unnecessary at best and an extra heap
allocation (for data created on the stack) at worst.

[breaking-change]
