### PR TITLE
Change target_os to windows instead of win32

### DIFF
--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -40,7 +40,7 @@ pub mod rc {
 #[doc(hidden)]
 #[cfg(target_os="macos")]
 #[cfg(target_os="linux")]
-#[cfg(target_os="win32")]
+#[cfg(target_os="windows")]
 mod platform {
     #[link(name = "csfml-audio")]
     extern {}

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -68,7 +68,7 @@ pub mod rc {
 #[doc(hidden)]
 #[cfg(target_os="macos")]
 #[cfg(target_os="linux")]
-#[cfg(target_os="win32")]
+#[cfg(target_os="windows")]
 mod platform {
     #[link(name = "csfml-graphics")]
     extern {}

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -40,7 +40,7 @@ pub use network::http::Http;
 #[doc(hidden)]
 #[cfg(target_os="macos")]
 #[cfg(target_os="linux")]
-#[cfg(target_os="win32")]
+#[cfg(target_os="windows")]
 mod platform {
     #[link(name = "csfml-network")]
     extern {}

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -37,7 +37,7 @@ pub use system::clock::Clock;
 #[doc(hidden)]
 #[cfg(target_os="macos")]
 #[cfg(target_os="linux")]
-#[cfg(target_os="win32")]
+#[cfg(target_os="windows")]
 mod platform {
     #[link(name = "csfml-system")]
     extern {}

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -35,7 +35,7 @@ pub use window::window_style::{WindowStyle, NoStyle, Titlebar,
 #[doc(hidden)]
 #[cfg(target_os="macos")]
 #[cfg(target_os="linux")]
-#[cfg(target_os="win32")]
+#[cfg(target_os="windows")]
 mod platform {
     #[link(name = "csfml-window")]
     extern {}


### PR DESCRIPTION
rsfml currently doesn't link properly on windows as target_os has been renamed ( rust-lang/rust#16435 ).  This fixes that.
