### PR TITLE
Make Drawable::draw callable on trait objects

### DIFF
--- a/examples/custom_drawable.rs
+++ b/examples/custom_drawable.rs
@@ -31,7 +31,7 @@ impl<'s> CustomDrawable<'s> {
 
 // Implements the drawable trait, only this function is mendatory.
 impl<'s> Drawable for CustomDrawable<'s> {
-    fn draw<RT: RenderTarget>(&self, render_target: &mut RT, _: &mut RenderStates) {
+    fn draw(&self, render_target: &mut RenderTarget, _: &mut RenderStates) {
         render_target.draw(&self.circle);
         render_target.draw(&self.rect)
     }

--- a/src/graphics/circle_shape/mod.rs
+++ b/src/graphics/circle_shape/mod.rs
@@ -155,7 +155,7 @@ impl<'s> CircleShape<'s> {
 }
 
 impl<'s> Drawable for CircleShape<'s> {
-    fn draw<RT:RenderTarget>(&self, render_target: &mut RT, render_states: &mut RenderStates) {
+    fn draw(&self, render_target: &mut RenderTarget, render_states: &mut RenderStates) {
         render_target.draw_circle_shape(self, render_states)
     }
 }

--- a/src/graphics/circle_shape/rc.rs
+++ b/src/graphics/circle_shape/rc.rs
@@ -614,7 +614,7 @@ impl Wrappable<*mut ffi::sfCircleShape> for CircleShape {
 }
 
 impl Drawable for CircleShape {
-    fn draw<RT:RenderTarget>(&self, render_target: &mut RT, render_states: &mut RenderStates) {
+    fn draw(&self, render_target: &mut RenderTarget, render_states: &mut RenderStates) {
         render_target.draw_circle_shape(self, render_states)
     }
 }

--- a/src/graphics/convex_shape/mod.rs
+++ b/src/graphics/convex_shape/mod.rs
@@ -157,7 +157,7 @@ impl<'s> ConvexShape<'s> {
 }
 
 impl<'s> Drawable for ConvexShape<'s> {
-    fn draw<RT: RenderTarget>(&self, render_target: &mut RT, render_states: &mut RenderStates) {
+    fn draw(&self, render_target: &mut RenderTarget, render_states: &mut RenderStates) {
         render_target.draw_convex_shape(self, render_states)
     }
 }

--- a/src/graphics/convex_shape/rc.rs
+++ b/src/graphics/convex_shape/rc.rs
@@ -627,7 +627,7 @@ impl Wrappable<*mut ffi::sfConvexShape> for ConvexShape {
 }
 
 impl Drawable for ConvexShape {
-    fn draw<RT: RenderTarget>(&self, render_target: &mut RT, render_states: &mut RenderStates) {
+    fn draw(&self, render_target: &mut RenderTarget, render_states: &mut RenderStates) {
         render_target.draw_convex_shape(self, render_states)
     }
 }

--- a/src/graphics/custom_shape/mod.rs
+++ b/src/graphics/custom_shape/mod.rs
@@ -321,9 +321,9 @@ impl<'s> CustomShape<'s> {
 }
 
 impl<'s> Drawable for CustomShape<'s> {
-    fn draw<RT: RenderTarget>(&self,
-                                 render_target: &mut RT,
-                                 render_states: &mut RenderStates) {
+    fn draw(&self,
+            render_target: &mut RenderTarget,
+            render_states: &mut RenderStates) {
         render_target.draw_shape(self, render_states)
     }
 }

--- a/src/graphics/custom_shape/rc.rs
+++ b/src/graphics/custom_shape/rc.rs
@@ -557,9 +557,9 @@ impl Shape {
 }
 
 impl Drawable for Shape {
-    fn draw<RT: RenderTarget>(&self,
-                                    render_target: &mut RT,
-                                    render_states: &mut RenderStates) {
+    fn draw(&self,
+            render_target: &mut RenderTarget,
+            render_states: &mut RenderStates) {
         render_target.draw_shape(self, render_states)
     }
 }

--- a/src/graphics/drawable.rs
+++ b/src/graphics/drawable.rs
@@ -32,5 +32,5 @@ use graphics::{RenderStates, RenderTarget};
 /// The trait drawable is inherited by each object who can be drawn in a RenderTarget
 pub trait Drawable {
     /// Draw a drawable object into a RenderTarget
-    fn draw<RT: RenderTarget>(&self, target: &mut RT, rs: &mut RenderStates);
+    fn draw(&self, target: &mut RenderTarget, rs: &mut RenderStates);
 }

--- a/src/graphics/rectangle_shape/mod.rs
+++ b/src/graphics/rectangle_shape/mod.rs
@@ -149,9 +149,9 @@ impl<'s> RectangleShape<'s> {
 
 
 impl<'s> Drawable for RectangleShape<'s> {
-    fn draw<RT: RenderTarget>(&self,
-                              render_target: &mut RT,
-                              render_states: &mut RenderStates) {
+    fn draw(&self,
+            render_target: &mut RenderTarget,
+            render_states: &mut RenderStates) {
         render_target.draw_rectangle_shape(self, render_states);
     }
 }

--- a/src/graphics/rectangle_shape/rc.rs
+++ b/src/graphics/rectangle_shape/rc.rs
@@ -610,9 +610,9 @@ impl Wrappable<*mut ffi::sfRectangleShape> for RectangleShape {
 }
 
 impl Drawable for RectangleShape {
-    fn draw<RT:RenderTarget>(&self,
-                             render_target: &mut RT,
-                             render_states: &mut RenderStates) {
+    fn draw(&self,
+            render_target: &mut RenderTarget,
+            render_states: &mut RenderStates) {
         render_target.draw_rectangle_shape(self, render_states);
     }
 }

--- a/src/graphics/render_target.rs
+++ b/src/graphics/render_target.rs
@@ -154,16 +154,16 @@ pub trait RenderTarget {
     ///
     /// # Arguments
     /// * object - Object to draw
-    fn draw<T: Drawable>(&mut self, object: &T);
+    fn draw(&mut self, object: &Drawable);
 
     /// Draw a drawable object to the render-target with a RenderStates
     ///
     /// # Arguments
     /// * object - Object to draw
     /// * renderStates - The renderStates to associate to the object
-    fn draw_with_renderstates<T: Drawable>(&mut self,
-                                           object: &T,
-                                           render_states: &mut RenderStates);
+    fn draw_with_renderstates(&mut self,
+                              object: &Drawable,
+                              render_states: &mut RenderStates);
 
     /// Draw a drawable object to the render-target with a RenderStates
     ///

--- a/src/graphics/render_texture.rs
+++ b/src/graphics/render_texture.rs
@@ -299,7 +299,7 @@ impl RenderTarget for RenderTexture {
     ///
     /// # Arguments
     /// * object - Object to draw
-    fn draw<T: Drawable>(&mut self, object: &T) {
+    fn draw(&mut self, object: &Drawable) {
         object.draw(self, &mut RenderStates::default());
     }
 
@@ -308,9 +308,9 @@ impl RenderTarget for RenderTexture {
     /// # Arguments
     /// * object - Object to draw
     /// * renderStates - The RenderStates to associate to the object
-    fn draw_with_renderstates<T: Drawable>(&mut self,
-                                                object: &T,
-                                                render_states: &mut RenderStates) {
+    fn draw_with_renderstates(&mut self,
+                              object: &Drawable,
+                              render_states: &mut RenderStates) {
         object.draw(self, render_states);
     }
 

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -730,7 +730,7 @@ impl RenderTarget for RenderWindow{
     ///
     /// # Arguments
     /// * object - Object to draw
-    fn draw<T: Drawable>(&mut self, object: &T) {
+    fn draw(&mut self, object: &Drawable) {
         object.draw(self, &mut RenderStates::default());
     }
 
@@ -739,9 +739,9 @@ impl RenderTarget for RenderWindow{
     /// # Arguments
     /// * object - Object to draw
     /// * renderStates - The renderStates to associate to the object
-    fn draw_with_renderstates<T: Drawable>(&mut self,
-                                           object: &T,
-                                           render_states: &mut RenderStates) {
+    fn draw_with_renderstates(&mut self,
+                              object: &Drawable,
+                              render_states: &mut RenderStates) {
         object.draw(self, render_states);
     }
 

--- a/src/graphics/sprite/mod.rs
+++ b/src/graphics/sprite/mod.rs
@@ -242,9 +242,9 @@ impl<'s> Clone for Sprite<'s> {
 }
 
 impl<'s> Drawable for Sprite<'s> {
-    fn draw<RT:RenderTarget>(&self,
-                                render_target: &mut RT,
-                                render_states: &mut RenderStates) {
+    fn draw(&self,
+            render_target: &mut RenderTarget,
+            render_states: &mut RenderStates) {
         render_target.draw_sprite(self, render_states)
     }
 }

--- a/src/graphics/sprite/rc.rs
+++ b/src/graphics/sprite/rc.rs
@@ -484,9 +484,9 @@ impl Wrappable<*mut ffi::sfSprite> for Sprite {
 }
 
 impl Drawable for Sprite {
-    fn draw<RT:RenderTarget>(&self,
-                                   render_target: &mut RT,
-                                   render_states: &mut RenderStates) {
+    fn draw(&self,
+            render_target: &mut RenderTarget,
+            render_states: &mut RenderStates) {
         render_target.draw_sprite(self, render_states)
     }
 }

--- a/src/graphics/text/mod.rs
+++ b/src/graphics/text/mod.rs
@@ -321,9 +321,9 @@ impl<'s> Clone for Text<'s> {
 }
 
 impl<'s> Drawable for Text<'s> {
-    fn draw<RT:RenderTarget>(&self,
-                                render_target: &mut RT,
-                                render_states: &mut RenderStates) {
+    fn draw(&self,
+            render_target: &mut RenderTarget,
+            render_states: &mut RenderStates) {
         render_target.draw_text(self, render_states)
     }
 }

--- a/src/graphics/text/rc.rs
+++ b/src/graphics/text/rc.rs
@@ -568,9 +568,9 @@ impl Wrappable<*mut ffi::sfText> for Text {
 }
 
 impl Drawable for Text {
-    fn draw<RT:RenderTarget>(&self,
-                                   render_target: &mut RT,
-                                   render_states: &mut RenderStates) {
+    fn draw(&self,
+            render_target: &mut RenderTarget,
+            render_states: &mut RenderStates) {
         render_target.draw_text(self, render_states)
     }
 }

--- a/src/graphics/vertex_array.rs
+++ b/src/graphics/vertex_array.rs
@@ -296,9 +296,9 @@ impl Wrappable<*mut ffi::sfVertexArray> for VertexArray {
 }
 
 impl Drawable for VertexArray {
-    fn draw<RT: RenderTarget>(&self,
-                                 render_target: &mut RT,
-                                 render_states: &mut RenderStates) {
+    fn draw(&self,
+            render_target: &mut RenderTarget,
+            render_states: &mut RenderStates) {
         render_target.draw_vertex_array(self, render_states)
     }
 }


### PR DESCRIPTION
Now you can f.ex. store a `Vec` of `Drawable`s (trait objects), loop
through them and call `draw` on each of them.

More information about this issue:
http://stackoverflow.com/q/32081065/3425536