### PR TITLE
Cleaned up manual matching on SfBool.

### DIFF
--- a/src/audio/music.rs
+++ b/src/audio/music.rs
@@ -36,7 +36,7 @@ use system::Time;
 use system::vector3::Vector3f;
 use traits::Wrappable;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::audio::music as ffi;
 
 /// Play Music
@@ -107,22 +107,14 @@ impl Music {
     /// # Arguments
     /// * loop - SFTRUE to play in loop, SFFALSE to play once
     pub fn set_loop(&mut self, lloop: bool) -> () {
-        unsafe {
-            match lloop {
-                true    => ffi::sfMusic_setLoop(self.music, SFTRUE),
-                false   => ffi::sfMusic_setLoop(self.music, SFFALSE)
-            }
-        }
+        unsafe { ffi::sfMusic_setLoop(self.music, SfBool::from_bool(lloop)) }
     }
 
     /// Tell whether or not a music is in loop mode
     ///
     /// Return true if the music is looping, false otherwise
     pub fn get_loop(&self) -> bool {
-        match unsafe { ffi::sfMusic_getLoop(self.music) } {
-            SFFALSE => false,
-            SFTRUE => true
-        }
+        unsafe { ffi::sfMusic_getLoop(self.music) }.to_bool()
     }
 
     /// Get the total duration of a music
@@ -289,10 +281,7 @@ impl SoundSource for Music {
     /// * relative - true to set the position relative, false to set it absolute
     fn set_relative_to_listener(&mut self, relative: bool) -> () {
         unsafe {
-            match relative {
-                true    => ffi::sfMusic_setRelativeToListener(self.music, SFTRUE),
-                false   => ffi::sfMusic_setRelativeToListener(self.music, SFFALSE)
-            }
+            ffi::sfMusic_setRelativeToListener(self.music, SfBool::from_bool(relative))
         }
     }
 
@@ -363,9 +352,8 @@ impl SoundSource for Music {
     ///
     /// Return true if the position is relative, false if it's absolute
     fn is_relative_to_listener(&self) -> bool {
-        match unsafe { ffi::sfMusic_isRelativeToListener(self.music) } {
-            SFFALSE => false,
-            SFTRUE  => true
+        unsafe {
+            ffi::sfMusic_isRelativeToListener(self.music).to_bool()
         }
     }
 
@@ -375,7 +363,7 @@ impl SoundSource for Music {
     fn get_min_distance(&self) -> f32 {
         unsafe {
            ffi::sfMusic_getMinDistance(self.music) as f32
-       }
+        }
     }
 
     /// Get the attenuation factor of a music

--- a/src/audio/sound/mod.rs
+++ b/src/audio/sound/mod.rs
@@ -34,7 +34,7 @@ use system::Time;
 use system::vector3::Vector3f;
 use traits::Wrappable;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::audio::sound as ffi;
 
 pub mod rc;
@@ -104,24 +104,14 @@ impl<'s> Sound<'s> {
     ///
     /// Return true if the sound is looping, false otherwise
     pub fn set_loop(&mut self, lloop: bool) -> () {
-        unsafe {
-            if lloop == true {
-                ffi::sfSound_setLoop(self.sound, SFTRUE)
-            }
-            else {
-                ffi::sfSound_setLoop(self.sound, SFFALSE)
-            }
-        }
+        unsafe { ffi::sfSound_setLoop(self.sound, SfBool::from_bool(lloop)) }
     }
 
     /// Tell whether or not a sound is in loop mode
     ///
     /// Return true if the sound is looping, false otherwise
     pub fn get_loop(&self) -> bool {
-        match unsafe {ffi::sfSound_getLoop(self.sound)} {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe { ffi::sfSound_getLoop(self.sound) }.to_bool()
     }
 
     /// Start or resume playing a sound
@@ -275,11 +265,7 @@ impl<'s> SoundSource for Sound<'s> {
     /// * relative - true to set the position relative, false to set it absolute
     fn set_relative_to_listener(&mut self, relative: bool) -> () {
         unsafe {
-            if relative == true {
-                ffi::sfSound_setRelativeToListener(self.sound, SFTRUE);
-            } else {
-                ffi::sfSound_setRelativeToListener(self.sound, SFFALSE);
-            }
+            ffi::sfSound_setRelativeToListener(self.sound, SfBool::from_bool(relative))
         }
     }
 
@@ -346,9 +332,8 @@ impl<'s> SoundSource for Sound<'s> {
     ///
     /// Return true if the position is relative, false if it's absolute
     fn is_relative_to_listener(&self) -> bool {
-        match unsafe {ffi::sfSound_isRelativeToListener(self.sound)} {
-            SFFALSE => false,
-            SFTRUE  => true
+        unsafe {
+            ffi::sfSound_isRelativeToListener(self.sound).to_bool()
         }
     }
 

--- a/src/audio/sound/rc.rs
+++ b/src/audio/sound/rc.rs
@@ -36,7 +36,7 @@ use system::Time;
 use system::vector3::Vector3f;
 use traits::Wrappable;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::audio::sound as ffi;
 
 /// Play sounds.
@@ -108,12 +108,7 @@ impl Sound {
     /// Return true if the sound is looping, false otherwise
     pub fn set_loop(&mut self, lloop: bool) -> () {
         unsafe {
-            if lloop == true {
-                ffi::sfSound_setLoop(self.sound, SFTRUE)
-            }
-            else {
-                ffi::sfSound_setLoop(self.sound, SFFALSE)
-            }
+            ffi::sfSound_setLoop(self.sound, SfBool::from_bool(lloop))
         }
     }
 
@@ -121,10 +116,7 @@ impl Sound {
     ///
     /// Return true if the sound is looping, false otherwise
     pub fn get_loop(&self) -> bool {
-        match unsafe {ffi::sfSound_getLoop(self.sound)} {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe {ffi::sfSound_getLoop(self.sound)}.to_bool()
     }
 
     /// Start or resume playing a sound
@@ -278,11 +270,7 @@ impl SoundSource for Sound {
     /// * relative - true to set the position relative, false to set it absolute
     fn set_relative_to_listener(&mut self, relative: bool) -> () {
         unsafe {
-            if relative == true {
-                ffi::sfSound_setRelativeToListener(self.sound, SFTRUE);
-            } else {
-                ffi::sfSound_setRelativeToListener(self.sound, SFFALSE);
-            }
+            ffi::sfSound_setRelativeToListener(self.sound, SfBool::from_bool(relative))
         }
     }
 
@@ -349,10 +337,7 @@ impl SoundSource for Sound {
     ///
     /// Return true if the position is relative, false if it's absolute
     fn is_relative_to_listener(&self) -> bool {
-        match unsafe {ffi::sfSound_isRelativeToListener(self.sound)} {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe {ffi::sfSound_isRelativeToListener(self.sound)}.to_bool()
     }
 
     /// Get the minimum distance of a sound

--- a/src/audio/sound_buffer.rs
+++ b/src/audio/sound_buffer.rs
@@ -31,7 +31,6 @@ use std::ffi::CString;
 use traits::Wrappable;
 use system::Time;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
 use ffi::audio::sound_buffer as ffi;
 
 /// Storage of audio sample
@@ -95,10 +94,7 @@ impl SoundBuffer {
     /// Return true if saving succeeded, false if it faileds
     pub fn save_to_file(&self, filename: &str) -> bool {
         let c_str = CString::new(filename.as_bytes()).unwrap().as_ptr();
-        match unsafe { ffi::sfSoundBuffer_saveToFile(self.sound_buffer, c_str) } {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe { ffi::sfSoundBuffer_saveToFile(self.sound_buffer, c_str) }.to_bool()
     }
 
     /// Get the number of samples stored in a sound buffer

--- a/src/audio/sound_buffer_recorder.rs
+++ b/src/audio/sound_buffer_recorder.rs
@@ -32,7 +32,6 @@ use libc::c_uint;
 use traits::Wrappable;
 use audio::sound_buffer::SoundBuffer;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
 use ffi::audio::sound_buffer_recorder as ffi;
 
 /// Store captured audio data in sound Buffer
@@ -120,10 +119,7 @@ impl SoundBufferRecorder {
     ///
     /// Return true if audio capture is supported, false otherwise
     pub fn is_available() -> bool {
-        match unsafe { ffi::sfSoundRecorder_isAvailable() } {
-            SFFALSE => false,
-            SFTRUE  => true,
-        }
+        unsafe { ffi::sfSoundRecorder_isAvailable() }.to_bool()
     }
 
 }

--- a/src/ffi/sfml_types.rs
+++ b/src/ffi/sfml_types.rs
@@ -22,8 +22,6 @@
 * 3. This notice may not be removed or altered from any source distribution.
 */
 
-pub use self::SfBool::{SFFALSE, SFTRUE};
-
 #[repr(C)]
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum SfBool {
@@ -32,17 +30,19 @@ pub enum SfBool {
 }
 
 impl SfBool {
+    #[inline(always)]
     pub fn to_bool(&self) -> bool {
-        match self {
-            &SFFALSE => false,
-            &SFTRUE => true
+        match *self {
+            SfBool::SFFALSE => false,
+            SfBool::SFTRUE => true
         }
     }
 
+    #[inline(always)]
     pub fn from_bool(b: bool) -> SfBool {
         match b {
-            true => SFTRUE,
-            false => SFFALSE
+            true => SfBool::SFTRUE,
+            false => SfBool::SFFALSE
         }
     }
 }

--- a/src/graphics/circle_shape/mod.rs
+++ b/src/graphics/circle_shape/mod.rs
@@ -32,7 +32,7 @@ use graphics::{Drawable, Transformable, Shape, IntRect, FloatRect, Color, Textur
                RenderTarget, Transform, RenderStates};
 use system::vector2::Vector2f;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::circle_shape as ffi;
 
 // pub mod rc;
@@ -71,7 +71,7 @@ impl<'s> CircleShape<'s> {
             None
         } else {
             unsafe {
-                ffi::sfCircleShape_setTexture(circle, texture.unwrap(), SFTRUE);
+                ffi::sfCircleShape_setTexture(circle, texture.unwrap(), SfBool::SFTRUE);
             }
             Some(CircleShape {
                     circle_shape: circle,
@@ -418,14 +418,7 @@ impl<'s> Shape<'s> for CircleShape<'s> {
                        reset_rect: bool) -> () {
         self.texture = Some(texture);
         unsafe {
-            match reset_rect {
-                true        => ffi::sfCircleShape_setTexture(self.circle_shape,
-                                                             texture.unwrap(),
-                                                             SFTRUE),
-                false       => ffi::sfCircleShape_setTexture(self.circle_shape,
-                                                             texture.unwrap(),
-                                                             SFFALSE),
-            }
+            ffi::sfCircleShape_setTexture(self.circle_shape, texture.unwrap(), SfBool::from_bool(reset_rect))
         }
     }
 
@@ -437,7 +430,7 @@ impl<'s> Shape<'s> for CircleShape<'s> {
         unsafe {
             ffi::sfCircleShape_setTexture(self.circle_shape,
                                           ptr::null_mut(),
-                                          SFTRUE)
+                                          SfBool::SFTRUE)
         }
     }
 

--- a/src/graphics/circle_shape/rc.rs
+++ b/src/graphics/circle_shape/rc.rs
@@ -34,7 +34,7 @@ use graphics::{IntRect, FloatRect, Color, Texture,
                RenderTarget, Transform, rc, RenderStates};
 use system::vector2::Vector2f;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::circle_shape as ffi;
 
 /// Specialized shape representing a circle.
@@ -73,7 +73,7 @@ impl CircleShape {
             unsafe {
                 ffi::sfCircleShape_setTexture(circle,
                                               (*texture).borrow().unwrap(),
-                                              SFTRUE);
+                                              SfBool::SFTRUE);
             }
             Some(CircleShape {
                     circle_shape: circle,
@@ -182,16 +182,7 @@ impl CircleShape {
                        texture: Rc<RefCell<Texture>>,
                        reset_rect: bool) -> () {
         unsafe {
-            match reset_rect {
-                true        =>
-                    ffi::sfCircleShape_setTexture(self.circle_shape,
-                                                  (*texture).borrow().unwrap(),
-                                                  SFTRUE),
-                false       =>
-                    ffi::sfCircleShape_setTexture(self.circle_shape,
-                                                  (*texture).borrow().unwrap(),
-                                                  SFFALSE),
-            };
+            ffi::sfCircleShape_setTexture(self.circle_shape, (*texture).borrow().unwrap(), SfBool::from_bool(reset_rect))
         }
         self.texture = Some(texture);
     }
@@ -204,7 +195,7 @@ impl CircleShape {
         unsafe {
             ffi::sfCircleShape_setTexture(self.circle_shape,
                                           ptr::null_mut(),
-                                          SFTRUE)
+                                          SfBool::SFTRUE)
         }
     }
 

--- a/src/graphics/convex_shape/mod.rs
+++ b/src/graphics/convex_shape/mod.rs
@@ -38,7 +38,7 @@ use traits::Wrappable;
 use graphics::{Shape, Drawable, Transformable, Color, Texture, RenderTarget, FloatRect, IntRect, Transform, RenderStates};
 use system::vector2::Vector2f;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::convex_shape as ffi;
 
 // pub mod rc;
@@ -96,7 +96,7 @@ impl<'s> ConvexShape<'s> {
             None
         } else {
             unsafe {
-                ffi::sfConvexShape_setTexture(shape, texture.unwrap(), SFTRUE);
+                ffi::sfConvexShape_setTexture(shape, texture.unwrap(), SfBool::SFTRUE);
                 ffi::sfConvexShape_setPointCount(shape, points_count as c_uint)
             }
             Some(ConvexShape {
@@ -419,14 +419,7 @@ impl<'s> Shape<'s> for ConvexShape<'s> {
                        reset_rect: bool) -> () {
         self.texture = Some(texture);
         unsafe {
-            match reset_rect {
-                true        => ffi::sfConvexShape_setTexture(self.convex_shape,
-                                                             texture.unwrap(),
-                                                             SFTRUE),
-                false       => ffi::sfConvexShape_setTexture(self.convex_shape,
-                                                             texture.unwrap(),
-                                                             SFFALSE)
-            }
+            ffi::sfConvexShape_setTexture(self.convex_shape, texture.unwrap(), SfBool::from_bool(reset_rect))
         }
     }
 
@@ -438,7 +431,7 @@ impl<'s> Shape<'s> for ConvexShape<'s> {
         unsafe {
             ffi::sfConvexShape_setTexture(self.convex_shape,
                                           ptr::null_mut(),
-                                          SFTRUE)
+                                          SfBool::SFTRUE)
         }
     }
 

--- a/src/graphics/convex_shape/rc.rs
+++ b/src/graphics/convex_shape/rc.rs
@@ -40,7 +40,7 @@ use traits::{Wrappable, Drawable};
 use graphics::{Color, Texture, RenderTarget, FloatRect, IntRect, Transform, rc, RenderStates};
 use system::vector2::Vector2f;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::convex_shape as ffi;
 
 /// Specialized shape representing a convex polygon
@@ -97,7 +97,7 @@ impl ConvexShape {
             None
         } else {
             unsafe {
-                ffi::sfConvexShape_setTexture(shape, (*texture).borrow().unwrap(), SFTRUE);
+                ffi::sfConvexShape_setTexture(shape, (*texture).borrow().unwrap(), SfBool::SFTRUE);
                 ffi::sfConvexShape_setPointCount(shape, points_count as c_uint)
             }
             Some(ConvexShape {
@@ -384,14 +384,7 @@ impl ConvexShape {
     /// * reset_rect - Should the texture rect be reset to the size of the new texture?
     pub fn set_texture(&mut self, texture: Rc<RefCell<Texture>>, reset_rect: bool) -> () {
         unsafe {
-            match reset_rect {
-                true        => ffi::sfConvexShape_setTexture(self.convex_shape,
-                                                             (*texture).borrow().unwrap(), 
-                                                             SFTRUE),
-                false       => ffi::sfConvexShape_setTexture(self.convex_shape,
-                                                             (*texture).borrow().unwrap(), 
-                                                             SFFALSE)
-            };
+            ffi::sfConvexShape_setTexture(self.convex_shape, (*texture).borrow().unwrap(), SfBool::from_bool(reset_rect))
         }
         self.texture = Some(texture);
     }
@@ -404,7 +397,7 @@ impl ConvexShape {
         unsafe {
             ffi::sfConvexShape_setTexture(self.convex_shape,
                                           ptr::null_mut(),
-                                          SFTRUE)
+                                          SfBool::SFTRUE)
         }
     }
 

--- a/src/graphics/custom_shape/mod.rs
+++ b/src/graphics/custom_shape/mod.rs
@@ -32,7 +32,7 @@ use graphics::{Drawable, Transformable, RenderTarget, RenderStates, Texture, Col
                Transform, IntRect, FloatRect};
 use system::vector2::Vector2f;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::shape as ffi;
 
 // pub mod rc;
@@ -104,7 +104,7 @@ impl<'s> CustomShape<'s> {
             None
         } else {
             unsafe {
-                ffi::sfShape_setTexture(sp, texture.unwrap(), SFTRUE);
+                ffi::sfShape_setTexture(sp, texture.unwrap(), SfBool::SFTRUE);
             }
             Some(CustomShape {
                     shape:     sp,
@@ -131,14 +131,7 @@ impl<'s> CustomShape<'s> {
                        reset_rect: bool) -> () {
         self.texture = Some(texture);
         unsafe {
-            match reset_rect {
-                true        => ffi::sfShape_setTexture(self.shape,
-                                                       texture.unwrap(),
-                                                       SFTRUE),
-                false       => ffi::sfShape_setTexture(self.shape,
-                                                       texture.unwrap(),
-                                                       SFFALSE),
-            }
+            ffi::sfShape_setTexture(self.shape, texture.unwrap(), SfBool::from_bool(reset_rect))
         }
     }
 
@@ -148,7 +141,7 @@ impl<'s> CustomShape<'s> {
     pub fn disable_texture(&mut self) -> () {
         self.texture = None;
         unsafe {
-            ffi::sfShape_setTexture(self.shape, ptr::null_mut(), SFTRUE)
+            ffi::sfShape_setTexture(self.shape, ptr::null_mut(), SfBool::SFTRUE)
         }
     }
 

--- a/src/graphics/custom_shape/rc.rs
+++ b/src/graphics/custom_shape/rc.rs
@@ -34,7 +34,7 @@ use graphics::{RenderTarget, rc, Texture, Color,
                Transform, IntRect, FloatRect, RenderStates};
 use system::vector2::Vector2f;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::shape as ffi;
 
 #[doc(hidden)]
@@ -106,7 +106,7 @@ impl Shape {
             unsafe {
                 ffi::sfShape_setTexture(sp,
                                         (*texture).borrow().unwrap(),
-                                        SFTRUE);
+                                        SfBool::SFTRUE);
             }
             Some(Shape {
                     shape: sp,
@@ -363,16 +363,9 @@ impl Shape {
                        texture: Rc<RefCell<Texture>>,
                        reset_rect: bool) -> () {
         unsafe {
-            match reset_rect {
-                true  =>
-                    ffi::sfShape_setTexture(self.shape,
-                                            (*texture).borrow().unwrap(),
-                                            SFTRUE),
-                false =>
-                    ffi::sfShape_setTexture(self.shape,
-                                            (*texture).borrow().unwrap(),
-                                            SFFALSE),
-            };
+            ffi::sfShape_setTexture(self.shape,
+                                    (*texture).borrow().unwrap(),
+                                    SfBool::from_bool(reset_rect))
         }
         self.texture = Some(texture);
     }
@@ -383,7 +376,7 @@ impl Shape {
     pub fn disable_texture(&mut self) -> () {
         self.texture = None;
         unsafe {
-            ffi::sfShape_setTexture(self.shape, ptr::null_mut(), SFTRUE)
+            ffi::sfShape_setTexture(self.shape, ptr::null_mut(), SfBool::SFTRUE)
         }
     }
 

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -31,7 +31,7 @@ use std::ffi::CString;
 use traits::Wrappable;
 use graphics::{Texture, Glyph};
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::font as ffi;
 
 /// Class for loading and manipulating character fonts
@@ -162,16 +162,7 @@ impl Font {
                      character_size: u32,
                      bold: bool) -> Glyph {
         unsafe {
-            match bold {
-                true        => ffi::sfFont_getGlyph(self.font,
-                                                    codepoint,
-                                                    character_size as c_uint,
-                                                    SFFALSE),
-                false       => ffi::sfFont_getGlyph(self.font,
-                                                    codepoint,
-                                                    character_size as c_uint,
-                                                    SFTRUE)
-            }
+            ffi::sfFont_getGlyph(self.font, codepoint, character_size as c_uint, SfBool::from_bool(bold))
         }
     }
 }

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -31,7 +31,7 @@ use traits::Wrappable;
 use system::vector2::Vector2u;
 use graphics::{Color, IntRect};
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::image as ffi;
 
 /// Loading, manipulating and saving images.
@@ -183,10 +183,7 @@ impl Image {
     /// Return true if saving was successful
     pub fn save_to_file(&self, filename: &str) -> bool {
         let c_str = CString::new(filename.as_bytes()).unwrap().as_ptr();
-        match unsafe { ffi::sfImage_saveToFile(self.image, c_str) } {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe { ffi::sfImage_saveToFile(self.image, c_str) }.to_bool()
     }
 
     /// Return the size of an image
@@ -285,20 +282,12 @@ impl Image {
                       source_rect: &IntRect,
                       apply_alpha: bool) -> () {
         unsafe {
-            match apply_alpha {
-                true        =>  ffi::sfImage_copyImage(self.image,
-                                                       source.unwrap(),
-                                                       dest_x as c_uint,
-                                                       dest_y as c_uint,
-                                                       *source_rect,
-                                                       SFFALSE),
-                false       =>  ffi::sfImage_copyImage(self.image,
-                                                       source.unwrap(),
-                                                       dest_x as c_uint,
-                                                       dest_y as c_uint,
-                                                       *source_rect,
-                                                       SFTRUE)
-            }
+            ffi::sfImage_copyImage(self.image,
+                                   source.unwrap(),
+                                   dest_x as c_uint,
+                                   dest_y as c_uint,
+                                   *source_rect,
+                                   SfBool::from_bool(apply_alpha))
         }
     }
 }

--- a/src/graphics/rect.rs
+++ b/src/graphics/rect.rs
@@ -28,7 +28,6 @@
 
 use libc::c_int;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
 use ffi::graphics::rect as ffi;
 
 /// Utility classes for manipulating rectangles of i32.
@@ -81,10 +80,7 @@ impl IntRect {
     ///
     /// Return true if the point is inside
     pub fn contains(self, x: i32, y: i32) -> bool {
-        match unsafe { ffi::sfIntRect_contains(&self, x as c_int, y as c_int) } {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe { ffi::sfIntRect_contains(&self, x as c_int, y as c_int) }.to_bool()
     }
 
     /// Check intersection between two rectangles
@@ -98,10 +94,7 @@ impl IntRect {
     pub fn intersects(rect1: &IntRect,
                       rect2: &IntRect,
                       intersections: &IntRect) -> bool {
-        match unsafe { ffi::sfIntRect_intersects(rect1, rect2, intersections) } {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe { ffi::sfIntRect_intersects(rect1, rect2, intersections) }.to_bool()
     }
 }
 
@@ -128,10 +121,7 @@ impl FloatRect {
     ///
     /// Return true if the point is inside
     pub fn contains(self, x: f32, y: f32) -> bool {
-        match unsafe { ffi::sfFloatRect_contains(&self, x, y) } {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe { ffi::sfFloatRect_contains(&self, x, y) }.to_bool()
     }
 
     /// Check intersection between two rectangles
@@ -145,10 +135,6 @@ impl FloatRect {
     pub fn intersects(rect1: &FloatRect,
         rect2: &FloatRect,
         intersections: &FloatRect) -> bool {
-
-        match unsafe { ffi::sfFloatRect_intersects(rect1, rect2, intersections) } {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe { ffi::sfFloatRect_intersects(rect1, rect2, intersections) }.to_bool()
     }
 }

--- a/src/graphics/rectangle_shape/mod.rs
+++ b/src/graphics/rectangle_shape/mod.rs
@@ -32,7 +32,7 @@ use system::vector2::Vector2f;
 use graphics::{Drawable, Shape, Transformable, FloatRect, IntRect, Color, Texture,
                RenderTarget, Transform, RenderStates};
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::rectangle_shape as ffi;
 
 // pub mod rc;
@@ -70,7 +70,7 @@ impl<'s> RectangleShape<'s> {
             unsafe {
                 ffi::sfRectangleShape_setTexture(rectangle,
                                                  texture.unwrap(),
-                                                 SFTRUE);
+                                                 SfBool::SFTRUE);
             }
             Some(RectangleShape {
                     rectangle_shape: rectangle,
@@ -414,16 +414,9 @@ impl<'s> Shape<'s> for RectangleShape<'s> {
     fn set_texture(&mut self, texture: &'s Texture, reset_rect: bool) -> () {
         self.texture = Some(texture);
         unsafe {
-            match reset_rect {
-                false =>
-                    ffi::sfRectangleShape_setTexture(self.rectangle_shape,
-                                                     texture.unwrap(),
-                                                     SFFALSE),
-                true  =>
-                    ffi::sfRectangleShape_setTexture(self.rectangle_shape,
-                                                     texture.unwrap(),
-                                                     SFTRUE)
-            }
+            ffi::sfRectangleShape_setTexture(self.rectangle_shape,
+                                             texture.unwrap(),
+                                             SfBool::from_bool(reset_rect))
         }
     }
 
@@ -435,7 +428,7 @@ impl<'s> Shape<'s> for RectangleShape<'s> {
         unsafe {
             ffi::sfRectangleShape_setTexture(self.rectangle_shape,
                                              ptr::null_mut(),
-                                             SFTRUE)
+                                             SfBool::SFTRUE)
         }
     }
 

--- a/src/graphics/rectangle_shape/rc.rs
+++ b/src/graphics/rectangle_shape/rc.rs
@@ -34,7 +34,7 @@ use system::vector2::Vector2f;
 use graphics::{FloatRect, IntRect, Color, Texture,
                RenderTarget, Transform, rc, RenderStates};
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::rectangle_shape as ffi;
 
 /// Specialized shape representing a rectangle
@@ -71,7 +71,7 @@ impl RectangleShape {
             unsafe {
                 ffi::sfRectangleShape_setTexture(rectangle,
                                                  (*texture).borrow().unwrap(),
-                                                 SFTRUE);
+                                                 SfBool::SFTRUE);
             }
             Some(RectangleShape {
                     rectangle_shape: rectangle,
@@ -398,16 +398,9 @@ impl RectangleShape {
                        texture: Rc<RefCell<Texture>>,
                        reset_rect: bool) -> () {
         unsafe {
-            match reset_rect {
-                false       =>
-                    ffi::sfRectangleShape_setTexture(self.rectangle_shape,
-                                                     (*texture).borrow().unwrap(),
-                                                     SFFALSE),
-                true        =>
-                    ffi::sfRectangleShape_setTexture(self.rectangle_shape,
-                                                     (*texture).borrow().unwrap(),
-                                                     SFTRUE)
-            }
+            ffi::sfRectangleShape_setTexture(self.rectangle_shape,
+                                             (*texture).borrow().unwrap(),
+                                             SfBool::from_bool(reset_rect))
         }
         self.texture = Some(texture);
     }
@@ -420,7 +413,7 @@ impl RectangleShape {
         unsafe {
             ffi::sfRectangleShape_setTexture(self.rectangle_shape,
                                              ptr::null_mut(),
-                                             SFTRUE)
+                                             SfBool::SFTRUE)
         }
     }
 

--- a/src/graphics/render_texture.rs
+++ b/src/graphics/render_texture.rs
@@ -32,7 +32,7 @@ use graphics::{Drawable, View, Color, IntRect, Texture, CircleShape, RectangleSh
                RenderStates, Sprite, ConvexShape, VertexArray,
                RenderTarget, Vertex, PrimitiveType, CustomShape};
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::render_texture as ffi;
 
 /// Target for off-screen 2D rendering into a texture
@@ -52,14 +52,8 @@ impl RenderTexture {
     pub fn new(width: u32,
                height: u32,
                depth_buffer: bool) -> Option<RenderTexture> {
-
-        let tex = match depth_buffer {
-            false       => unsafe { ffi::sfRenderTexture_create(width as c_uint,
-                                                                height as c_uint, 
-                                                                SFFALSE) },
-            true        => unsafe { ffi::sfRenderTexture_create(width as c_uint, 
-                                                                height as c_uint, 
-                                                                SFTRUE) }
+        let tex = unsafe {
+            ffi::sfRenderTexture_create(width as c_uint, height as c_uint, SfBool::from_bool(depth_buffer))
         };
         if tex.is_null() {
             None
@@ -82,18 +76,9 @@ impl RenderTexture {
     /// # Arguments
     /// * active - true to activate, false to deactivate
     pub fn set_active(&mut self, active: bool) -> bool {
-        let ret = unsafe {
-            match active {
-                false => ffi::sfRenderTexture_setActive(self.render_texture,
-                                                        SFFALSE),
-                true  => ffi::sfRenderTexture_setActive(self.render_texture,
-                                                        SFTRUE)
-            }
-        };
-        match ret {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe {
+            ffi::sfRenderTexture_setActive(self.render_texture, SfBool::from_bool(active))
+        }.to_bool()
     }
 
     /// Get the target texture of a render texture
@@ -115,12 +100,7 @@ impl RenderTexture {
     /// * smooth - true to enable smoothing, false to disable it
     pub fn set_smooth(&mut self, smooth: bool) -> () {
         unsafe {
-            match smooth {
-                true        => ffi::sfRenderTexture_setSmooth(self.render_texture,
-                                                              SFTRUE),
-                false       => ffi::sfRenderTexture_setSmooth(self.render_texture,
-                                                              SFFALSE)
-            }
+            ffi::sfRenderTexture_setSmooth(self.render_texture, SfBool::from_bool(smooth))
         }
     }
 
@@ -128,10 +108,7 @@ impl RenderTexture {
     ///
     /// Return true if smoothing is enabled, false if it is disabled
     pub fn is_smooth(&self) -> bool {
-        match unsafe { ffi::sfRenderTexture_isSmooth(self.render_texture) } {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe { ffi::sfRenderTexture_isSmooth(self.render_texture) }.to_bool()
     }
 }
 

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -41,7 +41,7 @@ use graphics::{Drawable, Color, CircleShape, RectangleShape, Text, Sprite, Verte
                RenderStates, View, Image, IntRect, RenderTarget,
                Vertex, PrimitiveType, ConvexShape, CustomShape};
 
-use ffi::sfml_types::{SfBool, SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::render_window as ffi;
 
 /// Window that can serve as a target for 2D drawing.
@@ -194,13 +194,10 @@ impl RenderWindow {
     /// Return the event if an event was returned, or NoEvent if the event queue was empty
     pub fn poll_event(&mut self) -> event::Event {
         let mut event = event::raw::sfEvent { data: [032; 6] };
-        let have_event: bool =  unsafe {
-            match ffi::sfRenderWindow_pollEvent(self.render_window, &mut event) {
-                SFFALSE     => false,
-                SFTRUE      => true
-            }
-        };
-        if have_event == false {
+        let have_event = unsafe {
+            ffi::sfRenderWindow_pollEvent(self.render_window, &mut event)
+        }.to_bool();
+        if !have_event {
             event::NoEvent
         } else {
             event::raw::get_wrapped_event(&mut event)
@@ -220,13 +217,10 @@ impl RenderWindow {
     /// Return the event or NoEvent if an error has occured
     pub fn wait_event(&mut self) -> event::Event {
         let mut event = event::raw::sfEvent { data: [032; 6] };
-        let have_event: bool =  unsafe {
-            match ffi::sfRenderWindow_waitEvent(self.render_window, &mut event) {
-                SFFALSE     => false,
-                SFTRUE      => true
-            }
-        };
-        if have_event == false {
+        let have_event = unsafe {
+            ffi::sfRenderWindow_waitEvent(self.render_window, &mut event)
+        }.to_bool();
+        if !have_event {
             event::NoEvent
         } else {
             event::raw::get_wrapped_event(&mut event)
@@ -253,14 +247,7 @@ impl RenderWindow {
     /// true.
     ////
     pub fn is_open(&self) -> bool {
-        let tmp: SfBool;
-        unsafe {
-            tmp = ffi::sfRenderWindow_isOpen(self.render_window);
-        }
-        match tmp {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe { ffi::sfRenderWindow_isOpen(self.render_window) }.to_bool()
     }
 
     /// Display on screen what has been rendered to the window so far
@@ -325,12 +312,8 @@ impl RenderWindow {
     /// * visible - true to show the window, false to hide it
     ////
     pub fn set_visible(&mut self, visible: bool) -> () {
-        let tmp: SfBool = match visible {
-            true    => SFTRUE,
-            false   => SFFALSE
-        };
         unsafe {
-            ffi::sfRenderWindow_setVisible(self.render_window, tmp);
+            ffi::sfRenderWindow_setVisible(self.render_window, SfBool::from_bool(visible));
         }
     }
 
@@ -340,12 +323,8 @@ impl RenderWindow {
     /// * visible - true to  false to hide
     ////
     pub fn set_mouse_cursor_visible(&mut self, visible: bool) -> () {
-        let tmp: SfBool = match visible {
-            true    => SFTRUE,
-            false   => SFFALSE
-        };
         unsafe {
-            ffi::sfRenderWindow_setMouseCursorVisible(self.render_window, tmp);
+            ffi::sfRenderWindow_setMouseCursorVisible(self.render_window, SfBool::from_bool(visible));
         }
     }
 
@@ -360,13 +339,8 @@ impl RenderWindow {
     /// * enabled - true to enable v-sync, false to deactivate
     ////
     pub fn set_vertical_sync_enabled(&mut self, enabled: bool) -> () {
-        let tmp: SfBool =
-            match enabled {
-            true    => SFTRUE,
-            false   => SFFALSE
-        };
         unsafe {
-            ffi::sfRenderWindow_setVerticalSyncEnabled(self.render_window, tmp);
+            ffi::sfRenderWindow_setVerticalSyncEnabled(self.render_window, SfBool::from_bool(enabled));
         }
     }
 
@@ -382,12 +356,8 @@ impl RenderWindow {
     /// * enabled - true to enable, false to disable
     ////
     pub fn set_key_repeat_enabled(&mut self, enabled: bool) -> () {
-        let tmp: SfBool = match enabled {
-            true    => SFTRUE,
-            false   => SFFALSE
-        };
         unsafe {
-            ffi::sfRenderWindow_setKeyRepeatEnabled(self.render_window, tmp);
+            ffi::sfRenderWindow_setKeyRepeatEnabled(self.render_window, SfBool::from_bool(enabled));
         }
     }
 
@@ -405,17 +375,9 @@ impl RenderWindow {
     /// Return true if operation was successful, false otherwise
     ////
     pub fn set_active(&mut self, enabled: bool) -> bool {
-        let tmp: SfBool = match enabled {
-            true    => SFTRUE,
-            false   => SFFALSE
-        };
-        let res: SfBool = unsafe {
-            ffi::sfRenderWindow_setActive(self.render_window, tmp)
-        };
-        match res {
-            SFTRUE      => true,
-            SFFALSE     => false
-        }
+        unsafe {
+            ffi::sfRenderWindow_setActive(self.render_window, SfBool::from_bool(enabled))
+        }.to_bool()
     }
 
     /// Change the joystick threshold
@@ -901,9 +863,9 @@ impl Iterator for Events {
 
     fn next(&mut self) -> Option<event::Event> {
         let mut event = event::raw::sfEvent { data: [032; 6] };
-        match unsafe { ffi::sfRenderWindow_pollEvent(self.render_window, &mut event) } {
-            SFFALSE     => None,
-            SFTRUE      => Some(event::raw::get_wrapped_event(&mut event))
+        match unsafe { ffi::sfRenderWindow_pollEvent(self.render_window, &mut event) }.to_bool() {
+            false     => None,
+            true      => Some(event::raw::get_wrapped_event(&mut event))
         }
     }
 }

--- a/src/graphics/shader/mod.rs
+++ b/src/graphics/shader/mod.rs
@@ -37,7 +37,6 @@ use graphics::{Texture, Color};
 use system::vector2::Vector2f;
 use system::vector3::Vector3f;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
 use ffi::graphics::shader as ffi;
 
 // pub mod rc;
@@ -277,10 +276,7 @@ impl<'s> Shader<'s> {
     ///
     /// Return true if the system can use shaders, false otherwise
     pub fn is_available() -> bool {
-        match unsafe { ffi::sfShader_isAvailable() } {
-            SFFALSE   => false,
-            SFTRUE    => true
-        }
+        unsafe { ffi::sfShader_isAvailable() }.to_bool()
     }
 
     /// Change a 2-components vector parameter of a shader

--- a/src/graphics/shader/rc.rs
+++ b/src/graphics/shader/rc.rs
@@ -38,7 +38,6 @@ use graphics::{Texture, Color};
 use system::vector2::Vector2f;
 use system::vector3::Vector3f;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
 use ffi::graphics::shader as ffi;
 
 /// Shader class (vertex and fragment)
@@ -278,10 +277,7 @@ impl Shader {
     ///
     /// Return true if the system can use shaders, false otherwise
     pub fn is_available() -> bool {
-        match unsafe { ffi::sfShader_isAvailable() } {
-            SFFALSE   => false,
-            SFTRUE    => true
-        }
+        unsafe { ffi::sfShader_isAvailable() }.to_bool()
     }
 
     /// Change a 2-components vector parameter of a shader

--- a/src/graphics/sprite/mod.rs
+++ b/src/graphics/sprite/mod.rs
@@ -35,7 +35,7 @@ use graphics::{Drawable, Transformable, FloatRect, IntRect, Color, Texture,
                RenderTarget, Transform, RenderStates};
 use system::vector2::Vector2f;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::sprite as ffi;
 
 // pub mod rc;
@@ -74,7 +74,7 @@ impl<'s> Sprite<'s> {
             None
         } else {
             unsafe {
-                ffi::sfSprite_setTexture(sp, texture.unwrap(), SFTRUE);
+                ffi::sfSprite_setTexture(sp, texture.unwrap(), SfBool::SFTRUE);
             }
             Some(Sprite {
                     sprite: sp,
@@ -117,14 +117,9 @@ impl<'s> Sprite<'s> {
     pub fn set_texture(&mut self, texture: &'s Texture, reset_rect: bool) {
         self.texture = Some(texture);
         unsafe {
-            match reset_rect {
-                true        => ffi::sfSprite_setTexture(self.sprite,
-                                                        texture.unwrap(),
-                                                        SFTRUE),
-                false       => ffi::sfSprite_setTexture(self.sprite,
-                                                        texture.unwrap(),
-                                                        SFFALSE)
-            }
+            ffi::sfSprite_setTexture(self.sprite,
+                                     texture.unwrap(),
+                                     SfBool::from_bool(reset_rect))
         }
     }
 
@@ -134,7 +129,7 @@ impl<'s> Sprite<'s> {
     pub fn disable_texture(&mut self) -> () {
         self.texture = None;
         unsafe {
-            ffi::sfSprite_setTexture(self.sprite, ptr::null_mut(), SFTRUE)
+            ffi::sfSprite_setTexture(self.sprite, ptr::null_mut(), SfBool::SFTRUE)
         }
     }
 

--- a/src/graphics/sprite/rc.rs
+++ b/src/graphics/sprite/rc.rs
@@ -37,7 +37,7 @@ use graphics::{FloatRect, IntRect, Color, Texture,
                RenderTarget, Transform, rc, RenderStates};
 use system::vector2::Vector2f;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::sprite as ffi;
 
 /// Drawable representation of a texture
@@ -76,7 +76,7 @@ impl Sprite {
             unsafe {
                 ffi::sfSprite_setTexture(sp,
                                          (*texture).borrow().unwrap(),
-                                         SFTRUE);
+                                         SfBool::SFTRUE);
             }
             Some(Sprite {
                     sprite: sp,
@@ -157,16 +157,9 @@ impl Sprite {
                        texture: Rc<RefCell<Texture>>,
                        reset_rect: bool) -> (){
         unsafe {
-            match reset_rect {
-                true  =>
-                    ffi::sfSprite_setTexture(self.sprite,
-                                             (*texture).borrow().unwrap(),
-                                             SFTRUE),
-                false =>
-                    ffi::sfSprite_setTexture(self.sprite,
-                                             (*texture).borrow().unwrap(),
-                                             SFFALSE)
-            }
+            ffi::sfSprite_setTexture(self.sprite,
+                                     (*texture).borrow().unwrap(),
+                                     SfBool::from_bool(reset_rect))
         }
         self.texture = Some(texture);
     }
@@ -177,7 +170,7 @@ impl Sprite {
     pub fn disable_texture(&mut self) -> () {
         self.texture = None;
         unsafe {
-            ffi::sfSprite_setTexture(self.sprite, ptr::null_mut(), SFTRUE)
+            ffi::sfSprite_setTexture(self.sprite, ptr::null_mut(), SfBool::SFTRUE)
         }
     }
 

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -35,7 +35,7 @@ use graphics::{RenderWindow, Image, IntRect};
 use system::vector2::Vector2u;
 use window::Window;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::graphics::texture as ffi;
 
 /// Image used for drawing
@@ -281,10 +281,7 @@ impl Texture {
     /// * smooth - true to enable smoothing, false to disable it
     pub fn set_smooth(&mut self, smooth: bool) -> () {
         unsafe {
-            match smooth {
-                true        => ffi::sfTexture_setSmooth(self.texture, SFTRUE),
-                false       => ffi::sfTexture_setSmooth(self.texture, SFFALSE)
-            }
+            ffi::sfTexture_setSmooth(self.texture, SfBool::from_bool(smooth))
         }
     }
 
@@ -292,10 +289,7 @@ impl Texture {
     ///
     /// Return true if smoothing is enabled, false if it is disabled
     pub fn is_smooth(&self) -> bool {
-        match unsafe { ffi::sfTexture_isSmooth(self.texture) } {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe { ffi::sfTexture_isSmooth(self.texture) }.to_bool()
     }
 
     /// Enable or disable repeating for a texture
@@ -318,10 +312,7 @@ impl Texture {
     /// * repeated  - true to repeat the texture, false to disable repeating
     pub fn set_repeated(&mut self, repeated: bool) -> () {
         unsafe {
-            match repeated {
-                true        => ffi::sfTexture_setRepeated(self.texture, SFTRUE),
-                false       => ffi::sfTexture_setRepeated(self.texture, SFFALSE)
-            }
+            ffi::sfTexture_setRepeated(self.texture, SfBool::from_bool(repeated))
         }
     }
 
@@ -329,10 +320,7 @@ impl Texture {
     ///
     /// Return frue if repeat mode is enabled, false if it is disabled
     pub fn is_repeated(&self) -> bool {
-        match unsafe { ffi::sfTexture_isRepeated(self.texture) } {
-            SFFALSE   => false,
-            SFTRUE    => true
-        }
+        unsafe { ffi::sfTexture_isRepeated(self.texture) }.to_bool()
     }
 
     /// Bind a texture for rendering

--- a/src/network/ftp.rs
+++ b/src/network/ftp.rs
@@ -33,7 +33,6 @@ use traits::Wrappable;
 use network::IpAddress;
 use system::Time;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
 use ffi::network::ftp as ffi;
 
 /// The differents FTP modes availables.
@@ -186,10 +185,7 @@ impl ListingResponse {
     ///
     /// Return true if the status is a success, false if it is a failure
     pub fn is_ok(&self) -> bool {
-        match unsafe { ffi::sfFtpListingResponse_isOk(self.listing_response) } {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe { ffi::sfFtpListingResponse_isOk(self.listing_response) }.to_bool()
     }
 
     /// Get the status code of a FTP listing response
@@ -250,10 +246,7 @@ impl DirectoryResponse {
     ///
     /// Return true if the status is a success, false if it is a failure
     pub fn is_ok(&self) -> bool {
-        match unsafe { ffi::sfFtpDirectoryResponse_isOk(self.directory_response) } {
-            SFFALSE => false,
-            SFTRUE => true
-        }
+        unsafe { ffi::sfFtpDirectoryResponse_isOk(self.directory_response) }.to_bool()
     }
 
     /// Get the status code of a FTP directory response
@@ -302,10 +295,7 @@ impl Response {
     ///
     /// Return true if the status is a success, false if it is a failure
     pub fn is_ok(&self) -> bool {
-        match unsafe { ffi::sfFtpResponse_isOk(self.response) } {
-            SFFALSE => false,
-            SFTRUE => true
-        }
+        unsafe { ffi::sfFtpResponse_isOk(self.response) }.to_bool()
     }
 
     /// Get the status code of a FTP response

--- a/src/network/packet.rs
+++ b/src/network/packet.rs
@@ -30,7 +30,7 @@ use std::str;
 
 use traits::Wrappable;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::network::packet as ffi;
 
 /// Utility class to build blocks of data to transfer over the network.
@@ -98,10 +98,7 @@ impl Packet {
     ///
     /// Return true if all data was read, false otherwise
     pub fn end_of_packet(&self) -> bool {
-        match unsafe { ffi::sfPacket_endOfPacket(self.packet) } {
-            SFFALSE => false,
-            SFTRUE => true
-        }
+        unsafe { ffi::sfPacket_endOfPacket(self.packet) }.to_bool()
     }
 
     /// Test the validity of a packet, for reading
@@ -114,18 +111,12 @@ impl Packet {
     ///
     /// Return true if last data extraction from packet was successful
     pub fn can_read(&self) -> bool {
-        match unsafe { ffi::sfPacket_canRead(self.packet) } {
-            SFFALSE => false,
-            SFTRUE => true
-        }
+        unsafe { ffi::sfPacket_canRead(self.packet) }.to_bool()
     }
 
     /// Function to extract data from a packet
     pub fn read_bool(&self) -> bool {
-        match unsafe { ffi::sfPacket_readBool(self.packet) } {
-            SFFALSE => false,
-            SFTRUE => true
-        }
+        unsafe { ffi::sfPacket_readBool(self.packet) }.to_bool()
     }
 
     /// Function to extract data from a packet
@@ -197,10 +188,7 @@ impl Packet {
     /// Function to insert data into a packet
     pub fn write_bool(&self, data: bool) -> () {
         unsafe {
-            match data {
-                true    => ffi::sfPacket_writeBool(self.packet, SFTRUE),
-                false    => ffi::sfPacket_writeBool(self.packet, SFFALSE)
-            }
+            ffi::sfPacket_writeBool(self.packet, SfBool::from_bool(data))
         }
     }
 

--- a/src/network/tcp_listener.rs
+++ b/src/network/tcp_listener.rs
@@ -29,7 +29,7 @@ use std::mem;
 use traits::Wrappable;
 use network::{TcpSocket, SocketStatus};
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::network::tcp_listener as ffi;
 
 /// Socket that listens to new TCP connections
@@ -68,10 +68,7 @@ impl TcpListener {
     /// * blocking - true to set the socket as blocking, false for non-blocking
     pub fn set_blocking(&mut self, blocking: bool) -> () {
         unsafe {
-            match blocking  {
-                true        => ffi::sfTcpListener_setBlocking(self.listener, SFTRUE),
-                false       => ffi::sfTcpListener_setBlocking(self.listener, SFFALSE)
-            }
+            ffi::sfTcpListener_setBlocking(self.listener, SfBool::from_bool(blocking))
         }
     }
 
@@ -79,10 +76,7 @@ impl TcpListener {
     ///
     /// Return true if the socket is blocking, false otherwise
     pub fn is_blocking(&self) -> bool {
-        match unsafe { ffi::sfTcpListener_isBlocking(self.listener) } {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe { ffi::sfTcpListener_isBlocking(self.listener) }.to_bool()
     }
 
     /// Get the port to which a TCP listener is bound locally

--- a/src/network/tcp_socket.rs
+++ b/src/network/tcp_socket.rs
@@ -32,7 +32,7 @@ use traits::Wrappable;
 use network::{IpAddress, Packet, SocketStatus};
 use system::Time;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::network::tcp_socket as ffi;
 
 /// Specialized socket using the TCP protocol
@@ -71,10 +71,7 @@ impl TcpSocket {
     /// * blocking - true to set the socket as blocking, false for non-blocking
     pub fn set_blocking(&mut self, blocking: bool) -> () {
         unsafe {
-            match blocking  {
-                true        => ffi::sfTcpSocket_setBlocking(self.socket, SFTRUE),
-                false       => ffi::sfTcpSocket_setBlocking(self.socket, SFFALSE)
-            }
+            ffi::sfTcpSocket_setBlocking(self.socket, SfBool::from_bool(blocking))
         }
     }
 
@@ -82,10 +79,7 @@ impl TcpSocket {
     ///
     /// Return true if the socket is blocking, false otherwise
     pub fn is_blocking(&self) -> bool {
-        match unsafe { ffi::sfTcpSocket_isBlocking(self.socket) } {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe { ffi::sfTcpSocket_isBlocking(self.socket) }.to_bool()
     }
 
     /// Get the port to which a TCP socket is bound locally

--- a/src/network/udp_socket.rs
+++ b/src/network/udp_socket.rs
@@ -31,7 +31,7 @@ use std::vec::Vec;
 use traits::Wrappable;
 use network::{Packet, IpAddress, SocketStatus};
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::network::udp_socket as ffi;
 
 /// Specialized socket using the UDP protocol.
@@ -70,10 +70,7 @@ impl UdpSocket {
     /// blocking - true to set the socket as blocking, false for non-blocking
     pub fn set_blocking(&self, blocking: bool) -> () {
         unsafe {
-            match blocking  {
-                true        => ffi::sfUdpSocket_setBlocking(self.socket, SFTRUE),
-                false       => ffi::sfUdpSocket_setBlocking(self.socket, SFFALSE)
-            }
+            ffi::sfUdpSocket_setBlocking(self.socket, SfBool::from_bool(blocking))
         }
     }
 
@@ -81,10 +78,7 @@ impl UdpSocket {
     ///
     /// Return true if the socket is blocking, false otherwise
     pub fn is_blocking(&self) -> bool {
-        match unsafe { ffi::sfUdpSocket_isBlocking(self.socket) } {
-            SFFALSE  => false,
-            SFTRUE   => true
-        }
+        unsafe { ffi::sfUdpSocket_isBlocking(self.socket) }.to_bool()
     }
 
     /// Get the port to which a UDP socket is bound locally

--- a/src/window/context.rs
+++ b/src/window/context.rs
@@ -26,7 +26,7 @@
 //!
 //! Class holding a valid drawing context.
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::window::context as ffi;
 
 /// Drawing context
@@ -55,10 +55,7 @@ impl Context {
     /// * active - True to activate, False to deactivate
     pub fn set_active(&mut self, active: bool) -> () {
         unsafe {
-            match active {
-                true    => ffi::sfContext_setActive(self.cont, SFTRUE),
-                false   => ffi::sfContext_setActive(self.cont, SFFALSE)
-            }
+            ffi::sfContext_setActive(self.cont, SfBool::from_bool(active))
         }
     }
 }

--- a/src/window/joystick.rs
+++ b/src/window/joystick.rs
@@ -30,7 +30,6 @@
 
 use libc::c_uint;
 
-use ffi::sfml_types::{SFFALSE, SFTRUE};
 use ffi::window::joystick as ffi;
 
 /// Maximum number of supported joysticks.
@@ -71,10 +70,7 @@ pub enum Axis {
  */
 pub fn is_connected(joystick: u32) -> bool {
     unsafe {
-        match ffi::sfJoystick_isConnected(joystick as c_uint) {
-            SFFALSE   => false,
-            SFTRUE    => true
-        }
+        ffi::sfJoystick_isConnected(joystick as c_uint).to_bool()
     }
 }
 
@@ -105,10 +101,7 @@ pub fn button_count(joystick: u32) -> u32 {
  */
 pub fn has_axis(joystick: u32, axis: Axis) -> bool {
     unsafe {
-        match ffi::sfJoystick_hasAxis(joystick as c_uint, axis as c_uint) {
-            SFFALSE     => false,
-            SFTRUE      => true
-        }
+        ffi::sfJoystick_hasAxis(joystick as c_uint, axis as c_uint).to_bool()
     }
 }
 
@@ -125,10 +118,7 @@ pub fn has_axis(joystick: u32, axis: Axis) -> bool {
  */
 pub fn is_button_pressed(joystick: u32, button: u32) -> bool {
     unsafe {
-        match ffi::sfJoystick_isButtonPressed(joystick as c_uint, button as c_uint) {
-            SFFALSE    => false,
-            SFTRUE     => true
-        }
+        ffi::sfJoystick_isButtonPressed(joystick as c_uint, button as c_uint).to_bool()
     }
 }
 

--- a/src/window/keyboard.rs
+++ b/src/window/keyboard.rs
@@ -27,7 +27,6 @@
 
 use libc::c_int;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
 use ffi::window::keyboard as ffi;
 
 /// Key codes
@@ -150,9 +149,6 @@ pub enum Key {
  */
 pub fn is_key_pressed(key: Key) -> bool {
     unsafe {
-        match ffi::sfKeyboard_isKeyPressed(key as c_int) {
-            SFFALSE  => false,
-            SFTRUE   => true
-        }
+        ffi::sfKeyboard_isKeyPressed(key as c_int).to_bool()
     }
 }

--- a/src/window/mouse.rs
+++ b/src/window/mouse.rs
@@ -30,7 +30,6 @@
 
 use libc::c_uint;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
 use ffi::window::mouse as ffi;
 
 /// Mouse buttons
@@ -58,9 +57,6 @@ pub enum MouseButton {
 */
 pub fn is_button_pressed(button: MouseButton) -> bool {
     unsafe {
-        match ffi::sfMouse_isButtonPressed(button as c_uint) {
-            SFFALSE   => false,
-            SFTRUE    => true
-        }
+        ffi::sfMouse_isButtonPressed(button as c_uint).to_bool()
     }
 }

--- a/src/window/video_mode.rs
+++ b/src/window/video_mode.rs
@@ -32,7 +32,6 @@ use std::vec::Vec;
 
 use traits::Wrappable;
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
 use ffi::window::video_mode as ffi;
 
 /// VideoMode defines a video mode (width, height, bpp, frequency)
@@ -81,15 +80,11 @@ impl VideoMode {
     ///
     /// return true if the video mode is valid for fullscreen mode
     pub fn is_valid(&self) -> bool {
-        let i = unsafe { ffi::sfVideoMode_isValid(ffi::sfVideoMode {
+        unsafe { ffi::sfVideoMode_isValid(ffi::sfVideoMode {
                     width: self.width as c_uint,
                     height: self.height as c_uint,
                     bits_per_pixel: self.bits_per_pixel as c_uint
-                }) };
-        match i {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+                }) }.to_bool()
     }
 
     /// Static Method, get the current desktop video mode

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -36,7 +36,7 @@ use traits::Wrappable;
 use window::{event, VideoMode, ContextSettings, WindowStyle};
 use system::vector2::{Vector2i, Vector2u};
 
-use ffi::sfml_types::{SFTRUE, SFFALSE};
+use ffi::sfml_types::SfBool;
 use ffi::window::window as ffi;
 
 ///
@@ -147,13 +147,10 @@ impl Window {
     /// Return the event if an event was returned, or NoEvent if the event queue was empty
     pub fn poll_event(&mut self) -> event::Event {
         let mut event = event::raw::sfEvent { data: [032; 6] };
-        let have_event: bool =  unsafe {
-            match ffi::sfWindow_pollEvent(self.window, &mut event) {
-                SFFALSE     => false,
-                SFTRUE      => true
-            }
+        let have_event = unsafe {
+            ffi::sfWindow_pollEvent(self.window, &mut event).to_bool()
         };
-        if have_event == false {
+        if !have_event {
             event::NoEvent
         } else {
             event::raw::get_wrapped_event(&mut event)
@@ -173,14 +170,11 @@ impl Window {
     /// Return the event or NoEvent if an error has occured
     pub fn wait_event(&mut self) -> event::Event {
         let mut event = event::raw::sfEvent { data: [032; 6] };
-        let have_event: bool =  unsafe {
-            match ffi::sfWindow_waitEvent(self.window, &mut event) {
-                SFFALSE     => false,
-                SFTRUE      => true
-            }
+        let have_event = unsafe {
+            ffi::sfWindow_waitEvent(self.window, &mut event).to_bool()
         };
-        if have_event == false {
-            return event::NoEvent;
+        if !have_event {
+            event::NoEvent
         } else {
             event::raw::get_wrapped_event(&mut event)
         }
@@ -228,11 +222,7 @@ impl Window {
     /// Note that a hidden window (set_visible(false)) will return
     /// true.
     pub fn is_open(&self) -> bool {
-        let tmp = unsafe { ffi::sfWindow_isOpen(self.window) };
-        match tmp {
-            SFFALSE => false,
-            SFTRUE  => true
-        }
+        unsafe { ffi::sfWindow_isOpen(self.window) }.to_bool()
     }
 
     /// Get the settings of the OpenGL context of a window
@@ -264,10 +254,7 @@ impl Window {
     /// * visible - true to show the window, false to hide it
     pub fn set_visible(&mut self, visible: bool) -> () {
         unsafe {
-            match visible {
-                true    => ffi::sfWindow_setVisible(self.window, SFTRUE),
-                false   => ffi::sfWindow_setVisible(self.window, SFFALSE)
-            }
+            ffi::sfWindow_setVisible(self.window, SfBool::from_bool(visible))
         }
     }
 
@@ -277,10 +264,7 @@ impl Window {
     /// * visible - true to  false to hide
     pub fn set_mouse_cursor_visible(&mut self, visible: bool) -> () {
         unsafe {
-            match visible {
-                true    => ffi::sfWindow_setMouseCursorVisible(self.window, SFTRUE),
-                false   => ffi::sfWindow_setMouseCursorVisible(self.window, SFFALSE)
-            }
+            ffi::sfWindow_setMouseCursorVisible(self.window, SfBool::from_bool(visible))
         }
     }
 
@@ -295,10 +279,7 @@ impl Window {
     /// * enabled - true to enable v-sync, false to deactivate
     pub fn set_vertical_sync_enabled(&mut self, enabled: bool) -> () {
         unsafe {
-            match enabled {
-                true    => ffi::sfWindow_setVerticalSyncEnabled(self.window, SFTRUE),
-                false   => ffi::sfWindow_setVerticalSyncEnabled(self.window, SFFALSE)
-            }
+            ffi::sfWindow_setVerticalSyncEnabled(self.window, SfBool::from_bool(enabled))
         }
     }
 
@@ -314,10 +295,7 @@ impl Window {
     /// * enabled - true to enable, false to disable
     pub fn set_key_repeat_enabled(&mut self, enabled: bool) -> () {
         unsafe {
-            match enabled {
-                true    => ffi::sfWindow_setKeyRepeatEnabled(self.window, SFTRUE),
-                false   => ffi::sfWindow_setKeyRepeatEnabled(self.window, SFFALSE)
-            }
+            ffi::sfWindow_setKeyRepeatEnabled(self.window, SfBool::from_bool(enabled))
         }
     }
 
@@ -334,14 +312,7 @@ impl Window {
     ///
     /// Return true if operation was successful, false otherwise
     pub fn set_active(&mut self, enabled: bool) -> bool {
-        let tmp = unsafe { match enabled {
-                true    => ffi::sfWindow_setActive(self.window, SFTRUE),
-                false   => ffi::sfWindow_setActive(self.window, SFFALSE)
-            }};
-        match tmp {
-            SFTRUE   => true,
-            SFFALSE  => false
-        }
+        unsafe { ffi::sfWindow_setActive(self.window, SfBool::from_bool(enabled)) }.to_bool()
     }
 
     /// Display on screen what has been rendered to the window so far
@@ -465,9 +436,9 @@ impl Iterator for Events {
 
     fn next(&mut self) -> Option<event::Event> {
         let mut event = event::raw::sfEvent { data: [032; 6] };
-        match unsafe { ffi::sfWindow_pollEvent(self.window, &mut event) } {
-            SFFALSE     => None,
-            SFTRUE      => Some(event::raw::get_wrapped_event(&mut event))
+        match unsafe { ffi::sfWindow_pollEvent(self.window, &mut event) }.to_bool() {
+            false     => None,
+            true      => Some(event::raw::get_wrapped_event(&mut event))
         }
     }
 }


### PR DESCRIPTION
Instead, methods `SfBool::from_bool` and `to_bool` are used to remove the heavy duplication that was present beforehand.

One possible improvement that could be made is use of the `From` and `Into` traits to avoid the need to import `SfBool` anywhere at all.

From #97.