### PR TITLE
Update to latest Rust by switching to 'old_io' in sound capture example.

### DIFF
--- a/src/examples/sound_capture/main.rs
+++ b/src/examples/sound_capture/main.rs
@@ -9,7 +9,7 @@ extern crate rsfml;
 
 use std::rc::Rc;
 use std::cell::RefCell;
-use std::io::{BufferedReader, stdin};
+use std::old_io::{BufferedReader, stdin};
 
 use rsfml::audio::{rc, SoundBufferRecorder, Playing};
 use rsfml::system::{sleep, Time};
@@ -25,7 +25,7 @@ fn main() -> () {
     let mut stdin = BufferedReader::new(stdin());
     let mut line = stdin.read_line().unwrap();
     unsafe { line.as_mut_vec().pop(); }
-    let sample_rate: u32 = match line.as_slice().parse() {
+    let sample_rate: u32 = match line.as_slice().parse().ok() {
         Some(value)     => value,
         None            => panic!("Error, input is not valid")
     };

--- a/src/graphics/vertex_array.rs
+++ b/src/graphics/vertex_array.rs
@@ -40,7 +40,7 @@ pub struct VertexArray {
 }
 
 /// An iterator over the vertice of a VertexArray
-pub struct Vertices<'s> {
+pub struct Vertices {
     #[doc(hidden)]
     vertex_array: *mut ffi::sfVertexArray,
     #[doc(hidden)]
@@ -256,7 +256,7 @@ impl Clone for VertexArray {
     }
 }
 
-impl<'s> Iterator for Vertices<'s> {
+impl<'s> Iterator for Vertices {
     type Item = &'s Vertex;
 
     fn next(&mut self) -> Option<&'s Vertex> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,6 @@
 //! Here is a list of all modules :
 
 #![crate_name = "rsfml"]
-#![license = "Zlib/png"]
 #![doc(html_logo_url = "http://rust-sfml.org/logo_rsfml.png")]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]


### PR DESCRIPTION
Figured this would be more stable than trying to use the new std::io (AFAIK it's still in flux).