### PR TITLE
Add get/set_vertex methods to VertexArray and fix doc

### DIFF
--- a/src/graphics/vertex_array.rs
+++ b/src/graphics/vertex_array.rs
@@ -141,6 +141,13 @@ impl VertexArray {
         unsafe { &mut *(sfVertexArray_getVertex(self.vertex_array, index) as *mut _) }
     }
 
+    /// Sets the `index`-th vertex to `vertex`.
+    /// Panics if `index >= self.vertex_count()`.
+    pub fn set_vertex(&mut self, index: usize, vertex: &Vertex) {
+        let v = self.get_vertex_mut(index);
+        *v = *vertex;
+    }
+
     pub(super) fn raw(&self) -> *const sfVertexArray {
         self.vertex_array
     }

--- a/src/graphics/vertex_array.rs
+++ b/src/graphics/vertex_array.rs
@@ -148,6 +148,33 @@ impl VertexArray {
         *v = *vertex;
     }
 
+    /// Returns an immutable reference to the `index`-th vertex in the `VertexArray`.
+    ///
+    /// # Safety
+    /// The behaviour is undefined if `index >= self.vertex_count()`.
+    #[must_use]
+    pub unsafe fn get_vertex_unchecked(&self, index: usize) -> &Vertex {
+        &*(sfVertexArray_getVertex(self.vertex_array, index) as *const _)
+    }
+
+    /// Returns a mutable reference to the `index`-th vertex in the `VertexArray`.
+    ///
+    /// # Safety
+    /// The behaviour is undefined if `index >= self.vertex_count()`.
+    #[must_use]
+    pub unsafe fn get_vertex_mut_unchecked(&mut self, index: usize) -> &mut Vertex {
+        &mut *(sfVertexArray_getVertex(self.vertex_array, index) as *mut _)
+    }
+
+    /// Sets the `index`-th vertex to `vertex`.
+    ///
+    /// # Safety
+    /// The behaviour is undefined if `index >= self.vertex_count()`.
+    pub unsafe fn set_vertex_unchecked(&mut self, index: usize, vertex: &Vertex) {
+        let v = self.get_vertex_mut_unchecked(index);
+        *v = *vertex;
+    }
+
     pub(super) fn raw(&self) -> *const sfVertexArray {
         self.vertex_array
     }

--- a/src/graphics/vertex_array.rs
+++ b/src/graphics/vertex_array.rs
@@ -24,7 +24,7 @@ impl VertexArray {
     ///
     /// # Arguments
     /// * `primitive_type` - The type of the `VertexArray`
-    /// * `vertex_count` - The maximal number of vertex
+    /// * `vertex_count` - The initial number of vertex
     #[must_use]
     pub fn new(primitive_type: PrimitiveType, vertex_count: usize) -> VertexArray {
         let mut arr = Self::default();
@@ -65,7 +65,7 @@ impl VertexArray {
         unsafe { sfVertexArray_resize(self.vertex_array, vertex_count) }
     }
 
-    /// Add a vertex to a vertex array array
+    /// Add a vertex to a vertex array
     ///
     /// # Arguments
     /// * vertex - Vertex to add
@@ -118,6 +118,29 @@ impl VertexArray {
             pos: 0,
         }
     }
+
+    /// Returns an immutable reference to the `index`-th vertex in the `VertexArray`.
+    /// Panics if `index >= self.vertex_count()`.
+    #[must_use]
+    pub fn get_vertex(&self, index: usize) -> &Vertex {
+        assert!(
+            index < self.vertex_count(),
+            "get_vertex(): tried to get an inexisting vertex!"
+        );
+        unsafe { &*(sfVertexArray_getVertex(self.vertex_array, index) as *const _) }
+    }
+
+    /// Returns a mutable reference to the `index`-th vertex in the `VertexArray`.
+    /// Panics if `index >= self.vertex_count()`.
+    #[must_use]
+    pub fn get_vertex_mut(&mut self, index: usize) -> &mut Vertex {
+        assert!(
+            index < self.vertex_count(),
+            "get_vertex_mut(): tried to get an inexisting vertex!"
+        );
+        unsafe { &mut *(sfVertexArray_getVertex(self.vertex_array, index) as *mut _) }
+    }
+
     pub(super) fn raw(&self) -> *const sfVertexArray {
         self.vertex_array
     }

--- a/src/graphics/vertex_array.rs
+++ b/src/graphics/vertex_array.rs
@@ -127,7 +127,7 @@ impl VertexArray {
             index < self.vertex_count(),
             "get_vertex(): tried to get an inexisting vertex!"
         );
-        unsafe { &*(sfVertexArray_getVertex(self.vertex_array, index) as *const _) }
+        unsafe { self.get_vertex_unchecked(index) }
     }
 
     /// Returns a mutable reference to the `index`-th vertex in the `VertexArray`.
@@ -138,7 +138,7 @@ impl VertexArray {
             index < self.vertex_count(),
             "get_vertex_mut(): tried to get an inexisting vertex!"
         );
-        unsafe { &mut *(sfVertexArray_getVertex(self.vertex_array, index) as *mut _) }
+        unsafe { self.get_vertex_mut_unchecked(index) }
     }
 
     /// Sets the `index`-th vertex to `vertex`.


### PR DESCRIPTION
The `VertexArray` struct currently has incorrect documentation on its `new` method: it states that its `vertex_count` argument is "The maximal number of vertex". However, that is really the *inital* number of vertices.

Moreover, there is no way to modify an existing Vertex: you can only `append` them - which resizes the array.

This PR addresses both problems by:
- fixing the documentation
- adding `get_vertex()`, `get_vertex_mut()` and `set_vertex()` methods to the `VertexArray`.

Edit:
- also adding `unchecked` versions of those methods.
