### PR TITLE
Rename non_snake_case public methods to snake_case

### DIFF
--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -1,40 +1,3 @@
-rust-sfml [![Build Status](https://api.travis-ci.org/jeremyletang/rust-sfml.png?branch=master)](https://travis-ci.org/jeremyletang/rust-sfml)
-=========
-
-
-SFML bindings for Rust
-
-This is a Rust binding for SFML, the Simple and Fast Multimedia Library, developed by Laurent Gomila.
-
-SFML website : www.sfml-dev.org
-
-Installation
-============
-
-You must install the SFML2.1 and CSFML2.1 libraries on your computer which are used for the binding.
-
-SFML2.1: http://www.sfml-dev.org/download/sfml/2.1/
-
-CSFML2.1: http://www.sfml-dev.org/download/csfml/
-
-Then clone the repo and build the library with the following command.
-
-You can use Cargo to build rust-sfml:
-```Shell
-> cargo build
-```
-
-Examples are located under the `examples` directory.
-You can run an example with `cargo run --example example_name`
-
-Rust-sfml works on Linux, Windows and OSX.
-
-Short example
-=============
-
-Here is a short example, draw a circle shape and display it.
-
-```Rust
 extern crate sfml;
 
 use sfml::system::Vector2f;
@@ -72,14 +35,3 @@ fn main() {
         window.display()
     }
 }
-
-```
-
-
-License
-=======
-
-This software is a binding of the SFML library created by Laurent Gomila, which is provided under the Zlib/png license.
-
-This software is provided under the same license than the SFML, the Zlib/png license.
-

--- a/examples/pong.rs
+++ b/examples/pong.rs
@@ -51,7 +51,7 @@ fn main() {
     left_paddle.set_size(&(paddle_size - 3f32));
     left_paddle.set_outline_thickness(3.);
     left_paddle.set_outline_color(&Color::black());
-    left_paddle.set_fill_color(&Color::new_RGB(100, 100, 200));
+    left_paddle.set_fill_color(&Color::new_rgb(100, 100, 200));
     left_paddle.set_origin(&(paddle_size / 2f32));
 
     // Create the right paddle
@@ -62,7 +62,7 @@ fn main() {
     right_paddle.set_size(&(paddle_size - 3f32));
     right_paddle.set_outline_thickness(3.);
     right_paddle.set_outline_color(&Color::black());
-    right_paddle.set_fill_color(&Color::new_RGB(200, 100, 100));
+    right_paddle.set_fill_color(&Color::new_rgb(200, 100, 100));
     right_paddle.set_origin(&(paddle_size / 2f32));
 
     // Create the ball
@@ -229,7 +229,7 @@ fn main() {
             //let a = r.gen::<float>();
         }
         // Clear the window
-        window.clear(&Color::new_RGB(50, 200, 50));
+        window.clear(&Color::new_rgb(50, 200, 50));
 
         if is_playing {
             // Draw the paddles and the ball

--- a/src/graphics/color.rs
+++ b/src/graphics/color.rs
@@ -22,8 +22,6 @@
 * 3. This notice may not be removed or altered from any source distribution.
 */
 
-#![allow(non_snake_case)]
-
 //! Utility class for manpulating RGBA colors
 //!
 //! Color is a simple color class composed of 4 components: Red, Green, Blue, Alpha
@@ -58,7 +56,7 @@ impl Color {
     /// * blue - Blue component  (0 .. 255)
     ///
     /// Return Color object constructed from the components
-    pub fn new_RGB(red: u8, green: u8, blue: u8) -> Color {
+    pub fn new_rgb(red: u8, green: u8, blue: u8) -> Color {
         Color {
             red: red,
             green: green,
@@ -76,7 +74,7 @@ impl Color {
     /// * alpha - Alpha component  (0 .. 255)
     ///
     /// Return Color object constructed from the components
-    pub fn new_RGBA(red: u8, green: u8, blue: u8, alpha: u8) -> Color {
+    pub fn new_rgba(red: u8, green: u8, blue: u8, alpha: u8) -> Color {
         Color {
             red: red,
             green: green,
@@ -109,47 +107,47 @@ impl Color {
 
     /// Black predefined color
     pub fn black() -> Color {
-        Color::new_RGB(0, 0, 0)
+        Color::new_rgb(0, 0, 0)
     }
 
     /// White predefined color
     pub fn white() -> Color {
-        Color::new_RGB(255, 255, 255)
+        Color::new_rgb(255, 255, 255)
     }
 
     /// Red predefined color
     pub fn red() -> Color {
-        Color::new_RGB(255, 0, 0)
+        Color::new_rgb(255, 0, 0)
     }
 
     /// Green predefined color
     pub fn green() -> Color {
-        Color::new_RGB(0, 255, 0)
+        Color::new_rgb(0, 255, 0)
     }
 
     /// Blue predefined color
     pub fn blue() -> Color {
-        Color::new_RGB(0, 0, 255)
+        Color::new_rgb(0, 0, 255)
     }
 
     /// Yellow predefined color
     pub fn yellow() -> Color {
-        Color::new_RGB(255, 255, 0)
+        Color::new_rgb(255, 255, 0)
     }
 
     /// Magenta predefined color
     pub fn magenta() -> Color {
-        Color::new_RGB(255, 0, 255)
+        Color::new_rgb(255, 0, 255)
     }
 
     /// Cyan predifined color
     pub fn cyan() -> Color {
-        Color::new_RGB(0, 255, 255)
+        Color::new_rgb(0, 255, 255)
     }
 
     /// Tranparent predefined color
     pub fn transparent() -> Color {
-        Color::new_RGBA(0, 0, 0, 0)
+        Color::new_rgba(0, 0, 0, 0)
     }
 
 }

--- a/src/graphics/render_states/rc.rs
+++ b/src/graphics/render_states/rc.rs
@@ -24,8 +24,6 @@
 
 //! Define the states used for drawing to a RenderTarget
 
-#![allow(non_snake_case)]
-
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::ptr;
@@ -37,9 +35,9 @@ use ffi::graphics::render_states as ffi;
 
 /// Define the states used for drawing to a RenderTarget
 pub struct RenderStates {
-    sfRenderStates: ffi::sfRenderStates,
+    sf_render_states: ffi::sfRenderStates,
     /// Blending mode.
-    pub blendMode: BlendMode,
+    pub blend_mode: BlendMode,
     /// Transform
     pub transform: Transform,
     /// Texture
@@ -65,13 +63,13 @@ impl RenderStates {
         shader: Option<Rc<RefCell<rc::Shader>>>) -> RenderStates {
 
         RenderStates {
-            sfRenderStates: ffi::sfRenderStates {
+                sf_render_states: ffi::sfRenderStates {
                 blendMode: blend_mode as i32,
                 transform: transform,
                 texture: ptr::null_mut(),
                 shader: ptr::null_mut()
             },
-            blendMode: blend_mode,
+            blend_mode: blend_mode,
             transform: transform,
             texture: texture,
             shader: shader
@@ -81,7 +79,7 @@ impl RenderStates {
     /// Create a new RenderStates initialized to default.
     ///
     /// # default
-    /// * blendMode is initialized to BlendAlpha
+    /// * blend_mode is initialized to BlendAlpha
     /// * transform is initialized to the identity matrix
     /// * texture is initialized to None
     /// * shader is initialized to None
@@ -89,13 +87,13 @@ impl RenderStates {
     /// Return a new default RenderStates
     pub fn default() -> RenderStates {
         RenderStates {
-            sfRenderStates: ffi::sfRenderStates {
+                sf_render_states: ffi::sfRenderStates {
                 blendMode: BlendAlpha as i32,
                 transform: Transform::new_identity(),
                 texture: ptr::null_mut(),
                 shader: ptr::null_mut()
             },
-            blendMode: BlendAlpha,
+            blend_mode: BlendAlpha,
             transform: Transform::new_identity(),
             texture: None,
             shader: None
@@ -104,19 +102,19 @@ impl RenderStates {
 
     #[doc(hidden)]
     pub fn unwrap(&mut self) -> *mut ffi::sfRenderStates {
-        self.sfRenderStates.blendMode = self.blendMode as i32;
-        self.sfRenderStates.transform = self.transform;
-        self.sfRenderStates.texture = if !self.texture.is_none() {
+        self.sf_render_states.blendMode = self.blend_mode as i32;
+        self.sf_render_states.transform = self.transform;
+        self.sf_render_states.texture = if !self.texture.is_none() {
             self.texture.as_ref().unwrap().borrow().unwrap()
         } else {
             ptr::null_mut()
         };
-        self.sfRenderStates.shader = if !self.shader.is_none() {
+        self.sf_render_states.shader = if !self.shader.is_none() {
             self.shader.as_ref().unwrap().borrow().unwrap()
         } else {
             ptr::null_mut()
         };
 
-        &mut self.sfRenderStates as *mut ffi::sfRenderStates
+        &mut self.sf_render_states as *mut ffi::sfRenderStates
     }
 }

--- a/src/graphics/render_target.rs
+++ b/src/graphics/render_target.rs
@@ -24,8 +24,6 @@
 
 //Authored on 2014-08-30 by Brandon Sanderson
 
-#![allow(non_snake_case)]
-
 use graphics::{Color, View, RenderStates, CircleShape, RectangleShape, Text, Sprite, VertexArray,
                IntRect, rc, Vertex, PrimitiveType, ConvexShape, Shape};
 use traits::Drawable;
@@ -201,19 +199,19 @@ pub trait RenderTarget {
     /// you know which states have really changed, and need to be
     /// saved and restored). Take a look at the resetGLStates
     /// function if you do so.
-    fn push_GL_states(&mut self);
+    fn push_gl_states(&mut self);
 
     /// Restore the previously saved OpenGL render states and matrices
-    fn pop_GL_states(&mut self);
+    fn pop_gl_states(&mut self);
 
     /// Reset the internal OpenGL states so that the target is ready for drawing
     ///
     /// This function can be used when you mix SFML drawing
     /// and direct OpenGL rendering, if you choose not to use
-    /// push_GL_states/pop_GL_states. It makes sure that all OpenGL
+    /// push_gl_states/pop_gl_states. It makes sure that all OpenGL
     /// states needed by SFML are set, so that subsequent draw()
     /// calls will work as expected.
-    fn reset_GL_states(&mut self);
+    fn reset_gl_states(&mut self);
 
 
     /// Draw Text

--- a/src/graphics/render_texture.rs
+++ b/src/graphics/render_texture.rs
@@ -22,8 +22,6 @@
 * 3. This notice may not be removed or altered from any source distribution.
 */
 
-#![allow(non_snake_case)]
-
 //! Target for off-screen 2D rendering into a texture
 
 use libc::c_uint;
@@ -669,14 +667,14 @@ impl RenderTarget for RenderTexture {
     /// you know which states have really changed, and need to be
     /// saved and restored). Take a look at the resetGLStates
     /// function if you do so.
-    fn push_GL_states(&mut self) -> () {
+    fn push_gl_states(&mut self) -> () {
         unsafe {
             ffi::sfRenderTexture_pushGLStates(self.render_texture)
         }
     }
 
     /// Restore the previously saved OpenGL render states and matrices
-    fn pop_GL_states(&mut self) -> () {
+    fn pop_gl_states(&mut self) -> () {
         unsafe {
             ffi::sfRenderTexture_popGLStates(self.render_texture)
         }
@@ -689,7 +687,7 @@ impl RenderTarget for RenderTexture {
     /// pushGLStates/popGLStates. It makes sure that all OpenGL
     /// states needed by SFML are set, so that subsequent sfRenderWindow_draw*()
     /// calls will work as expected.
-    fn reset_GL_states(&mut self) -> () {
+    fn reset_gl_states(&mut self) -> () {
         unsafe {
             ffi::sfRenderTexture_resetGLStates(self.render_texture)
         }

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -557,14 +557,14 @@ impl RenderTarget for RenderWindow{
     /// you know which states have really changed, and need to be
     /// saved and restored). Take a look at the resetGLStates
     /// function if you do so.
-    fn push_GL_states(&mut self) -> () {
+    fn push_gl_states(&mut self) -> () {
         unsafe {
             ffi::sfRenderWindow_pushGLStates(self.render_window)
         }
     }
 
     /// Restore the previously saved OpenGL render states and matrices
-    fn pop_GL_states(&mut self) -> () {
+    fn pop_gl_states(&mut self) -> () {
         unsafe {
             ffi::sfRenderWindow_popGLStates(self.render_window)
         }
@@ -574,10 +574,10 @@ impl RenderTarget for RenderWindow{
     ///
     /// This function can be used when you mix SFML drawing
     /// and direct OpenGL rendering, if you choose not to use
-    /// push_GL_states/pop_GL_states. It makes sure that all OpenGL
+    /// push_gl_states/pop_gl_states. It makes sure that all OpenGL
     /// states needed by SFML are set, so that subsequent draw()
     /// calls will work as expected.
-    fn reset_GL_states(&mut self) -> () {
+    fn reset_gl_states(&mut self) -> () {
         unsafe {
             ffi::sfRenderWindow_resetGLStates(self.render_window)
         }

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -22,7 +22,7 @@
 * 3. This notice may not be removed or altered from any source distribution.
 */
 
-#![allow(non_snake_case, missing_copy_implementations)]
+#![allow(missing_copy_implementations)]
 
 //! Window that can serve as a target for 2D drawing.
 //!
@@ -733,12 +733,12 @@ impl RenderTarget for RenderWindow{
     /// * point - Point to convert
     fn map_coords_to_pixel_current_view(&self,
                                             point: &Vector2f) -> Vector2i {
-        let currView =
+        let curr_view =
             unsafe { ffi::sfRenderWindow_getView(self.render_window) };
         unsafe {
             ffi::sfRenderWindow_mapCoordsToPixel(self.render_window,
                                                  *point,
-                                                 currView)
+                                                 curr_view)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@
 //!         }
 //!
 //!         // Clear the window
-//!         window.clear(&Color::new_RGB(0, 200, 200));
+//!         window.clear(&Color::new_rgb(0, 200, 200));
 //!         // Draw the shape
 //!         window.draw(&circle);
 //!         // Display things on screen


### PR DESCRIPTION
Changes public methods of Color and RenderTarget, which used UPPERCASE for acronyms.

I think this is appropriate if we want to be compliant with Rust naming conventions, but I want to know what @jeremyletang thinks before renaming them.