### PR TITLE
Do not include static SFML libraries in windows builds because CSFML …

### DIFF
--- a/ffi/sfml-build/src/lib.rs
+++ b/ffi/sfml-build/src/lib.rs
@@ -26,12 +26,16 @@ pub fn link_csfml(lib_name: &str) {
 
 // Add search path for SFML library files
 pub fn link_sfml(lib_name: &str) {
-    // SFML_HOME points to the base SFML directory
-    // Let cargo find the SFML library files there
-    if let Ok(sfml_home) = var("SFML_HOME") {
-        println!("cargo:rustc-link-search=native={}/lib", sfml_home);
-    }
+    // The windows build of CSFML links SFML libraries statically, so no
+    // need to link them to the rust executable as well.
+    if !cfg!(target_family = "windows") {
+        // SFML_HOME points to the base SFML directory
+        // Let cargo find the SFML library files there
+        if let Ok(sfml_home) = var("SFML_HOME") {
+            println!("cargo:rustc-link-search=native={}/lib", sfml_home);
+        }
 
-    // Link to the sfml library
-    println!("cargo:rustc-link-lib=sfml-{}", lib_name);
+        // Link to the sfml library
+        println!("cargo:rustc-link-lib=sfml-{}", lib_name);
+    }
 }

--- a/ffi/sfml-build/src/lib.rs
+++ b/ffi/sfml-build/src/lib.rs
@@ -28,7 +28,7 @@ pub fn link_csfml(lib_name: &str) {
 pub fn link_sfml(lib_name: &str) {
     // The windows build of CSFML links SFML libraries statically, so no
     // need to link them to the rust executable as well.
-    if !cfg!(target_family = "windows") {
+    if var("CARGO_CFG_TARGET_OS").unwrap_or_default() != "windows" {
         // SFML_HOME points to the base SFML directory
         // Let cargo find the SFML library files there
         if let Ok(sfml_home) = var("SFML_HOME") {


### PR DESCRIPTION
…are DLLs with SFML linked statically inside them.

See discussion in #138 