### PR TITLE
Fix error in window::Window example in doc

### DIFF
--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -26,12 +26,12 @@ pub type Handle = ffi::sfWindowHandle;
 /// # Usage example
 ///
 /// ```no_run
-/// use sfml::window::{Window, Event, Style};
+/// use sfml::window::{Window, Event, Style, ContextSettings};
 /// // Create a new window
 /// let mut window = Window::new((800, 600),
 ///                              "SFML window",
 ///                              Style::CLOSE,
-///                              &Default::default());
+///                              &ContextSettings::default());
 /// // Limit the framerate to 60 frames per second (this step is optional)
 /// window.set_framerate_limit(60);
 ///


### PR DESCRIPTION
Example in https://docs.rs/sfml/0.14.0/sfml/window/struct.Window.html is not
working. 

It was using &Default::default(), and it is not working. However, 
&ContextSettings::default() is working. This change update that example in the documentation.