### PR TITLE
Add ability to create the SFML window from an existing handle

### DIFF
--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -58,6 +58,32 @@ impl RenderWindow {
         }
     }
 
+    /// Create a render window from an existing platform-specific window handle
+    ///
+    /// This function creates a render window based on an existing platform
+    /// specific window handle which has been allocated outside of SFML. This is
+    /// only intended to be used in cases where you need to integrate SFML with
+    /// some other windowing library.
+    ///
+    /// This function is unsafe because it is the caller's responsibility to
+    /// ensure that it is called with a valid window handle.
+    ///
+    /// # Arguments
+    /// * handle - The handle to the platform-specific window handle to use for
+    ///            the window.
+    /// * settings - Additional settings for the underlying OpenGL context
+    pub unsafe fn from_handle(
+        handle: ::csfml_window_sys::sfWindowHandle,
+        settings: &ContextSettings,
+    ) -> RenderWindow {
+        let sf_render_win: *mut ffi::sfRenderWindow =
+            ffi::sfRenderWindow_createFromHandle(handle, &settings.raw());
+        assert!(!sf_render_win.is_null(), "Failed to create Window");
+        RenderWindow {
+            render_window: sf_render_win,
+        }
+    }
+
     /// Change a render window's icon
     /// pixels must be an array of width x height pixels in 32-bits RGBA format.
     ///

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -93,6 +93,26 @@ impl Window {
         Window { window: sf_win }
     }
 
+    /// Create a window from an existing platform-specific window handle
+    ///
+    /// This function creates a window based on an existing platform specific
+    /// window handle which has been allocated outside of SFML. This is only
+    /// intended to be used in cases where you need to integrate SFML with some
+    /// other windowing library.
+    ///
+    /// This function is unsafe because it is the caller's responsibility to
+    /// ensure that it is called with a valid window handle.
+    ///
+    /// # Arguments
+    /// * handle - The handle to the platform-specific window handle to use for
+    ///            the window.
+    /// * settings - Additional settings for the underlying OpenGL context
+    pub unsafe fn from_handle(handle: ffi::sfWindowHandle, settings: &ContextSettings) -> Window {
+        let sf_win: *mut ffi::sfWindow = ffi::sfWindow_createFromHandle(handle, &settings.raw());
+        assert!(!sf_win.is_null(), "Failed to create Window");
+        Window { window: sf_win }
+    }
+
     ///  Pop the event on top of event queue, if any, and return it
     ///
     /// This function is not blocking: if there's no pending event then


### PR DESCRIPTION
Add Window::from_handle and RenderWindow::from_handle as unsafe functions.

These would support creating windows from platform-specific window handles, such as HWIND on windows or an XLib Window on Linux. This allows SFML to be used to draw on top of windows allocated by other programs, such as for X screen savers or live desktops.

These functions are marked as unsafe because the caller is responsible for ensuring that the handle is valid. In my manual testing (only on Linux), these would crash with an X error if the window handle is invalid rather than panic at `assert!(!sf_render_win.is_null(), "Failed to create Window");`, so I'm not sure any additional error handling is possible.

