### PR TITLE
Fix CFG addribute (must be string)

### DIFF
--- a/src/audio/sound_buffer.rs
+++ b/src/audio/sound_buffer.rs
@@ -92,7 +92,7 @@ impl SoundBuffer {
     pub fn samples(&self) -> &[i16] {
         let len = self.sample_count();
         // TODO: Replace with TryFrom, or a similar standard library API, once available
-        #[cfg(target_pointer_width = 32)]
+        #[cfg(target_pointer_width = "32")]
         {
             if len > usize::max_value() as u64 {
                 panic!("Sample count {} too big to fit into usize", len);


### PR DESCRIPTION
Compiling in Rust 1.29.1, non-string CFG predicates are an error:

```
error: literal in `cfg` predicate value must be a string
  --> /[...]/.cargo/git/checkouts/rust-sfml-c922f9106b9b9542/0969fa3/src/audio/sound_buffer.rs:95:38
   |
95 |         #[cfg(target_pointer_width = 32)]
   |                                      ^^
```