### PR TITLE
Documentation: Add link to the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Requirements
 
 Documentation
 =====
-The SFML official API (C++) is available here: https://docs.rs/sfml/0.14.0/sfml/
+The API documentation is available at: https://docs.rs/sfml/
 
-To reference and install `rust-sfml`, you can take a look at the [github wiki](https://github.com/jeremyletang/rust-sfml/wiki)\
+If you need help with setting up `rust-sfml` on your system, you can take a look at the [wiki](https://github.com/jeremyletang/rust-sfml/wiki).\
 Please take note that:
    * This wiki is supported by the community
-   * The `rust-sfml` core team doeesn't review it
+   * The `rust-sfml` core team doesn't review it
    * Your contribution is welcome
 
 License

--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@ Requirements
 - [SFML 2.5](http://www.sfml-dev.org/download.php)
 - [CSFML 2.5](http://www.sfml-dev.org/download/csfml/)
 
-Usage
+Documentation
 =====
-You can find documentation about `rust-sfml` into the [dedicated wiki](https://github.com/jeremyletang/rust-sfml/wiki)
+The SFML official API (C++) is available here: https://docs.rs/sfml/0.14.0/sfml/
+
+To reference and install `rust-sfml`, you can take a look at the [github wiki](https://github.com/jeremyletang/rust-sfml/wiki)\
+Please take note that:
+   * This wiki is supported by the community
+   * The `rust-sfml` core team doeesn't review it
+   * Your contribution is welcome
 
 License
 =======

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Requirements
 - [SFML 2.5](http://www.sfml-dev.org/download.php)
 - [CSFML 2.5](http://www.sfml-dev.org/download/csfml/)
 
+Usage
+=====
+You can find documentation about `rust-sfml` into the [dedicated wiki](https://github.com/jeremyletang/rust-sfml/wiki)
+
 License
 =======
 


### PR DESCRIPTION
Small change, I did this because this is not natural to look at wiki tab for me in github projects.
I am used to see documentation linked from the README.md (and linked to others MD files, but this is not the point here 😄 )