### PR TITLE
Replace `transmute` with primitive casts in various raw() methods.

### DIFF
--- a/src/graphics/primitive_type.rs
+++ b/src/graphics/primitive_type.rs
@@ -29,7 +29,7 @@ pub enum PrimitiveType {
 
 impl PrimitiveType {
     pub(super) fn raw(self) -> sfPrimitiveType {
-        unsafe { ::std::mem::transmute(self) }
+        self as sfPrimitiveType
     }
     pub(super) unsafe fn from_raw(raw: sfPrimitiveType) -> Self {
         ::std::mem::transmute(raw)

--- a/src/window/joystick.rs
+++ b/src/window/joystick.rs
@@ -85,7 +85,7 @@ pub enum Axis {
 
 impl Axis {
     fn raw(self) -> ffi::sfJoystickAxis {
-        unsafe { ::std::mem::transmute(self) }
+        self as ffi::sfJoystickAxis
     }
     pub(super) unsafe fn from_raw(raw: ffi::sfJoystickAxis) -> Self {
         ::std::mem::transmute(raw)

--- a/src/window/mouse.rs
+++ b/src/window/mouse.rs
@@ -80,7 +80,7 @@ impl Button {
         unsafe { ffi::sfMouse_isButtonPressed(self.raw()) }.to_bool()
     }
     fn raw(self) -> ffi::sfMouseButton {
-        unsafe { ::std::mem::transmute(self) }
+        self as ffi::sfMouseButton
     }
     pub(super) unsafe fn from_raw(raw: ffi::sfMouseButton) -> Self {
         ::std::mem::transmute(raw)

--- a/src/window/sensor.rs
+++ b/src/window/sensor.rs
@@ -97,6 +97,6 @@ impl Type {
         ::std::mem::transmute(raw)
     }
     fn raw(self) -> sfSensorType {
-        unsafe { ::std::mem::transmute(self) }
+        self as sfSensorType
     }
 }


### PR DESCRIPTION
Removing needlessly `unsafe` code from some `enum` methods.