### PR TITLE
Re-export namespaced enum variants

### DIFF
--- a/src/audio/sound_status.rs
+++ b/src/audio/sound_status.rs
@@ -24,6 +24,8 @@
 
 //! Sound and musics statues
 
+pub use self::Status::{Stopped, Paused, Playing};
+
 use ffi::audio::sound_status as ffi;
 
 /// Enumeration of statuses for sounds and musics

--- a/src/ffi/sfml_types.rs
+++ b/src/ffi/sfml_types.rs
@@ -22,6 +22,8 @@
 * 3. This notice may not be removed or altered from any source distribution.
 */
 
+pub use self::SfBool::{SFFALSE, SFTRUE};
+
 #[repr(C)]
 #[deriving(PartialEq, Eq)]
 pub enum SfBool {

--- a/src/graphics/blend_mode.rs
+++ b/src/graphics/blend_mode.rs
@@ -24,6 +24,8 @@
 
 //! Available blending modes for drawing
 
+pub use self::BlendMode::{BlendAlpha, BlendAdd, BlendMultiply, BlendNone};
+
 ///Available Blending modes for drawing.
 #[deriving(Clone, PartialEq, Eq, PartialOrd, Ord, Show)]
 pub enum BlendMode {

--- a/src/graphics/primitive_type.rs
+++ b/src/graphics/primitive_type.rs
@@ -22,6 +22,9 @@
 * 3. This notice may not be removed or altered from any source distribution.
 */
 
+pub use self::PrimitiveType::{Points, Lines, LinesStrip, Triangles,
+                              TrianglesStrip, TrianglesFan, Quads};
+
 /**
  * Types of primitives that a VertexArray can render
  *

--- a/src/graphics/text_style.rs
+++ b/src/graphics/text_style.rs
@@ -22,6 +22,8 @@
 * 3. This notice may not be removed or altered from any source distribution.
 */
 
+pub use self::TextStyle::{Regular, Bold, Italic, Underlined};
+
 /// Availables texts styles
 #[deriving(Clone, PartialEq, Eq, PartialOrd, Ord, Show)]
 #[repr(C)]

--- a/src/network/socket_status.rs
+++ b/src/network/socket_status.rs
@@ -24,6 +24,9 @@
 
 //! Status codes that may be returned by socket functions.
 
+pub use self::SocketStatus::{SocketNone, SocketNotReady, SocketDisconnected,
+                             SocketError};
+
 use ffi::network::socket_status as ffi;
 
 /// Status codes that may be returned by socket functions.

--- a/src/window/event.rs
+++ b/src/window/event.rs
@@ -26,6 +26,13 @@
 //!
 //! Event holds all the informations about a system event that just happened.
 
+pub use self::Event::{Closed, Resized, LostFocus, GainedFocus, TextEntered,
+                     KeyPressed, KeyReleased, MouseWheelMoved,
+                     MouseButtonPressed, MouseButtonReleased, MouseMoved,
+                     MouseEntered, MouseLeft, JoystickButtonPressed,
+                     JoystickButtonReleased, JoystickMoved, JoystickConnected,
+                     JoystickDisconnected, NoEvent};
+
 use window::keyboard::Key;
 use window::mouse::MouseButton;
 use window::joystick::Axis;

--- a/src/window/window_style.rs
+++ b/src/window/window_style.rs
@@ -26,6 +26,9 @@
 //!
 //! Availables window styles
 
+pub use self::WindowStyle::{NoStyle, Titlebar, Resize, Close, Fullscreen,
+                            DefaultStyle};
+
 /// Enumeration of window creation styles
 #[deriving(Clone, PartialEq, Eq, PartialOrd, Ord, Show)]
 #[repr(C)]


### PR DESCRIPTION
Enums in Rust are now namespaced.
To adapt to this without changing the API, we simply re-export the
enum variants where appropriate.

The goal is to fix the build.
The API can be changed later to properly make use of this new behavior,
if desired.
