### PR TITLE
Add bare implementation of custom sound streams

### DIFF
--- a/examples/custom-sound-stream.rs
+++ b/examples/custom-sound-stream.rs
@@ -39,8 +39,8 @@ impl BitMelody {
 }
 
 fn main() {
-    let stream = BitMelody::new();
-    let mut player = SoundStreamPlayer::new(stream, 1, 44100);
+    let mut stream = BitMelody::new();
+    let mut player = SoundStreamPlayer::new(&mut stream, 1, 44100);
     player.play();
     loop {
         ::std::thread::sleep(::std::time::Duration::from_millis(100));

--- a/examples/custom-sound-stream.rs
+++ b/examples/custom-sound-stream.rs
@@ -1,0 +1,47 @@
+extern crate sfml;
+
+use sfml::audio::{SoundStream, SoundStreamPlayer};
+use sfml::system::Time;
+
+// Melody by ryg - https://youtu.be/tCRPUv8V22o?t=176
+struct BitMelody {
+    buf: [i16; 1024],
+    t: i32,
+}
+
+impl SoundStream for BitMelody {
+    fn get_data(&mut self) -> (&mut [i16], bool) {
+        for buf_sample in self.buf.iter_mut() {
+            self.t = self.t.wrapping_add(1);
+            let t = self.t;
+            let melody = b"36364689";
+            let index = t >> 13 & 7;
+            let note = t * (melody[index as usize] as i32 & 15);
+            let sample = (note / 12 & 128) +
+                         (((((t >> 12) ^ (t >> 12) - 2) % 11 * t) / 4 | t >> 13) & 127);
+            *buf_sample = sample as i16 * 128;
+        }
+        (&mut self.buf[..], true)
+    }
+    fn seek(&mut self, offset: Time) {
+        println!("Seek called with offset {:?}", offset.as_milliseconds());
+    }
+}
+
+impl BitMelody {
+    fn new() -> Self {
+        BitMelody {
+            buf: [0; 1024],
+            t: 0,
+        }
+    }
+}
+
+fn main() {
+    let stream = BitMelody::new();
+    let mut player = SoundStreamPlayer::new(stream, 1, 44100);
+    player.play();
+    loop {
+        ::std::thread::sleep(::std::time::Duration::from_millis(100));
+    }
+}

--- a/examples/custom-sound-stream.rs
+++ b/examples/custom-sound-stream.rs
@@ -5,7 +5,7 @@ use sfml::system::Time;
 
 // Melody by ryg - https://youtu.be/tCRPUv8V22o?t=176
 struct BitMelody {
-    buf: [i16; 1024],
+    buf: [i16; 2048],
     t: i32,
 }
 
@@ -27,12 +27,18 @@ impl SoundStream for BitMelody {
         // Not exactly correct, but meh.
         self.t = offset.as_milliseconds();
     }
+    fn channel_count(&self) -> u32 {
+        1
+    }
+    fn sample_rate(&self) -> u32 {
+        44100
+    }
 }
 
 impl BitMelody {
     fn new() -> Self {
         BitMelody {
-            buf: [0; 1024],
+            buf: [0; 2048],
             t: 0,
         }
     }
@@ -40,7 +46,7 @@ impl BitMelody {
 
 fn main() {
     let mut stream = BitMelody::new();
-    let mut player = SoundStreamPlayer::new(&mut stream, 1, 44100);
+    let mut player = SoundStreamPlayer::new(&mut stream);
     player.play();
     loop {
         ::std::thread::sleep(::std::time::Duration::from_millis(100));

--- a/examples/custom-sound-stream.rs
+++ b/examples/custom-sound-stream.rs
@@ -1,12 +1,13 @@
 extern crate sfml;
 
-use sfml::audio::{SoundStream, SoundStreamPlayer};
+use sfml::audio::{SoundStatus, SoundStream, SoundStreamPlayer};
 use sfml::system::Time;
 
 // Melody by ryg - https://youtu.be/tCRPUv8V22o?t=176
 struct BitMelody {
     buf: [i16; 2048],
     t: i32,
+    amp: i16,
 }
 
 impl SoundStream for BitMelody {
@@ -19,9 +20,13 @@ impl SoundStream for BitMelody {
             let note = t * (melody[index as usize] as i32 & 15);
             let sample = (note / 12 & 128) +
                          (((((t >> 12) ^ (t >> 12) - 2) % 11 * t) / 4 | t >> 13) & 127);
-            *buf_sample = sample as i16 * 128;
+            *buf_sample = sample as i16 * self.amp;
+            // Fade out after a while
+            if t > 1_048_576 && t % 4096 == 0 {
+                self.amp -= 1;
+            }
         }
-        (&mut self.buf[..], true)
+        (&mut self.buf[..], self.amp > 0)
     }
     fn seek(&mut self, offset: Time) {
         // Not exactly correct, but meh.
@@ -40,6 +45,7 @@ impl BitMelody {
         BitMelody {
             buf: [0; 2048],
             t: 0,
+            amp: 128,
         }
     }
 }
@@ -48,7 +54,7 @@ fn main() {
     let mut stream = BitMelody::new();
     let mut player = SoundStreamPlayer::new(&mut stream);
     player.play();
-    loop {
+    while player.get_status() == SoundStatus::Playing {
         ::std::thread::sleep(::std::time::Duration::from_millis(100));
     }
 }

--- a/examples/custom-sound-stream.rs
+++ b/examples/custom-sound-stream.rs
@@ -24,7 +24,8 @@ impl SoundStream for BitMelody {
         (&mut self.buf[..], true)
     }
     fn seek(&mut self, offset: Time) {
-        println!("Seek called with offset {:?}", offset.as_milliseconds());
+        // Not exactly correct, but meh.
+        self.t = offset.as_milliseconds();
     }
 }
 

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -32,6 +32,7 @@ pub use audio::music::Music;
 pub use audio::sound::Sound;
 pub use audio::sound_buffer_recorder::SoundBufferRecorder;
 pub use audio::sound_source::SoundSource;
+pub use audio::sound_stream::{SoundStream, SoundStreamPlayer};
 
 /// Sound implementation using reference counting to manage shared resources
 pub mod rc {
@@ -45,3 +46,4 @@ mod sound_status;
 mod music;
 mod sound;
 mod sound_buffer_recorder;
+mod sound_stream;

--- a/src/audio/sound_stream.rs
+++ b/src/audio/sound_stream.rs
@@ -97,6 +97,9 @@ impl<'a, S: SoundStream> SoundStreamPlayer<'a, S> {
 impl<'a, S: SoundStream> Drop for SoundStreamPlayer<'a, S> {
     fn drop(&mut self) {
         unsafe {
+            // It seems there can be problems (e.g. "pure virtual method called") if the
+            // stream is not stopped before it's destroyed. So let's make sure it's stopped.
+            sfSoundStream_stop(self.sf_sound_stream);
             sfSoundStream_destroy(self.sf_sound_stream);
         }
     }

--- a/src/audio/sound_stream.rs
+++ b/src/audio/sound_stream.rs
@@ -1,0 +1,81 @@
+use csfml_audio_sys::*;
+use csfml_system_sys::*;
+use ext::sf_bool_ext::SfBoolExt;
+use raw_conv::FromRaw;
+use system::Time;
+use std::panic;
+
+/// Trait for streamed audio sources.
+pub trait SoundStream {
+    /// Request a new chunk of audio samples from the stream source.
+    ///
+    /// Returns (`chunk`, `keep_playing`), where `chunk` is the chunk of audio samples,
+    /// and `keep_playing` tells the streaming loop whether to keep playing or to stop.
+    fn get_data(&mut self) -> (&mut [i16], bool);
+    /// Change the current playing position in the stream source.
+    fn seek(&mut self, offset: Time);
+}
+
+/// Player for custom streamed audio sources. See `SoundStream`.
+pub struct SoundStreamPlayer<S: SoundStream> {
+    _sound_stream: Box<S>,
+    sf_sound_stream: *mut sfSoundStream,
+}
+
+unsafe extern "C" fn get_data_callback<S: SoundStream>(chunk: *mut sfSoundStreamChunk,
+                                                       stream: *mut S)
+                                                       -> sfBool {
+    let (data, keep_playing) = match panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        (*stream).get_data()
+    })) {
+        Ok(ret) => ret,
+        Err(_) => {
+            use std::io::Write;
+            let _ = writeln!(::std::io::stderr(),
+                             "sound_stream: Stopping playback beacuse get_data_callback panicked.");
+            (&mut [][..], false)
+        }
+    };
+    (*chunk).samples = data.as_mut_ptr();
+    (*chunk).sampleCount = data.len() as u32;
+    sfBool::from_bool(keep_playing)
+}
+
+unsafe extern "C" fn seek_callback<S: SoundStream>(offset: sfTime, stream: *mut S) {
+    (*stream).seek(Time::from_raw(offset));
+}
+
+impl<S: SoundStream> SoundStreamPlayer<S> {
+    /// Create a new `SoundStreamPlayer` with the specified `SoundStream`.
+    pub fn new(sound_stream: S, channels: u32, sample_rate: u32) -> Self {
+        let mut boxed_sound_stream = Box::new(sound_stream);
+        let sound_stream_ptr: *mut SoundStream = &mut *boxed_sound_stream;
+        let get_data_callback =
+            get_data_callback::<S> as unsafe extern "C" fn(*mut sfSoundStreamChunk, *mut S) -> sfBool;
+        let seek_callback = seek_callback::<S> as unsafe extern "C" fn(sfTime, *mut S);
+        SoundStreamPlayer {
+            _sound_stream: boxed_sound_stream,
+            sf_sound_stream: unsafe {
+                sfSoundStream_create(Some(::std::mem::transmute(get_data_callback)),
+                                     Some(::std::mem::transmute(seek_callback)),
+                                     channels, // channel count
+                                     sample_rate, // sample rate
+                                     sound_stream_ptr as *mut _)
+            },
+        }
+    }
+    /// Start or resume playing the audio stream.
+    pub fn play(&mut self) {
+        unsafe {
+            sfSoundStream_play(self.sf_sound_stream);
+        }
+    }
+}
+
+impl<S: SoundStream> Drop for SoundStreamPlayer<S> {
+    fn drop(&mut self) {
+        unsafe {
+            sfSoundStream_destroy(self.sf_sound_stream);
+        }
+    }
+}

--- a/src/audio/sound_stream.rs
+++ b/src/audio/sound_stream.rs
@@ -79,6 +79,15 @@ impl<'a, S: SoundStream> SoundStreamPlayer<'a, S> {
     pub fn get_status(&self) -> SoundStatus {
         unsafe { ::std::mem::transmute(sfSoundStream_getStatus(self.sf_sound_stream)) }
     }
+    /// Stop playing the audio stream.
+    ///
+    /// This function stops the stream if it was playing or paused, and does nothing if it was
+    /// already stopped. It also resets the playing position (unlike pause()).
+    pub fn stop(&mut self) {
+        unsafe {
+            sfSoundStream_stop(self.sf_sound_stream);
+        }
+    }
 }
 
 impl<'a, S: SoundStream> Drop for SoundStreamPlayer<'a, S> {

--- a/src/audio/sound_stream.rs
+++ b/src/audio/sound_stream.rs
@@ -5,6 +5,7 @@ use raw_conv::FromRaw;
 use system::Time;
 use std::panic;
 use std::marker::PhantomData;
+use audio::SoundStatus;
 
 /// Trait for streamed audio sources.
 pub trait SoundStream {
@@ -73,6 +74,10 @@ impl<'a, S: SoundStream> SoundStreamPlayer<'a, S> {
         unsafe {
             sfSoundStream_play(self.sf_sound_stream);
         }
+    }
+    /// Get the current status of the stream (stopped, paused, playing)
+    pub fn get_status(&self) -> SoundStatus {
+        unsafe { ::std::mem::transmute(sfSoundStream_getStatus(self.sf_sound_stream)) }
     }
 }
 


### PR DESCRIPTION
In the original API, this is done by deriving `sf::SoundStream`.

For now, only the minimum required for the included example is implemented.

Oh yeah, this would also bump our **Rust** requirement to **1.9.0**, because  of `panic::catch_unwind`, which is required to make sure panic triggered in user code doesn't unwind across FFI boundaries.