### PR TITLE
Making bitflag-type enums public for reexporting.

### DIFF
--- a/src/graphics/text_style.rs
+++ b/src/graphics/text_style.rs
@@ -29,7 +29,7 @@
 bitflags! {
     #[doc="Available text styles."]
     #[repr(C)]
-    flags TextStyle: u32 {
+    pub flags TextStyle: u32 {
         #[doc="Regular characters, no style."]
         const REGULAR = 0,
         #[doc="Bold characters."]

--- a/src/window/window_style.rs
+++ b/src/window/window_style.rs
@@ -29,7 +29,7 @@
 bitflags! {
     #[doc="Available styles applicable to windows."]
     #[repr(C)]
-    flags WindowStyle: u32 {
+    pub flags WindowStyle: u32 {
         #[doc="No decorations (cannot be combined with other flags)."]
         const NO_STYLE = 0,
         #[doc="Title bar and fixed border."]


### PR DESCRIPTION
Stable Rust couldn't compile the enums bellow because they were private.

Enums changed are:
- graphics::text_style::TextStyle
- window::window_style::WindowStyle