### PR TITLE
Changed TextStyle and WindowStyle to be bitflags.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "zlib-acknowledgement"
 [dependencies]
 rand = ">=0.2.0"
 libc = ">=0.1.5"
+bitflags = ">=0.1"
 
 [lib]
 

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -82,7 +82,7 @@ mod texture;
 mod blend_mode;
 mod transform;
 mod text;
-mod text_style;
+pub mod text_style;
 mod shader;
 mod color;
 mod font;

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -89,7 +89,7 @@ impl RenderWindow {
         let sf_render_win: *mut ffi::sfRenderWindow = unsafe {
             ffi::sfRenderWindow_create(mode.unwrap(),
                                        c_str,
-                                       style as u32,
+                                       style.bits(),
                                        settings)
         };
         if sf_render_win.is_null() {
@@ -131,7 +131,7 @@ impl RenderWindow {
         unsafe {
             sf_render_win = ffi::sfRenderWindow_createUnicode(mode.unwrap(),
                                                               title.as_ptr() as *mut u32,
-                                                              style as u32,
+                                                              style.bits(),
                                                               settings);
         }
         if sf_render_win.is_null() {

--- a/src/graphics/text/mod.rs
+++ b/src/graphics/text/mod.rs
@@ -27,8 +27,6 @@
 //! Text is a drawable class that allows to easily
 //! display some text with custom style and color on a render target.
 
-use std::mem;
-use std::vec::Vec;
 use std::ffi::{CString, CStr};
 use std::str;
 use libc::{c_float, c_uint, size_t};
@@ -193,7 +191,7 @@ impl<'s> Text<'s> {
     /// * style - New style
     pub fn set_style(&mut self, style: TextStyle) -> () {
         unsafe {
-            ffi::sfText_setStyle(self.text, style as u32)
+            ffi::sfText_setStyle(self.text, style.bits())
         }
     }
 
@@ -213,7 +211,7 @@ impl<'s> Text<'s> {
     ///
     /// Return the current string style (see Style enum)
     pub fn get_style(&self) -> TextStyle {
-        unsafe { mem::transmute(ffi::sfText_getStyle(self.text)) }
+        unsafe { TextStyle::from_bits_truncate(ffi::sfText_getStyle(self.text)) }
     }
 
     /// Get the font of a text

--- a/src/graphics/text_style.rs
+++ b/src/graphics/text_style.rs
@@ -22,16 +22,28 @@
 * 3. This notice may not be removed or altered from any source distribution.
 */
 
-/// Availables texts styles
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Copy)]
-#[repr(C)]
-pub enum TextStyle {
-    /// Regular characters, no style.
-    Regular = 0,
-    /// Bold characters.
-    Bold = 1,
-    /// Italic characters.
-    Italic = 2,
-    /// Underlined characters.
-    Underlined = 4
+//! Available text styles.
+
+// Manual #[doc] tags are to work around rust-lang/rust#23812.
+
+bitflags! {
+    #[doc="Available text styles."]
+    #[derive(Debug)]
+    #[repr(C)]
+    flags TextStyle: u32 {
+        #[doc="Regular characters, no style."]
+        const REGULAR = 0,
+        #[doc="Bold characters."]
+        const BOLD = 1,
+        #[doc="Italic characters."]
+        const ITALIC = 2,
+        #[doc="Underlined characters."]
+        const UNDERLINED = 4
+    }
+}
+
+impl Default for TextStyle {
+    fn default() -> TextStyle {
+        REGULAR
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,8 @@
 #![warn(missing_docs)]
 
 extern crate libc;
+#[macro_use]
+extern crate bitflags;
 
 pub mod traits;
 pub mod system;

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -46,4 +46,4 @@ pub mod joystick;
 pub mod keyboard;
 pub mod mouse;
 pub mod event;
-mod window_style;
+pub mod window_style;

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -78,10 +78,9 @@ impl Window {
                title: &str,
                style: WindowStyle,
                settings: &ContextSettings) -> Option<Window> {
-
         let c_str = CString::new(title.as_bytes()).unwrap().as_ptr();
         let sf_win: *mut ffi::sfWindow = unsafe {
-            ffi::sfWindow_create(mode.unwrap(), c_str, style as u32, settings)
+            ffi::sfWindow_create(mode.unwrap(), c_str, style.bits(), settings)
         };
         if sf_win.is_null() {
             None
@@ -119,7 +118,7 @@ impl Window {
         let sf_win =
             unsafe { ffi::sfWindow_createUnicode(mode.unwrap(),
                                                  title.as_ptr(),
-                                                 style as u32, settings) };
+                                                 style.bits(), settings) };
         if sf_win.is_null() {
             None
         } else {

--- a/src/window/window_style.rs
+++ b/src/window/window_style.rs
@@ -22,24 +22,32 @@
 * 3. This notice may not be removed or altered from any source distribution.
 */
 
-//! Window styles
-//!
-//! Availables window styles
+//! Available styles applicable to windows.
 
-/// Enumeration of window creation styles
-#[repr(C)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Copy)]
-pub enum WindowStyle {
-    /// No border / title bar (this flag and all others are mutually exclusive)
-    NoStyle = 0,
-    /// Title bar + fixed border.
-    Titlebar = 1,
-    /// Titlebar + resizable border + maximize button.
-    Resize = 2,
-    /// Titlebar + close button.
-    Close = 4,
-    /// Fullscreen mode (this flag and all others are mutually exclusive)
-    Fullscreen = 8,
-    /// Default window style.
-    DefaultStyle = 7
+// Manual #[doc] tags are to work around rust-lang/rust#23812.
+
+bitflags! {
+    #[doc="Available styles applicable to windows."]
+    #[derive(Debug)]
+    #[repr(C)]
+    flags WindowStyle: u32 {
+        #[doc="No decorations (cannot be combined with other flags)."]
+        const NO_STYLE = 0,
+        #[doc="Title bar and fixed border."]
+        const TITLEBAR = 1,
+        #[doc="Title bar, resizable border, and maximize button."]
+        const RESIZE = 2,
+        #[doc="Title bar and close button."]
+        const CLOSE = 4,
+        #[doc="Fullscreen mode (ignores other flags)."]
+        const FULLSCREEN = 8,
+        #[doc="Default window style: title bar, resizable border, and close button."]
+        const DEFAULT_STYLE = 1 | 2 | 4
+    }
+}
+
+impl Default for WindowStyle {
+    fn default() -> WindowStyle {
+        DEFAULT_STYLE
+    }
 }


### PR DESCRIPTION
The `bitflags` crate and macro are used to define the bit flag structs. The constants are kept within their own modules.

From #97. Fixes #92.