### PR TITLE
Change a file reference in the Makefile to get it working again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ all: rsfml examples docs
 
 rsfml:
 	mkdir -p lib
-	rustc --out-dir=lib src/rsfml.rs
+	rustc --out-dir=lib src/lib.rs
 
 docs:
 	mkdir -p doc
-	rustdoc -o doc src/rsfml.rs
+	rustdoc -o doc src/lib.rs
 
 examples: rsfml
 	mkdir -p bin


### PR DESCRIPTION
The Makefile is out of date, for those still using it. This PR changes the file referenced in the Makefile from `rsfml.rs` to `lib.rs`
