### PR TITLE
Changed is_key_pressed and is_button_pressed to be methods.

### DIFF
--- a/src/window/keyboard.rs
+++ b/src/window/keyboard.rs
@@ -22,18 +22,15 @@
 * 3. This notice may not be removed or altered from any source distribution.
 */
 
-
-//! Keyboard inputs Give acces to real-time keyboard input.
-
 use libc::c_int;
-
 use ffi::window::keyboard as ffi;
 
-/// Key codes
+/// Key codes known to SFML.
 #[repr(i64)]
 #[allow(missing_docs)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Copy)]
 pub enum Key {
+    /// An unhandled key.
     Unknown = -1,
     A = 0,
     B,
@@ -75,10 +72,12 @@ pub enum Key {
     LControl,
     LShift,
     LAlt,
+    /// The left OS-specific key: Window, Apple, so on.
     LSystem,
     RControl,
     RShift,
     RAlt,
+    /// The right OS-specific key: Window, Apple, so on.
     RSystem,
     Menu,
     LBracket,
@@ -102,9 +101,13 @@ pub enum Key {
     Home,
     Insert,
     Delete,
+    /// The numpad addition key.
     Add,
+    /// The numpad subtraction key.
     Subtract,
+    /// The numpad multiplication key.
     Multiply,
+    /// The numpad division key.
     Divide,
     Left,
     Right,
@@ -136,19 +139,17 @@ pub enum Key {
     F14,
     F15,
     Pause,
+    /// The maximum available key code (not a real key).
     KeyCount
 }
 
-/**
- * Check if a key is pressed.
- *
- * # Arguments
- * * key - The key to check
- *
- * Return true if the key is pressed, false otherwise.
- */
-pub fn is_key_pressed(key: Key) -> bool {
-    unsafe {
-        ffi::sfKeyboard_isKeyPressed(key as c_int).to_bool()
+impl Key {
+    /// Return whether this key is currently pressed.
+    ///
+    /// Queries the real-time state of the keyboard, even if keys have been
+    /// pressed or released while no window was focused and no events were
+    /// triggered.
+    pub fn is_pressed(self) -> bool {
+        unsafe { ffi::sfKeyboard_isKeyPressed(self as c_int) }.to_bool()
     }
 }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -30,6 +30,8 @@ pub use window::video_mode::VideoMode;
 pub use window::context::Context;
 pub use window::context_settings::ContextSettings;
 pub use window::window_style::WindowStyle;
+pub use window::keyboard::Key;
+pub use window::mouse::MouseButton;
 
 #[cfg(any(target_os="macos", target_os="linux", target_os="windows"))]
 mod platform {
@@ -43,7 +45,7 @@ mod video_mode;
 mod context;
 mod context_settings;
 pub mod joystick;
-pub mod keyboard;
-pub mod mouse;
+mod keyboard;
+mod mouse;
 pub mod event;
 mod window_style;

--- a/src/window/mouse.rs
+++ b/src/window/mouse.rs
@@ -22,17 +22,10 @@
 * 3. This notice may not be removed or altered from any source distribution.
 */
 
-/*!
-* Mouse events.
-*
-* Give access to the real-time state of the mouse
-*/
-
 use libc::c_uint;
-
 use ffi::window::mouse as ffi;
 
-/// Mouse buttons
+/// Mouse buttons.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Copy)]
 pub enum MouseButton {
     /// The left mouse button.
@@ -47,16 +40,13 @@ pub enum MouseButton {
     XButton2
 }
 
-/**
-* Check if a mouse button is pressed
-*
-* # Arguments
-* * button - Button to check
-*
-* Return true if the button is pressed, false otherwise
-*/
-pub fn is_button_pressed(button: MouseButton) -> bool {
-    unsafe {
-        ffi::sfMouse_isButtonPressed(button as c_uint).to_bool()
+impl MouseButton {
+    /// Return whether this mouse button is currently pressed.
+    ///
+    /// Queries the real-time state of the mouse, even if buttons have been
+    /// pressed or released while no window was focused and no events were
+    /// triggered.
+    pub fn is_pressed(self) -> bool {
+        unsafe { ffi::sfMouse_isButtonPressed(self as c_uint) }.to_bool()
     }
 }


### PR DESCRIPTION
Also tidied documentation on `Key` and `MouseButton`.

This improves ergonomics, changing:
```rust
keyboard::is_key_pressed(Key::X)
mouse::is_button_pressed(MouseButton::Left)
```
to
```rust
Key::X.is_pressed()
MouseButton::Left.is_pressed()
```

From #97.