### PR TITLE
make Rect::new, Vector2::new and Vector3::new const

### DIFF
--- a/src/graphics/rect.rs
+++ b/src/graphics/rect.rs
@@ -23,7 +23,7 @@ pub type FloatRect = Rect<f32>;
 
 impl<T> Rect<T> {
     /// Construct a rectangle from its coordinates.
-    pub fn new(left: T, top: T, width: T, height: T) -> Self {
+    pub const fn new(left: T, top: T, width: T, height: T) -> Self {
         Rect {
             left,
             top,

--- a/src/system/vector2.rs
+++ b/src/system/vector2.rs
@@ -54,7 +54,7 @@ pub type Vector2f = Vector2<f32>;
 
 impl<T> Vector2<T> {
     /// Creates a new vector from its coordinates.
-    pub fn new(x: T, y: T) -> Self {
+    pub const fn new(x: T, y: T) -> Self {
         Self { x, y }
     }
 }

--- a/src/system/vector3.rs
+++ b/src/system/vector3.rs
@@ -50,7 +50,7 @@ pub struct Vector3<T> {
 
 impl<T> Vector3<T> {
     /// Create a new `Vector3` with the given values.
-    pub fn new(x: T, y: T, z: T) -> Self {
+    pub const fn new(x: T, y: T, z: T) -> Self {
         Self { x, y, z }
     }
 }


### PR DESCRIPTION
The base constructors of `Rect` and `Vector2/3` can be made `const`, so I think it's nice to have them const. 
This allows defining compile-time constants of type `Vector` and `Rect`.

Probably this is also true for other types, but these are among the most commonly used, so we can start with just these.