### PR TITLE
Added antialiasing, and a new pong example using AA

### DIFF
--- a/examples/pong.rs
+++ b/examples/pong.rs
@@ -8,8 +8,18 @@ use sfml::system::{Clock, Time, Vector2f};
 use sfml::audio::{Sound, SoundBuffer, SoundSource};
 use rand::{Rng, thread_rng};
 use std::f32::consts::PI;
+use std::env;
 
 fn main() {
+    let mut aa_level = 0;
+
+    if let Some(arg) = env::args().nth(1) {
+        if let Ok(arg_as_num) = arg.parse::<u32>() {
+            println!("Using {}xAA", arg_as_num);
+            aa_level = arg_as_num;
+        }
+    }
+
     // Define some constants
     let game_width: u32 = 800;
     let game_height: u32 = 600;
@@ -20,7 +30,9 @@ fn main() {
     let mut window = RenderWindow::new(VideoMode::new_init(game_width, game_height, 32),
                                        "SFML Pong",
                                        window_style::CLOSE,
-                                       &ContextSettingsBuilder::new().antialiasing_level(8).build())
+                                       &ContextSettingsBuilder::new()
+                                            .antialiasing_level(aa_level)
+                                            .build())
                          .unwrap();
     window.set_vertical_sync_enabled(true);
 

--- a/examples/pong.rs
+++ b/examples/pong.rs
@@ -3,7 +3,7 @@ extern crate rand;
 
 use sfml::graphics::{CircleShape, Color, Font, RectangleShape, RenderTarget, RenderWindow, Shape,
                      Text, Transformable};
-use sfml::window::{ContextSettingsBuilder, Key, VideoMode, event, window_style};
+use sfml::window::{ContextSettings, Key, VideoMode, event, window_style};
 use sfml::system::{Clock, Time, Vector2f};
 use sfml::audio::{Sound, SoundBuffer, SoundSource};
 use rand::{Rng, thread_rng};
@@ -30,9 +30,8 @@ fn main() {
     let mut window = RenderWindow::new(VideoMode::new_init(game_width, game_height, 32),
                                        "SFML Pong",
                                        window_style::CLOSE,
-                                       &ContextSettingsBuilder::new()
-                                            .antialiasing_level(aa_level)
-                                            .build())
+                                       &ContextSettings::new()
+                                            .antialiasing_level(aa_level))
                          .unwrap();
     window.set_vertical_sync_enabled(true);
 

--- a/examples/pong.rs
+++ b/examples/pong.rs
@@ -3,7 +3,7 @@ extern crate rand;
 
 use sfml::graphics::{CircleShape, Color, Font, RectangleShape, RenderTarget, RenderWindow, Shape,
                      Text, Transformable};
-use sfml::window::{Key, VideoMode, event, window_style};
+use sfml::window::{ContextSettingsBuilder, Key, VideoMode, event, window_style};
 use sfml::system::{Clock, Time, Vector2f};
 use sfml::audio::{Sound, SoundBuffer, SoundSource};
 use rand::{Rng, thread_rng};
@@ -20,7 +20,7 @@ fn main() {
     let mut window = RenderWindow::new(VideoMode::new_init(game_width, game_height, 32),
                                        "SFML Pong",
                                        window_style::CLOSE,
-                                       &Default::default())
+                                       &ContextSettingsBuilder::new().antialiasing_level(8).build())
                          .unwrap();
     window.set_vertical_sync_enabled(true);
 

--- a/src/window/context_settings.rs
+++ b/src/window/context_settings.rs
@@ -42,35 +42,26 @@ pub const CONTEXT_DEBUG: u32 = 1 << 2;
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Copy)]
 pub struct ContextSettings(pub ffi::sfContextSettings);
 
