### PR TITLE
Remove unused `desc` attribute from crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 
 name = "rust-sfml"
+description = "Rust binding for sfml"
 version = "0.9.0"
 authors = ["Jeremy Letang <letang.jeremy@gmail.com>"]
 

--- a/src/examples/borrow_res/main.rs
+++ b/src/examples/borrow_res/main.rs
@@ -1,7 +1,6 @@
 //! Example from SFML: borrow_res
 
 #![crate_name = "borrow_res"]
-#![desc = "Shape using borrow ressources example for rsfml"]
 #![crate_type = "bin"]
 
 extern crate rsfml;

--- a/src/examples/custom_drawable/main.rs
+++ b/src/examples/custom_drawable/main.rs
@@ -1,7 +1,6 @@
 //! Example from SFML: Custom drawable
 
 #![crate_name = "custom_drawable"]
-#![desc = "Custom drawable example for rsfml"]
 #![crate_type = "bin"]
 
 extern crate rsfml;

--- a/src/examples/pong/main.rs
+++ b/src/examples/pong/main.rs
@@ -1,7 +1,6 @@
 //! Example from SFML: Pong
 
 #![crate_name = "pong"]
-#![desc = "Pong example for rsfml"]
 #![crate_type = "bin"]
 #![allow(non_snake_case)]
 

--- a/src/examples/rc_res/main.rs
+++ b/src/examples/rc_res/main.rs
@@ -1,7 +1,6 @@
 //! Example from SFML: borrow_res
 
 #![crate_name = "rc_res"]
-#![desc = "Shape using borrow ressources example for rsfml"]
 #![crate_type = "bin"]
 
 extern crate rsfml;

--- a/src/examples/shape/main.rs
+++ b/src/examples/shape/main.rs
@@ -1,7 +1,6 @@
 //! Example from SFML: Shape
 
 #![crate_name = "shape"]
-#![desc = "Shape example for rsfml"]
 #![crate_type = "bin"]
 
 extern crate rsfml;

--- a/src/examples/sound/main.rs
+++ b/src/examples/sound/main.rs
@@ -1,7 +1,6 @@
 //! Example from SFML: play sound and music
 
 #![crate_name = "sound"]
-#![desc = "Sound example for rsfml"]
 #![crate_type = "bin"]
 
 extern crate rsfml;

--- a/src/examples/sound_capture/main.rs
+++ b/src/examples/sound_capture/main.rs
@@ -2,7 +2,6 @@
 
 
 #![crate_name = "sound_capture"]
-#![desc = "Sound capture example for rsfml"]
 #![crate_type = "bin"]
 #![allow(unused_must_use)]
 

--- a/src/examples/vertex_arrays/main.rs
+++ b/src/examples/vertex_arrays/main.rs
@@ -1,7 +1,6 @@
 //! Example from SFML: Shape
 
 #![crate_name = "vertex_arrays"]
-#![desc = "VertexArray example for rsfml"]
 #![crate_type = "bin"]
 
 #![feature(macro_rules)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,6 @@
 //! Here is a list of all modules :
 
 #![crate_name = "rsfml"]
-#![desc = "Rust binding for sfml"]
 #![license = "Zlib/png"]
 #![doc(html_logo_url = "http://rust-sfml.org/logo_rsfml.png")]
 #![crate_type = "rlib"]


### PR DESCRIPTION
The `desc` crate attribute has been removed from Rust.
You can use the `description` field in Cargo.toml to describe your package.

This commit removes the desc attribute from all crates.
A `description` field in Cargo.toml is added to describe the package.
