### PR TITLE
[WIP] Add SoundRecorder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,10 @@ name = "custom-shape"
 required-features = ["graphics"]
 
 [[example]]
+name = "custom-sound-recorder"
+required-features = ["audio"]
+
+[[example]]
 name = "custom-sound-stream"
 required-features = ["audio"]
 

--- a/examples/custom-sound-recorder.rs
+++ b/examples/custom-sound-recorder.rs
@@ -1,0 +1,26 @@
+extern crate sfml;
+
+use std::{thread, time};
+use sfml::audio::SoundRecorder;
+
+fn main(){
+
+    let sr = SoundRecorder::new(
+        || {
+            println!("Recording started!");
+            true
+        },
+        |_| {
+            println!("Samples received!");
+            true
+        },
+        || {
+            println!("Recording stopped!");
+        }
+    );
+
+    sr.start(44100);
+    thread::sleep(time::Duration::from_secs(3));
+    sr.stop();
+
+}

--- a/examples/custom-sound-recorder.rs
+++ b/examples/custom-sound-recorder.rs
@@ -5,7 +5,7 @@ use sfml::audio::SoundRecorder;
 
 fn main(){
 
-    let sr = SoundRecorder::new(
+    let mut sr = SoundRecorder::new(
         || {
             println!("Recording started!");
             true

--- a/examples/custom-sound-recorder.rs
+++ b/examples/custom-sound-recorder.rs
@@ -10,8 +10,8 @@ fn main(){
             println!("Recording started!");
             true
         },
-        |_| {
-            println!("Samples received!");
+        |samples| {
+            println!("Samples received! {}", samples.len());
             true
         },
         || {
@@ -19,6 +19,7 @@ fn main(){
         }
     );
 
+    sr.set_processing_interval(time::Duration::from_millis(10));
     sr.start(44100);
     thread::sleep(time::Duration::from_secs(3));
     sr.stop();

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -6,10 +6,14 @@ extern crate csfml_audio_sys;
 pub use self::music::Music;
 pub use self::sound::Sound;
 pub use self::sound_buffer::{SoundBuffer, SoundBufferRef};
+pub use self::sound_recorder::SoundRecorder;
 pub use self::sound_buffer_recorder::SoundBufferRecorder;
 pub use self::sound_source::SoundSource;
 pub use self::sound_status::SoundStatus;
 pub use self::sound_stream::{SoundStream, SoundStreamPlayer};
+
+#[derive(Debug, Clone, Copy)]
+pub struct SetDeviceError;
 
 mod sound_buffer;
 mod sound_source;
@@ -17,5 +21,6 @@ pub mod listener;
 mod sound_status;
 mod music;
 mod sound;
+mod sound_recorder;
 mod sound_buffer_recorder;
 mod sound_stream;

--- a/src/audio/sound_buffer_recorder.rs
+++ b/src/audio/sound_buffer_recorder.rs
@@ -3,6 +3,7 @@ use audio::sound_buffer::SoundBufferRef;
 use csfml_system_sys::*;
 use sf_bool_ext::SfBoolExt;
 use std::ffi::{CStr, CString};
+use super::SetDeviceError;
 
 /// Store captured audio data in sound Buffer
 ///
@@ -12,9 +13,6 @@ use std::ffi::{CStr, CString};
 pub struct SoundBufferRecorder {
     sound_buffer_recorder: *mut ffi::sfSoundBufferRecorder,
 }
-
-#[derive(Debug, Clone, Copy)]
-pub struct SetDeviceError;
 
 impl SoundBufferRecorder {
     /// Create a new sound buffer recorder

--- a/src/audio/sound_recorder.rs
+++ b/src/audio/sound_recorder.rs
@@ -1,0 +1,81 @@
+use audio::csfml_audio_sys::*;
+use csfml_system_sys::*;
+use sf_bool_ext::SfBoolExt;
+
+use super::SetDeviceError;
+
+use std::ffi::{CString};
+use std::ptr;
+use std::os::raw::c_void;
+use std::slice;
+
+pub struct SoundRecorder<T1: Fn() -> bool, T2: Fn(&[i16]) -> bool, T3: Fn()> {
+    sf_sound_recorder: *mut sfSoundRecorder,
+    on_start: T1,
+    on_data: T2,
+    on_stop: T3
+}
+
+unsafe extern "C"
+fn sound_recorder_on_start<T1: Fn() -> bool, T2: Fn(&[i16]) -> bool, T3: Fn()>(arg: *mut c_void) -> sfBool {
+    let sr = arg as *mut SoundRecorder<T1, T2, T3>;
+    let ref cb = (*sr).on_start;
+    sfBool::from_bool(cb())
+}
+
+unsafe extern "C"
+fn sound_recorder_on_data<T1: Fn() -> bool, T2: Fn(&[i16]) -> bool, T3: Fn()>(samples: *const sfInt16, len: usize, arg: *mut c_void) -> sfBool {
+    let sr = arg as *mut SoundRecorder<T1, T2, T3>;
+    let ref cb = (*sr).on_data;
+    let sample_slice = slice::from_raw_parts(samples, len);
+    sfBool::from_bool(cb(sample_slice))
+}
+
+unsafe extern "C"
+fn sound_recorder_on_stop<T1: Fn() -> bool, T2: Fn(&[i16]) -> bool, T3: Fn()>(arg: *mut c_void) {
+    let sr = arg as *mut SoundRecorder<T1, T2, T3>;
+    let ref cb = (*sr).on_stop;
+    cb();
+}
+
+impl<T1: Fn() -> bool, T2: Fn(&[i16]) -> bool, T3: Fn()> SoundRecorder<T1, T2, T3> {
+
+    pub fn new(on_start: T1, on_data: T2, on_stop: T3) -> SoundRecorder<T1, T2, T3> {
+        SoundRecorder{
+            sf_sound_recorder: unsafe {
+            sfSoundRecorder_create(
+                Some(sound_recorder_on_start::<T1, T2, T3>),
+                Some(sound_recorder_on_data::<T1, T2, T3>),
+                Some(sound_recorder_on_stop::<T1, T2, T3>),
+                ptr::null_mut()
+            )
+        }, on_start, on_data, on_stop }
+    }
+
+    pub fn start(&self, sample_rate: u32) -> bool {
+        unsafe { sfSoundRecorder_start(self.sf_sound_recorder, sample_rate) == sfTrue }
+    }
+
+    pub fn stop(&self) {
+        unsafe { sfSoundRecorder_stop(self.sf_sound_recorder) };
+    }
+
+    pub fn set_device(&mut self, name: &str) -> Result<(), SetDeviceError> {
+        let name = CString::new(name).unwrap();
+        let success = unsafe {
+            sfSoundRecorder_setDevice(self.sf_sound_recorder, name.as_ptr()).to_bool()
+        };
+        if success {
+            Ok(())
+        } else {
+            Err(SetDeviceError)
+        }
+    }
+
+}
+
+impl<T1: Fn() -> bool, T2: Fn(&[i16]) -> bool, T3: Fn()> Drop for SoundRecorder<T1, T2, T3> {
+    fn drop(&mut self) {
+        unsafe { sfSoundRecorder_destroy(self.sf_sound_recorder) };
+    }
+}

--- a/src/audio/sound_recorder.rs
+++ b/src/audio/sound_recorder.rs
@@ -4,10 +4,11 @@ use sf_bool_ext::SfBoolExt;
 
 use super::SetDeviceError;
 
-use std::ffi::{CString};
+use std::ffi::CString;
 use std::ptr;
 use std::os::raw::c_void;
 use std::slice;
+use std::time::Duration;
 
 pub struct SoundRecorder<T1: Fn() -> bool, T2: Fn(&[i16]) -> bool, T3: Fn()> {
     sf_sound_recorder: *mut sfSoundRecorder,
@@ -39,17 +40,20 @@ fn sound_recorder_on_stop<T1: Fn() -> bool, T2: Fn(&[i16]) -> bool, T3: Fn()>(ar
 }
 
 impl<T1: Fn() -> bool, T2: Fn(&[i16]) -> bool, T3: Fn()> SoundRecorder<T1, T2, T3> {
-
     pub fn new(on_start: T1, on_data: T2, on_stop: T3) -> SoundRecorder<T1, T2, T3> {
-        SoundRecorder{
+        SoundRecorder {
             sf_sound_recorder: unsafe {
-            sfSoundRecorder_create(
-                Some(sound_recorder_on_start::<T1, T2, T3>),
-                Some(sound_recorder_on_data::<T1, T2, T3>),
-                Some(sound_recorder_on_stop::<T1, T2, T3>),
-                ptr::null_mut()
-            )
-        }, on_start, on_data, on_stop }
+                sfSoundRecorder_create(
+                    Some(sound_recorder_on_start::<T1, T2, T3>),
+                    Some(sound_recorder_on_data::<T1, T2, T3>),
+                    Some(sound_recorder_on_stop::<T1, T2, T3>),
+                    ptr::null_mut()
+                )
+            },
+            on_start,
+            on_data,
+            on_stop
+        }
     }
 
     pub fn start(&self, sample_rate: u32) -> bool {
@@ -60,7 +64,7 @@ impl<T1: Fn() -> bool, T2: Fn(&[i16]) -> bool, T3: Fn()> SoundRecorder<T1, T2, T
         unsafe { sfSoundRecorder_stop(self.sf_sound_recorder) };
     }
 
-    pub fn set_device(&mut self, name: &str) -> Result<(), SetDeviceError> {
+    pub fn set_device(&self, name: &str) -> Result<(), SetDeviceError> {
         let name = CString::new(name).unwrap();
         let success = unsafe {
             sfSoundRecorder_setDevice(self.sf_sound_recorder, name.as_ptr()).to_bool()
@@ -72,6 +76,17 @@ impl<T1: Fn() -> bool, T2: Fn(&[i16]) -> bool, T3: Fn()> SoundRecorder<T1, T2, T
         }
     }
 
+    pub fn set_processing_interval(&self, interval: Duration) {
+        if interval.as_secs() > i64::max_value() as u64 {
+            panic!("Interval too big");
+        }
+        unsafe {
+            sfSoundRecorder_setProcessingInterval(
+                self.sf_sound_recorder,
+                sfMicroseconds((interval.subsec_nanos() / 1_000) as i64 + 1_000_000 * (interval.as_secs() as i64))
+            );
+        }
+    }
 }
 
 impl<T1: Fn() -> bool, T2: Fn(&[i16]) -> bool, T3: Fn()> Drop for SoundRecorder<T1, T2, T3> {

--- a/src/audio/sound_recorder.rs
+++ b/src/audio/sound_recorder.rs
@@ -56,15 +56,15 @@ impl<T1: Fn() -> bool, T2: Fn(&[i16]) -> bool, T3: Fn()> SoundRecorder<T1, T2, T
         }
     }
 
-    pub fn start(&self, sample_rate: u32) -> bool {
+    pub fn start(&mut self, sample_rate: u32) -> bool {
         unsafe { sfSoundRecorder_start(self.sf_sound_recorder, sample_rate) == sfTrue }
     }
 
-    pub fn stop(&self) {
+    pub fn stop(&mut self) {
         unsafe { sfSoundRecorder_stop(self.sf_sound_recorder) };
     }
 
-    pub fn set_device(&self, name: &str) -> Result<(), SetDeviceError> {
+    pub fn set_device(&mut self, name: &str) -> Result<(), SetDeviceError> {
         let name = CString::new(name).unwrap();
         let success = unsafe {
             sfSoundRecorder_setDevice(self.sf_sound_recorder, name.as_ptr()).to_bool()
@@ -76,7 +76,7 @@ impl<T1: Fn() -> bool, T2: Fn(&[i16]) -> bool, T3: Fn()> SoundRecorder<T1, T2, T
         }
     }
 
-    pub fn set_processing_interval(&self, interval: Duration) {
+    pub fn set_processing_interval(&mut self, interval: Duration) {
         if interval.as_secs() > i64::max_value() as u64 {
             panic!("Interval too big");
         }


### PR DESCRIPTION
Fixes #170. This is work in progress PR for adding `SoundRecorder` functionality to rust-sfml. I also created an example on how the the functionality could be used. I welcome any suggestions on how to improve the API. I still need to add documentation and work a bit more on the unsafe functions. Now the compiler is optimizing the closures during monomorphisation so much that I don't even need the `void*` because the function call gets inlined directly. But syntactically I still need an instance of the type of the closure to call it (I think). If there is a way to call a closure just by knowing it's type please let me know 😃. 