### PR TITLE
Make the different modules optional using Cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,17 @@ repository = "https://github.com/jeremyletang/rust-sfml"
 license = "zlib-acknowledgement"
 
 [features]
+default = ["graphics", "audio", "network"]
 # Used for conditonally setting clippy lint levels.
 # Run cargo clippy with `cargo clippy --features=clippy`.
 clippy = []
+window = ["csfml-window-sys", "bitflags"]
+graphics = ["window", "csfml-graphics-sys"]
+audio = ["csfml-audio-sys"]
+network = ["csfml-network-sys"]
 
 [dependencies]
-bitflags = "0.5"
+bitflags = {version = "0.5", optional = true }
 
 [dependencies.csfml-system-sys]
 path = "csfml-system-sys"
@@ -23,18 +28,22 @@ version = "0.1.0"
 [dependencies.csfml-window-sys]
 path = "csfml-window-sys"
 version = "0.1.0"
+optional = true
 
 [dependencies.csfml-graphics-sys]
 path = "csfml-graphics-sys"
 version = "0.1.0"
+optional = true
 
 [dependencies.csfml-audio-sys]
 path = "csfml-audio-sys"
 version = "0.1.0"
+optional = true
 
 [dependencies.csfml-network-sys]
 path = "csfml-network-sys"
 version = "0.1.0"
+optional = true
 
 [dev-dependencies]
 rand = "0.3"
@@ -42,5 +51,49 @@ rand = "0.3"
 [lib]
 name = "sfml"
 crate-type = ["dylib", "rlib"]
+
+[[example]]
+name = "borrowed-resources"
+required-features = ["graphics"]
+
+[[example]]
+name = "custom-drawable"
+required-features = ["graphics"]
+
+[[example]]
+name = "custom-shape"
+required-features = ["graphics"]
+
+[[example]]
+name = "custom-sound-stream"
+required-features = ["audio"]
+
+[[example]]
+name = "mouse"
+required-features = ["graphics"]
+
+[[example]]
+name = "music-stream"
+required-features = ["audio"]
+
+[[example]]
+name = "pong"
+required-features = ["graphics", "audio"]
+
+[[example]]
+name = "sound-capture"
+required-features = ["audio"]
+
+[[example]]
+name = "sound"
+required-features = ["audio"]
+
+[[example]]
+name = "unicode-text-entry"
+required-features = ["graphics"]
+
+[[example]]
+name = "vertex-arrays"
+required-features = ["graphics"]
 
 [workspace]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //!
 //! Here is a short example, draw a circle shape and display it.
 //!
-//! ```no_run
+//! ```ignore
 //! extern crate sfml;
 //!
 //! use sfml::system::Vector2f;
@@ -90,23 +90,35 @@
 
 #![warn(missing_docs)]
 
+#[cfg(feature="window")]
 #[macro_use]
 extern crate bitflags;
 extern crate csfml_system_sys;
+#[cfg(feature="window")]
 extern crate csfml_window_sys;
+#[cfg(feature="graphics")]
 extern crate csfml_graphics_sys;
+#[cfg(feature="audio")]
 extern crate csfml_audio_sys;
+#[cfg(feature="network")]
 extern crate csfml_network_sys;
 
+#[cfg(any(feature="graphics", feature="audio"))]
 mod inputstream;
 mod ext {
+    #[cfg(feature="window")]
     pub mod event;
     pub mod sf_bool_ext;
 }
+#[cfg(feature="window")]
 mod unicode_conv;
 
 pub mod system;
+#[cfg(feature="window")]
 pub mod window;
+#[cfg(feature="audio")]
 pub mod audio;
+#[cfg(feature="graphics")]
 pub mod graphics;
+#[cfg(feature="network")]
 pub mod network;

--- a/src/network/ip_address.rs
+++ b/src/network/ip_address.rs
@@ -157,3 +157,9 @@ impl FromRaw for IpAddress {
         IpAddress { ip: raw }
     }
 }
+
+#[test]
+fn ip_to_string() {
+    let ip = IpAddress::from_integer(101010);
+    assert_eq!(ip.to_string(), "0.1.138.146");
+}

--- a/src/system/sf_bool.rs
+++ b/src/system/sf_bool.rs
@@ -8,7 +8,7 @@ use csfml_system_sys::{sfBool, sfTrue, sfFalse};
 /// between the two types.
 ///
 /// # Example
-/// ```
+/// ```ignore
 /// use sfml::window::ContextSettings;
 /// let mut context_settings = ContextSettings::default();
 /// // We can't use `true` directly, but we can use the `.into()` method.

--- a/src/window/event.rs
+++ b/src/window/event.rs
@@ -39,12 +39,11 @@ use window::joystick::Axis;
 /// # Usage example
 ///
 /// ```
-/// # use sfml::graphics::RenderWindow;
-/// # use sfml::window::{Event, VideoMode, style, Key};
-/// # let mut window = RenderWindow::new(VideoMode::new(32, 32, 32),
-/// #                                    "test",
-/// #                                    style::CLOSE,
-/// #                                    &Default::default()).unwrap();
+/// # use sfml::window::{Event, VideoMode, style, Key, Window};
+/// # let mut window = Window::new(VideoMode::new(32, 32, 32),
+/// #                              "test",
+/// #                              style::CLOSE,
+/// #                              &Default::default()).unwrap();
 /// # fn do_something_with_the_new_size(_x: u32, _y: u32) {}
 /// while let Some(event) = window.poll_event() {
 ///     match event {

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -1,8 +1,0 @@
-extern crate sfml;
-use self::sfml::network::IpAddress;
-
-#[test]
-fn ip_to_string() {
-    let ip = IpAddress::from_integer(101010);
-    assert_eq!(ip.to_string(), "0.1.138.146");
-}


### PR DESCRIPTION
This enables users to only link to the SFML libraries that they are using.

Alternative to #159.

By default, all modules are enabled, but the user can opt-out with `default-features = false`.