### PR TITLE
Update sound capture example to use from_str instead of from_str_common

### DIFF
--- a/src/examples/sound_capture/main.rs
+++ b/src/examples/sound_capture/main.rs
@@ -11,7 +11,6 @@ extern crate rsfml;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::io::{BufferedReader, stdin};
-use std::num::strconv;
 
 use rsfml::audio::{rc, SoundBufferRecorder, Playing};
 use rsfml::system::{sleep, Time};
@@ -27,7 +26,7 @@ fn main() -> () {
     let mut stdin = BufferedReader::new(stdin());
     let mut line = stdin.read_line().unwrap();
     unsafe { line.as_mut_vec().pop(); }
-    let sample_rate: uint = match strconv::from_str_common(line.as_slice(), 10, false, false, false, strconv::ExpNone, true, false) {
+    let sample_rate: uint = match from_str::<uint>(line.as_slice()) {
         Some(value)     => value,
         None            => panic!("Error, input is not valid")
     };


### PR DESCRIPTION
`from_str_common` was removed from `strconv`, which caused the sound_capture example to fail to build. I replaced the use of `from_str_common` with `from_str` to get the example to build.