-/// Builder struct for `ContextSettings`
-pub struct ContextSettingsBuilder(pub ContextSettings);
-
-impl ContextSettingsBuilder {
-    /// Creates a new ContextSettingsBuilder.
-    pub fn new() -> ContextSettingsBuilder {
-        ContextSettingsBuilder(ContextSettings(ffi::sfContextSettings {
+impl ContextSettings {
+    /// Creates a new, default ContextSettings.
+    pub fn new() -> ContextSettings {
+        ContextSettings(ffi::sfContextSettings {
             depth_bits: 0,
             stencil_bits: 0,
             antialiasing_level: 0,
             major_version: 2,
             minor_version: 0,
             attribute_flags: CONTEXT_DEFAULT,
-        }))
+        })
     }
 
     /// Modifies `self` to use some specified level of antialiasing.
-    pub fn antialiasing_level(&mut self, level: u32) -> ContextSettingsBuilder {
-        let ContextSettingsBuilder(ContextSettings(ctx)) = *self;
-        return ContextSettingsBuilder(ContextSettings(ffi::sfContextSettings {
+    pub fn antialiasing_level(&mut self, level: u32) -> ContextSettings {
+        let ContextSettings(ctx) = *self;
+        ContextSettings(ffi::sfContextSettings {
             antialiasing_level: level,
             ..ctx
-        }));
-    }
-
-    /// "Finalizes" the `ContextSettings`.
-    pub fn build(&self) -> ContextSettings {
-        let ContextSettingsBuilder(ctx) = *self;
-        ctx
+        })
     }
 }
 

--- a/src/window/context_settings.rs
+++ b/src/window/context_settings.rs
@@ -42,6 +42,38 @@ pub const CONTEXT_DEBUG: u32 = 1 << 2;
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Copy)]
 pub struct ContextSettings(pub ffi::sfContextSettings);
 
+/// Builder struct for `ContextSettings`
+pub struct ContextSettingsBuilder(pub ContextSettings);
+
+impl ContextSettingsBuilder {
+    /// Creates a new ContextSettingsBuilder.
+    pub fn new() -> ContextSettingsBuilder {
+        ContextSettingsBuilder(ContextSettings(ffi::sfContextSettings {
+            depth_bits: 0,
+            stencil_bits: 0,
+            antialiasing_level: 0,
+            major_version: 2,
+            minor_version: 0,
+            attribute_flags: CONTEXT_DEFAULT,
+        }))
+    }
+
+    /// Modifies `self` to use some specified level of antialiasing.
+    pub fn antialiasing_level(&mut self, level: u32) -> ContextSettingsBuilder {
+        let ContextSettingsBuilder(ContextSettings(ctx)) = *self;
+        return ContextSettingsBuilder(ContextSettings(ffi::sfContextSettings {
+            antialiasing_level: level,
+            ..ctx
+        }));
+    }
+
+    /// "Finalizes" the `ContextSettings`.
+    pub fn build(&self) -> ContextSettings {
+        let ContextSettingsBuilder(ctx) = *self;
+        ctx
+    }
+}
+
 /// Create a default ContextSettings
 ///
 /// # Default values:

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -28,7 +28,7 @@
 pub use window::window::Window;
 pub use window::video_mode::VideoMode;
 pub use window::context::Context;
-pub use window::context_settings::{ContextSettings, ContextSettingsBuilder, CONTEXT_DEFAULT, CONTEXT_CORE, CONTEXT_DEBUG};
+pub use window::context_settings::{ContextSettings, CONTEXT_DEFAULT, CONTEXT_CORE, CONTEXT_DEBUG};
 pub use window::window_style::WindowStyle;
 pub use window::keyboard::Key;
 pub use window::mouse::MouseButton;

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -28,7 +28,7 @@
 pub use window::window::Window;
 pub use window::video_mode::VideoMode;
 pub use window::context::Context;
-pub use window::context_settings::{ContextSettings, CONTEXT_DEFAULT, CONTEXT_CORE, CONTEXT_DEBUG};
+pub use window::context_settings::{ContextSettings, ContextSettingsBuilder, CONTEXT_DEFAULT, CONTEXT_CORE, CONTEXT_DEBUG};
 pub use window::window_style::WindowStyle;
 pub use window::keyboard::Key;
 pub use window::mouse::MouseButton;


### PR DESCRIPTION
Here are two pictures, with a pair of modified Pong examples with a ball radius of `30.` and antialiasing levels `0` and `8` respectively.

![Without AA](http://i.imgur.com/waFeIg9.png)

![With 8xAA](http://i.imgur.com/nW8eyWO.png)

I have a low-res monitor, but I think the difference is clearly visible.