### PR TITLE
Make system::Time copyable.

### DIFF
--- a/src/system/time.rs
+++ b/src/system/time.rs
@@ -40,6 +40,7 @@ use ffi::system::time as ffi;
 /// Represents a time value.
 ///
 /// Time encapsulates a time value in a flexible way.
+#[derive(Copy, Clone)]
 pub struct Time {
     time: ffi::sfTime
 }


### PR DESCRIPTION
Not having this is annoying when trying to do something like
`current_elapsed - last_update > update_interval` to check
if things need an update.