### PR TITLE
Make RenderTarget and Drawable traits object-safe

### DIFF
--- a/examples/custom-drawable.rs
+++ b/examples/custom-drawable.rs
@@ -32,7 +32,7 @@ impl<'s> Bullet<'s> {
 
 // Implement the Drawable trait for our custom drawable.
 impl<'s> Drawable for Bullet<'s> {
-    fn draw<RT: RenderTarget>(&self, render_target: &mut RT, _: &mut RenderStates) {
+    fn draw(&self, render_target: &mut RenderTarget, _: &mut RenderStates) {
         render_target.draw(&self.head);
         render_target.draw(&self.torso)
     }

--- a/src/graphics/circle_shape.rs
+++ b/src/graphics/circle_shape.rs
@@ -132,7 +132,7 @@ impl<'s> Default for CircleShape<'s> {
 }
 
 impl<'s> Drawable for CircleShape<'s> {
-    fn draw<RT: RenderTarget>(&self, render_target: &mut RT, render_states: &mut RenderStates) {
+    fn draw(&self, render_target: &mut RenderTarget, render_states: &mut RenderStates) {
         render_target.draw_circle_shape(self, render_states)
     }
 }

--- a/src/graphics/convex_shape.rs
+++ b/src/graphics/convex_shape.rs
@@ -129,7 +129,7 @@ impl<'s> ConvexShape<'s> {
 }
 
 impl<'s> Drawable for ConvexShape<'s> {
-    fn draw<RT: RenderTarget>(&self, render_target: &mut RT, render_states: &mut RenderStates) {
+    fn draw(&self, render_target: &mut RenderTarget, render_states: &mut RenderStates) {
         render_target.draw_convex_shape(self, render_states)
     }
 }

--- a/src/graphics/custom_shape.rs
+++ b/src/graphics/custom_shape.rs
@@ -287,7 +287,7 @@ impl<'s> Raw for CustomShape<'s> {
 }
 
 impl<'s> Drawable for CustomShape<'s> {
-    fn draw<RT: RenderTarget>(&self, render_target: &mut RT, render_states: &mut RenderStates) {
+    fn draw(&self, render_target: &mut RenderTarget, render_states: &mut RenderStates) {
         render_target.draw_shape(self, render_states)
     }
 }

--- a/src/graphics/drawable.rs
+++ b/src/graphics/drawable.rs
@@ -31,5 +31,5 @@ use graphics::{RenderStates, RenderTarget};
 /// The trait drawable is inherited by each object who can be drawn in a `RenderTarget`
 pub trait Drawable {
     /// Draw a drawable object into a `RenderTarget`
-    fn draw<RT: RenderTarget>(&self, target: &mut RT, rs: &mut RenderStates);
+    fn draw(&self, target: &mut RenderTarget, rs: &mut RenderStates);
 }

--- a/src/graphics/rectangle_shape.rs
+++ b/src/graphics/rectangle_shape.rs
@@ -125,7 +125,7 @@ impl<'s> Default for RectangleShape<'s> {
 }
 
 impl<'s> Drawable for RectangleShape<'s> {
-    fn draw<RT: RenderTarget>(&self, render_target: &mut RT, render_states: &mut RenderStates) {
+    fn draw(&self, render_target: &mut RenderTarget, render_states: &mut RenderStates) {
         render_target.draw_rectangle_shape(self, render_states);
     }
 }

--- a/src/graphics/render_target.rs
+++ b/src/graphics/render_target.rs
@@ -155,16 +155,16 @@ pub trait RenderTarget {
     ///
     /// # Arguments
     /// * object - Object to draw
-    fn draw<T: Drawable>(&mut self, object: &T);
+    fn draw(&mut self, object: &Drawable);
 
     /// Draw a drawable object to the render-target with a RenderStates
     ///
     /// # Arguments
     /// * object - Object to draw
     /// * renderStates - The renderStates to associate to the object
-    fn draw_with_renderstates<T: Drawable>(&mut self,
-                                           object: &T,
-                                           render_states: &mut RenderStates);
+    fn draw_with_renderstates(&mut self,
+                              object: &Drawable,
+                              render_states: &mut RenderStates);
 
     /// Get the size of the rendering region of a window
     ///

--- a/src/graphics/render_texture.rs
+++ b/src/graphics/render_texture.rs
@@ -277,7 +277,7 @@ impl RenderTarget for RenderTexture {
     ///
     /// # Arguments
     /// * object - Object to draw
-    fn draw<T: Drawable>(&mut self, object: &T) {
+    fn draw(&mut self, object: &Drawable) {
         object.draw(self, &mut RenderStates::default());
     }
 
@@ -286,9 +286,9 @@ impl RenderTarget for RenderTexture {
     /// # Arguments
     /// * object - Object to draw
     /// * renderStates - The RenderStates to associate to the object
-    fn draw_with_renderstates<T: Drawable>(&mut self,
-                                           object: &T,
-                                           render_states: &mut RenderStates) {
+    fn draw_with_renderstates(&mut self,
+                              object: &Drawable,
+                              render_states: &mut RenderStates) {
         object.draw(self, render_states);
     }
 

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -685,7 +685,7 @@ impl RenderTarget for RenderWindow {
     ///
     /// # Arguments
     /// * object - Object to draw
-    fn draw<T: Drawable>(&mut self, object: &T) {
+    fn draw(&mut self, object: &Drawable) {
         object.draw(self, &mut RenderStates::default());
     }
 
@@ -694,9 +694,9 @@ impl RenderTarget for RenderWindow {
     /// # Arguments
     /// * object - Object to draw
     /// * renderStates - The renderStates to associate to the object
-    fn draw_with_renderstates<T: Drawable>(&mut self,
-                                           object: &T,
-                                           render_states: &mut RenderStates) {
+    fn draw_with_renderstates(&mut self,
+                              object: &Drawable,
+                              render_states: &mut RenderStates) {
         object.draw(self, render_states);
     }
 

--- a/src/graphics/sprite.rs
+++ b/src/graphics/sprite.rs
@@ -215,7 +215,7 @@ impl<'s> Clone for Sprite<'s> {
 }
 
 impl<'s> Drawable for Sprite<'s> {
-    fn draw<RT: RenderTarget>(&self, render_target: &mut RT, render_states: &mut RenderStates) {
+    fn draw(&self, render_target: &mut RenderTarget, render_states: &mut RenderStates) {
         render_target.draw_sprite(self, render_states)
     }
 }

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -245,7 +245,7 @@ impl<'s> Clone for Text<'s> {
 }
 
 impl<'s> Drawable for Text<'s> {
-    fn draw<RT: RenderTarget>(&self, render_target: &mut RT, render_states: &mut RenderStates) {
+    fn draw(&self, render_target: &mut RenderTarget, render_states: &mut RenderStates) {
         render_target.draw_text(self, render_states)
     }
 }

--- a/src/graphics/vertex_array.rs
+++ b/src/graphics/vertex_array.rs
@@ -247,7 +247,7 @@ impl Raw for VertexArray {
 }
 
 impl Drawable for VertexArray {
-    fn draw<RT: RenderTarget>(&self, render_target: &mut RT, render_states: &mut RenderStates) {
+    fn draw(&self, render_target: &mut RenderTarget, render_states: &mut RenderStates) {
         render_target.draw_vertex_array(self, render_states)
     }
 }


### PR DESCRIPTION
Hi! I think object-safe traits are preferable, but my Rust is a little rusty. Let me know if there's any cleanup needed or if you don't think this change is a good idea. :)