### PR TITLE
Adds commutativity to operators +, -, *, /

### DIFF
--- a/src/system/vector2.rs
+++ b/src/system/vector2.rs
@@ -1,31 +1,30 @@
-/*
-* Rust-SFML - Copyright (c) 2013 Letang Jeremy.
-*
-* The original software, SFML library, is provided by Laurent Gomila.
-*
-* This software is provided 'as-is', without any express or implied warranty.
-* In no event will the authors be held liable for any damages arising from
-* the use of this software.
-*
-* Permission is granted to anyone to use this software for any purpose,
-* including commercial applications, and to alter it and redistribute it
-* freely, subject to the following restrictions:
-*
-* 1. The origin of this software must not be misrepresented; you must not claim
-*    that you wrote the original software. If you use this software in a product,
-*    an acknowledgment in the product documentation would be appreciated but is
-*    not required.
-*
-* 2. Altered source versions must be plainly marked as such, and must not be
-*    misrepresented as being the original software.
-*
-* 3. This notice may not be removed or altered from any source distribution.
-*/
+// Rust-SFML - Copyright (c) 2013 Letang Jeremy.
+//
+// The original software, SFML library, is provided by Laurent Gomila.
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from
+// the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not claim
+//    that you wrote the original software. If you use this software in a product,
+//    an acknowledgment in the product documentation would be appreciated but is
+//    not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
 
 //! Utility Class providing 2 dimensional vectors for i32, u32, and f32.
 
-use std::ops::{Add, Sub, Mul, Div};
-use raw_conv::{Raw, FromRaw};
+use std::ops::{Add, Div, Mul, Sub};
+use raw_conv::{FromRaw, Raw};
 
 /// Implementation of Vector2i
 #[repr(C)]
@@ -34,7 +33,7 @@ pub struct Vector2<T> {
     /// X coordinate of the vector.
     pub x: T,
     /// Y coordinate of the vector.
-    pub y: T
+    pub y: T,
 }
 
 /// export Vector2<i32> as Vector2i
@@ -47,57 +46,42 @@ pub type Vector2f = Vector2<f32>;
 impl<T> Vector2<T> {
     /// Build a new Vector2<T>
     pub fn new(x: T, y: T) -> Vector2<T> {
-        Vector2 {
-            x: x,
-            y: y
-        }
+        Vector2 { x: x, y: y }
     }
 }
 
