### PR TITLE
Fix examples in docs

### DIFF
--- a/src/rsfml.rs
+++ b/src/rsfml.rs
@@ -65,10 +65,10 @@
 //! On OSX window must be launched in the main thread. You should override the
 //! rust runtime start function.
 //!
-//! ```Rust
+//! ```rust
 //! #[cfg(target_os="macos")]
 //! #[start]
-//! fn start(argc: int, argv: **u8) -> int {
+//! fn start(argc: int, argv: *const *const u8) -> int {
 //!     std::rt::start_on_main_thread(argc, argv, main)
 //! }
 //! ```
@@ -77,45 +77,44 @@
 //!
 //! Here is a short example, draw a circle shape and display it.
 //!
-//! ```Rust
+//! ```rust
 //! extern crate native;
 //! extern crate rsfml;
 //!
 //! use rsfml::system::Vector2f;
 //! use rsfml::window::{ContextSettings, VideoMode, event, Close};
-//! use rsfml::graphics::{RenderWindow, CircleShape, Color};
+//! use rsfml::graphics::{RenderWindow, RenderTarget, CircleShape, Color};
 //!
 //! #[start]
-//! fn start(argc: int, argv: **u8) -> int {
+//! fn start(argc: int, argv: *const *const u8) -> int {
 //!     native::start(argc, argv, main)
 //! }
 //!
 //! fn main () -> () {
-//!      // Create the window of the application
-//!     let setting = ContextSettings::default();
+//!     // Create the window of the application
 //!     let mut window = match RenderWindow::new(VideoMode::new_init(800, 600, 32),
 //!                                              "SFML Example",
 //!                                              Close,
-//!                                              &setting) {
+//!                                              &ContextSettings::default()) {
 //!         Some(window) => window,
 //!         None => fail!("Cannot create a new Render Window.")
 //!     };
 //!
 //!     // Create a CircleShape
 //!     let mut circle = match CircleShape::new() {
-//!         Some(circle)    => circle,
-//!         None()          => fail!("Error, cannot create ball")
+//!         Some(circle) => circle,
+//!         None       => fail!("Error, cannot create ball")
 //!     };
 //!     circle.set_radius(30.);
 //!     circle.set_fill_color(&Color::red());
 //!     circle.set_position(&Vector2f::new(100., 100.));
 //!
 //!     while window.is_open() {
-//!         loop {
-//!             match window.poll_event() {
+//!         // Handle events
+//!         for event in window.events() {
+//!             match event {
 //!                 event::Closed => window.close(),
-//!                 event::NoEvent => break,
-//!                 _ => {}
+//!                 _             => {/* do nothing */}
 //!             }
 //!         }
 //!


### PR DESCRIPTION
Update examples to work with latest Rust/rsfml.
Use `rust` instead of `Rust` as language identifier, as
rustdoc only recognizes `rust` (at least on linux).
