### PR TITLE
VertexArray: remove checked get/set_vertex, refactor Index* and example

### DIFF
--- a/examples/vertex-arrays.rs
+++ b/examples/vertex-arrays.rs
@@ -46,6 +46,35 @@ fn main() {
         vertex_array[1].color, vertex_array[1].position
     );
 
+    unsafe {
+        println!("\nMutable unchecked access to a vertex");
+        let vertex = vertex_array.get_vertex_mut_unchecked(1);
+        println!(
+            "Before Vertex Color: {:?} | Position: {:?}",
+            vertex.color, vertex.position
+        );
+        vertex.position.x = 100.0;
+        println!(
+            "After Vertex Color: {:?} | Position: {:?}",
+            vertex.color, vertex.position
+        );
+    }
+
+    // Or:
+    unsafe {
+        vertex_array.set_vertex_unchecked(1, &Vertex::with_pos((20., 40.)));
+        println!("[2] After Vertex Position: {:?}", vertex_array[1].position);
+    }
+
+    println!("\nImmutable unchecked access to a vertex");
+    unsafe {
+        println!(
+            "Vertex Color: {:?} | Position: {:?}",
+            vertex_array.get_vertex_unchecked(1).color,
+            vertex_array.get_vertex_unchecked(1).position
+        );
+    }
+
     loop {
         while let Some(e) = window.poll_event() {
             if e == Event::Closed {

--- a/src/graphics/vertex_array.rs
+++ b/src/graphics/vertex_array.rs
@@ -120,35 +120,6 @@ impl VertexArray {
     }
 
     /// Returns an immutable reference to the `index`-th vertex in the `VertexArray`.
-    /// Panics if `index >= self.vertex_count()`.
-    #[must_use]
-    pub fn get_vertex(&self, index: usize) -> &Vertex {
-        assert!(
-            index < self.vertex_count(),
-            "get_vertex(): tried to get an inexisting vertex!"
-        );
-        unsafe { self.get_vertex_unchecked(index) }
-    }
-
-    /// Returns a mutable reference to the `index`-th vertex in the `VertexArray`.
-    /// Panics if `index >= self.vertex_count()`.
-    #[must_use]
-    pub fn get_vertex_mut(&mut self, index: usize) -> &mut Vertex {
-        assert!(
-            index < self.vertex_count(),
-            "get_vertex_mut(): tried to get an inexisting vertex!"
-        );
-        unsafe { self.get_vertex_mut_unchecked(index) }
-    }
-
-    /// Sets the `index`-th vertex to `vertex`.
-    /// Panics if `index >= self.vertex_count()`.
-    pub fn set_vertex(&mut self, index: usize, vertex: &Vertex) {
-        let v = self.get_vertex_mut(index);
-        *v = *vertex;
-    }
-
-    /// Returns an immutable reference to the `index`-th vertex in the `VertexArray`.
     ///
     /// # Safety
     /// The behaviour is undefined if `index >= self.vertex_count()`.
@@ -234,7 +205,7 @@ impl Index<usize> for VertexArray {
             idx,
             self.vertex_count()
         );
-        unsafe { &*(sfVertexArray_getVertex(self.vertex_array, idx) as *const Vertex) }
+        unsafe { self.get_vertex_unchecked(idx) }
     }
 }
 
@@ -246,7 +217,7 @@ impl IndexMut<usize> for VertexArray {
             idx,
             self.vertex_count()
         );
-        unsafe { &mut *(sfVertexArray_getVertex(self.vertex_array, idx) as *mut Vertex) }
+        unsafe { self.get_vertex_mut_unchecked(idx) }
     }
 }
 


### PR DESCRIPTION
Checked `get/set_vertex()` are superfluous since VertexArray already has Index/Mut traits. Leaving the unchecked versions, refactoring index/_mut to use them and updating the vertex array example.