-impl<T: Add + Copy> Add<T> for Vector2<T> {
-    type Output = Vector2<T::Output>;
+macro_rules! impl_ops {
+    ( $_trait:ident, $_func:ident, $( $_type:ty ),+ ) => {
+        impl<T: $_trait + Copy> $_trait<T> for Vector2<T> {
+            type Output = Vector2<T::Output>;
 
-    fn add(self, rhs: T) -> Vector2<T::Output> {
-        Vector2 {
-            x: self.x + rhs,
-            y: self.y + rhs
+            fn $_func(self, rhs: T) -> Vector2<T::Output> {
+                Vector2 {
+                    x: $_trait::$_func(self.x, rhs),
+                    y: $_trait::$_func(self.y, rhs)
+                }
+            }
         }
+
+        $(
+            impl $_trait<Vector2<$_type>> for $_type {
+                type Output = Vector2<$_type>;
+
+                fn $_func(self, rhs: Vector2<$_type>) -> Vector2<$_type> {
+                    Vector2 {
+                        x: $_trait::$_func(self, rhs.x),
+                        y: $_trait::$_func(self, rhs.y)
+                    }
+                }
+            }
+        )+
     }
 }
 
-impl<T: Sub + Copy> Sub<T> for Vector2<T> {
-    type Output = Vector2<T::Output>;
-
-    fn sub(self, rhs: T) -> Vector2<T::Output> {
-        Vector2 {
-            x: self.x - rhs,
-            y: self.y - rhs
-        }
-    }
-}
-
-impl<T: Mul + Copy> Mul<T> for Vector2<T> {
-    type Output = Vector2<T::Output>;
-
-    fn mul(self, rhs: T) -> Vector2<T::Output> {
-        Vector2 {
-            x: self.x * rhs,
-            y: self.y * rhs
-        }
-    }
-}
-
-impl<T: Div + Copy> Div<T> for Vector2<T> {
-    type Output = Vector2<T::Output>;
-
-    fn div(self, rhs: T) -> Vector2<T::Output> {
-        Vector2 {
-            x: self.x / rhs,
-            y: self.y / rhs
-        }
-    }
-}
-
+impl_ops!(Add, add, i32, u32, f32);
+impl_ops!(Sub, sub, i32, u32, f32);
+impl_ops!(Mul, mul, i32, u32, f32);
+impl_ops!(Div, div, i32, u32, f32);
 
 impl<T: Add> Add for Vector2<T> {
     type Output = Vector2<T::Output>;
@@ -105,7 +89,7 @@ impl<T: Add> Add for Vector2<T> {
     fn add(self, rhs: Vector2<T>) -> Vector2<T::Output> {
         Vector2 {
             x: self.x + rhs.x,
-            y: self.y + rhs.y
+            y: self.y + rhs.y,
         }
     }
 }
@@ -116,7 +100,7 @@ impl<T: Sub> Sub for Vector2<T> {
     fn sub(self, rhs: Vector2<T>) -> Vector2<T::Output> {
         Vector2 {
             x: self.x - rhs.x,
-            y: self.y - rhs.y
+            y: self.y - rhs.y,
         }
     }
 }
@@ -127,7 +111,7 @@ impl<T: Mul> Mul for Vector2<T> {
     fn mul(self, rhs: Vector2<T>) -> Vector2<T::Output> {
         Vector2 {
             x: self.x * rhs.x,
-            y: self.y * rhs.y
+            y: self.y * rhs.y,
         }
     }
 }
@@ -138,7 +122,7 @@ impl<T: Div> Div for Vector2<T> {
     fn div(self, rhs: Vector2<T>) -> Vector2<T::Output> {
         Vector2 {
             x: self.x / rhs.x,
-            y: self.y / rhs.y
+            y: self.y / rhs.y,
         }
     }
 }
@@ -162,14 +146,14 @@ impl ToVec for Vector2f {
     fn to_vector2i(&self) -> Vector2i {
         Vector2i {
             x: self.x as i32,
-            y: self.y as i32
+            y: self.y as i32,
         }
     }
 
     fn to_vector2u(&self) -> Vector2u {
         Vector2u {
             x: self.x as u32,
-            y: self.y as u32
+            y: self.y as u32,
         }
     }
 }
@@ -178,18 +162,18 @@ impl ToVec for Vector2i {
     fn to_vector2f(&self) -> Vector2f {
         Vector2f {
             x: self.x as f32,
-            y: self.y as f32
+            y: self.y as f32,
         }
     }
 
     fn to_vector2i(&self) -> Vector2i {
-         *self
+        *self
     }
 
     fn to_vector2u(&self) -> Vector2u {
         Vector2u {
             x: self.x as u32,
-            y: self.y as u32
+            y: self.y as u32,
         }
     }
 }
@@ -198,14 +182,14 @@ impl ToVec for Vector2u {
     fn to_vector2f(&self) -> Vector2f {
         Vector2f {
             x: self.x as f32,
-            y: self.y as f32
+            y: self.y as f32,
         }
     }
 
     fn to_vector2i(&self) -> Vector2i {
         Vector2i {
             x: self.x as i32,
-            y: self.y as i32
+            y: self.y as i32,
         }
     }
 

--- a/src/system/vector3.rs
+++ b/src/system/vector3.rs
@@ -57,53 +57,40 @@ pub type Vector3i = Vector3<i32>;
 /// export Vector3<u32> as Vector3u
 pub type Vector3u = Vector3<u32>;
 
-impl<T: Add + Copy> Add<T> for Vector3<T> {
-    type Output = Vector3<T::Output>;
+macro_rules! impl_ops {
+    ( $_trait:ident, $_func:ident, $( $_type:ty ),+ ) => {
+        impl<T: $_trait + Copy> $_trait<T> for Vector3<T> {
+            type Output = Vector3<T::Output>;
 
-    fn add(self, rhs: T) -> Vector3<T::Output> {
-        Vector3 {
-            x: self.x + rhs,
-            y: self.y + rhs,
-            z: self.z + rhs
+            fn $_func(self, rhs: T) -> Vector3<T::Output> {
+                Vector3 {
+                    x: $_trait::$_func(self.x, rhs),
+                    y: $_trait::$_func(self.y, rhs),
+                    z: $_trait::$_func(self.z, rhs)
+                }
+            }
         }
+
+        $(
+            impl $_trait<Vector3<$_type>> for $_type {
+                type Output = Vector3<$_type>;
+
+                fn $_func(self, rhs: Vector3<$_type>) -> Vector3<$_type> {
+                    Vector3 {
+                        x: $_trait::$_func(self, rhs.x),
+                        y: $_trait::$_func(self, rhs.y),
+                        z: $_trait::$_func(self, rhs.z)
+                    }
+                }
+            }
+        )+
     }
 }
 
-impl<T: Sub + Copy> Sub<T> for Vector3<T> {
-    type Output = Vector3<T::Output>;
-
-    fn sub(self, rhs: T) -> Vector3<T::Output> {
-        Vector3 {
-            x: self.x - rhs,
-            y: self.y - rhs,
-            z: self.z - rhs
-        }
-    }
-}
-
-impl<T: Mul + Copy> Mul<T> for Vector3<T> {
-    type Output = Vector3<T::Output>;
-
-    fn mul(self, rhs: T) -> Vector3<T::Output> {
-        Vector3 {
-            x: self.x * rhs,
-            y: self.y * rhs,
-            z: self.z * rhs
-        }
-    }
-}
-
-impl<T: Div + Copy> Div<T> for Vector3<T> {
-    type Output = Vector3<T::Output>;
-
-    fn div(self, rhs: T) -> Vector3<T::Output> {
-        Vector3 {
-            x: self.x / rhs,
-            y: self.y / rhs,
-            z: self.z / rhs
-        }
-    }
-}
+impl_ops!(Add, add, i32, u32, f32);
+impl_ops!(Sub, sub, i32, u32, f32);
+impl_ops!(Mul, mul, i32, u32, f32);
+impl_ops!(Div, div, i32, u32, f32);
 
 
 impl<T: Add> Add for Vector3<T> {
@@ -153,6 +140,7 @@ impl<T: Div> Div for Vector3<T> {
         }
     }
 }
+
 
 impl Raw for Vector3f {
     type Raw = ::csfml_system_sys::sfVector3f;


### PR DESCRIPTION
Previously, one could write e.g. `v * 3` but not `3 * v`, where `v` is a Vector2<T> or a Vector3<T>. This commit adds implementations of Add, Sub, Mul, and Div for i32, u32, and f32 upon their respective Vectors, to allow either expression to work.

We can only add implementations of these traits for certain types, due to the restrictions on traits imposed by the language. We still can't, therefore, write `i * v` where `i` is an arbitrary type, even if `i` implements `Mul`. But this commit will at least allow this expression for the six types (Vector[23][uif]) used by the library.

