### PR TITLE
Implemented MulAssign and DivAssign between two vectors

### DIFF
--- a/src/system/vector2.rs
+++ b/src/system/vector2.rs
@@ -151,6 +151,13 @@ impl<T: MulAssign + Copy> MulAssign<T> for Vector2<T> {
     }
 }
 
+impl<T: MulAssign + Copy> MulAssign<Vector2<T>> for Vector2<T> {
+    fn mul_assign(&mut self, rhs: Vector2<T>) {
+        self.x *= rhs.x;
+        self.y *= rhs.y;
+    }
+}
+
 impl<T: Div> Div for Vector2<T> {
     type Output = Vector2<T::Output>;
 
@@ -166,6 +173,13 @@ impl<T: DivAssign + Copy> DivAssign<T> for Vector2<T> {
     fn div_assign(&mut self, rhs: T) {
         self.x /= rhs;
         self.y /= rhs;
+    }
+}
+
+impl<T: DivAssign + Copy> DivAssign<Vector2<T>> for Vector2<T> {
+    fn div_assign(&mut self, rhs: Vector2<T>) {
+        self.x /= rhs.x;
+        self.y /= rhs.y;
     }
 }
 

--- a/src/system/vector3.rs
+++ b/src/system/vector3.rs
@@ -154,6 +154,14 @@ impl<T: MulAssign + Copy> MulAssign<T> for Vector3<T> {
     }
 }
 
+impl<T: MulAssign + Copy> MulAssign<Vector3<T>> for Vector3<T> {
+    fn mul_assign(&mut self, rhs: Vector3<T>) {
+        self.x *= rhs.x;
+        self.y *= rhs.y;
+        self.z *= rhs.z;
+    }
+}
+
 impl<T: Div> Div for Vector3<T> {
     type Output = Vector3<T::Output>;
 
@@ -171,6 +179,14 @@ impl<T: DivAssign + Copy> DivAssign<T> for Vector3<T> {
         self.x /= rhs;
         self.y /= rhs;
         self.z /= rhs;
+    }
+}
+
+impl<T: DivAssign + Copy> DivAssign<Vector3<T>> for Vector3<T> {
+    fn div_assign(&mut self, rhs: Vector3<T>) {
+        self.x /= rhs.x;
+        self.y /= rhs.y;
+        self.z /= rhs.z;
     }
 }
 


### PR DESCRIPTION
Hi.

First, thank you for this great binding of a great library.

I noticed that in the C++ version of SFML, the operators `*=` and `/=` are implemented between vectors, so you can do something like `v1 *= v2` where `v1` and `v2` are vectors (as you can see in [this doc](https://www.sfml-dev.org/documentation/2.4.2/classsf_1_1Vector2.php) for example).

When I tried to do that in rust-sfml, I found out that the traits were not implemented. We can do `v1 = v1 * v2`, but not `v1 *= v2`.

This pull request implements the traits `MulAssign<VectorX<T>>` and `DivAssign<VectorX<T>>` so we are able to do it.