### PR TITLE
Remove associated_types and default_type_params from feature list

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@
 #![crate_type = "dylib"]
 #![allow(dead_code, non_camel_case_types, unused_attributes)]
 #![warn(missing_docs)]
-#![feature(unsafe_destructor, associated_types, default_type_params)]
+#![feature(unsafe_destructor)]
 
 extern crate libc;
 


### PR DESCRIPTION
These features are now ungated in Rust.