### PR TITLE
Rename package from rust-sfml to sfml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 
-name = "rust-sfml"
+name = "sfml"
 description = "Rust binding for sfml"
 version = "0.9.0"
 authors = ["Jeremy Letang <letang.jeremy@gmail.com>"]


### PR DESCRIPTION
I left this out of #80 as an oversight.

Basically the same arguments apply. The package is used in the context
of Rust, so the `rust-` prefix is redundant.