### PR TITLE
link sfml

### DIFF
--- a/build_sys_common.rs
+++ b/build_sys_common.rs
@@ -19,4 +19,5 @@ pub fn link_csfml(lib: &str) {
 
     // link it
     println!("cargo:rustc-link-lib=csfml-{}", lib);
+    println!("cargo:rustc-link-lib=sfml-{}", lib);
 }


### PR DESCRIPTION
On my linux, also linking sfml is necessary (csfml is just a binding).