### PR TITLE
Implement SFML2.3-style BlendMode.

### DIFF
--- a/csfml-graphics-sys/src/lib.rs
+++ b/csfml-graphics-sys/src/lib.rs
@@ -75,6 +75,45 @@ pub enum sfPrimitiveType {
     sfQuads
 }
 
+/**
+ * BlendMode factor types
+ */
+#[repr(C)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Copy)]
+pub enum sfBlendFactor {
+    sfBlendFactorZero,
+    sfBlendFactorOne,
+    sfBlendFactorSrcColor,
+    sfBlendFactorOneMinusSrcColor,
+    sfBlendFactorDstColor,
+    sfBlendFactorOneMinusDstColor,
+    sfBlendFactorSrcAlpha,
+    sfBlendFactorOneMinusSrcAlpha,
+    sfBlendFactorDstAlpha,
+    sfBlendFactorOneMinusDstAlpha,
+}
+
+/**
+ * BlendMode equations
+ */
+#[repr(C)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Copy)]
+pub enum sfBlendEquation {
+    sfBlendEquationAdd,
+    sfBlendEquationSubtract
+}
+
+#[repr(C)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Copy)]
+pub struct sfBlendMode {
+    pub colorSrcFactor: sfBlendFactor,
+    pub colorDstFactor: sfBlendFactor,
+    pub colorEquation: sfBlendEquation,
+    pub alphaSrcFactor: sfBlendFactor,
+    pub alphaDstFactor: sfBlendFactor,
+    pub alphaEquation: sfBlendEquation,
+}
+
 #[repr(C)]
 #[allow(missing_docs)]
 #[derive(Clone, Copy)]
@@ -329,7 +368,7 @@ extern "C" {
 
 #[repr(C)]
 pub struct sfRenderStates {
-    pub blendMode: i32,
+    pub blendMode: sfBlendMode,
     pub transform: sfTransform,
     pub texture: *mut sfTexture,
     pub shader: *mut sfShader

--- a/src/graphics/blend_mode.rs
+++ b/src/graphics/blend_mode.rs
@@ -23,16 +23,76 @@
 */
 
 //! Available blending modes for drawing
+use csfml_graphics_sys as ffi;
+
+use csfml_graphics_sys::sfBlendEquation::*;
+use csfml_graphics_sys::sfBlendFactor::*;
 
 ///Available Blending modes for drawing.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Copy)]
-pub enum BlendMode {
-    /// Pixel = Source * Source.a + Dest * (1 - Source.a)
-    Alpha = 0,
-    /// Pixel = Source + Dest.
-    Add = 1,
-    /// Pixel = Source * Dest.
-    Multiply = 2,
-    /// Pixel = Source.
-    None = 3
+pub struct BlendMode(pub ffi::sfBlendMode);
+
+impl BlendMode {
+
+    ///Create a new BlendMode
+    pub fn new(
+      col_src: ffi::sfBlendFactor,
+      col_dst: ffi::sfBlendFactor,
+      col_equ: ffi::sfBlendEquation,
+      alpha_src: ffi::sfBlendFactor,
+      alpha_dst: ffi::sfBlendFactor,
+      alpha_equ: ffi::sfBlendEquation)
+        -> BlendMode {
+        BlendMode(ffi::sfBlendMode {
+          colorSrcFactor: col_src,
+          colorDstFactor: col_dst,
+          colorEquation: col_equ,
+          alphaSrcFactor: alpha_src,
+          alphaDstFactor: alpha_dst,
+          alphaEquation: alpha_equ,
+        })
+    }
+
+    ///BlendMode ALPHA
+    pub fn blend_alpha() -> BlendMode {
+        BlendMode::new(
+          sfBlendFactorSrcAlpha,
+          sfBlendFactorOneMinusSrcAlpha,
+          sfBlendEquationAdd,
+          sfBlendFactorOne,
+          sfBlendFactorOneMinusSrcAlpha,
+          sfBlendEquationAdd)
+    }
+
+    ///BlendMode ADD
+    pub fn blend_add() -> BlendMode {
+        BlendMode::new(
+          sfBlendFactorSrcAlpha,
+          sfBlendFactorOne,
+          sfBlendEquationAdd,
+          sfBlendFactorOne,
+          sfBlendFactorOne,
+          sfBlendEquationAdd)
+    }
+
+    ///BlendMode MULTIPLY
+    pub fn blend_multiply() -> BlendMode {
+        BlendMode::new(
+          sfBlendFactorDstColor,
+          sfBlendFactorZero,
+          sfBlendEquationAdd,
+          sfBlendFactorDstColor,
+          sfBlendFactorZero,
+          sfBlendEquationAdd)
+    }
+    ///BlendMode NONE
+    pub fn blend_none() -> BlendMode {
+        BlendMode::new(
+          sfBlendFactorOne,
+          sfBlendFactorZero,
+          sfBlendEquationAdd,
+          sfBlendFactorOne,
+          sfBlendFactorZero,
+          sfBlendEquationAdd)
+    }
 }

--- a/src/graphics/render_states/mod.rs
+++ b/src/graphics/render_states/mod.rs
@@ -62,7 +62,7 @@ impl<'s> RenderStates<'s> {
                shader: Option<&'s Shader<'s>>) -> RenderStates<'s> {
         RenderStates {
                 sf_render_states: ffi::sfRenderStates {
-                blendMode: blend_mode as i32,
+                blendMode: blend_mode.0,
                 transform: transform.0,
                 texture: ptr::null_mut(),
                 shader: ptr::null_mut()
@@ -86,12 +86,12 @@ impl<'s> RenderStates<'s> {
     pub fn default() -> RenderStates<'s> {
         RenderStates {
                 sf_render_states: ffi::sfRenderStates {
-                blendMode: BlendMode::Alpha as i32,
+                blendMode: BlendMode::blend_alpha().0,
                 transform: Transform::new_identity().0,
                 texture: ptr::null_mut(),
                 shader: ptr::null_mut()
             },
-            blend_mode: BlendMode::Alpha,
+            blend_mode: BlendMode::blend_alpha(),
             transform: Transform::new_identity(),
             texture: None,
             shader: None
@@ -101,7 +101,7 @@ impl<'s> RenderStates<'s> {
     // Internal rust-sfml use only
     #[doc(hidden)]
     pub fn unwrap(&mut self) -> *mut ffi::sfRenderStates {
-        self.sf_render_states.blendMode = self.blend_mode as i32;
+        self.sf_render_states.blendMode = self.blend_mode.0;
         self.sf_render_states.transform = self.transform.0;
         self.sf_render_states.texture = if !self.texture.is_none() {
             self.texture.unwrap().unwrap()


### PR DESCRIPTION
This stops programs from segfaulting on regular draw calls.