### PR TITLE
add handle() method to Window and RenderWindow

### DIFF
--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -90,10 +90,10 @@ impl RenderWindow {
 
     /// Get the OS-specific handle of the window.
     ///
-    /// The type of the returned handle is sf::WindowHandle, which is a typedef to the handle type defined by the OS.
+    /// The type of the returned handle is Handle, which is a typedef to the handle type defined by the OS.
     /// You shouldn't need to use this function, unless you have very specific stuff to implement that SFML
     /// doesn't support, or implement a temporary workaround until a bug is fixed.
-    pub fn handle(&self) -> Handle {
+    pub fn system_handle(&self) -> Handle {
         unsafe { ffi::sfRenderWindow_getSystemHandle(self.render_window) }
     }
 

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -88,6 +88,15 @@ impl RenderWindow {
         }
     }
 
+    /// Get the OS-specific handle of the window.
+    ///
+    /// The type of the returned handle is sf::WindowHandle, which is a typedef to the handle type defined by the OS.
+    /// You shouldn't need to use this function, unless you have very specific stuff to implement that SFML
+    /// doesn't support, or implement a temporary workaround until a bug is fixed.
+    pub fn handle(&self) -> Handle {
+        unsafe { ffi::sfRenderWindow_getSystemHandle(self.render_window) }
+    }
+
     /// Change a render window's icon
     /// pixels must be an array of width x height pixels in 32-bits RGBA format.
     ///

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -122,6 +122,15 @@ impl Window {
         Window { window: sf_win }
     }
 
+    /// Get the OS-specific handle of the window.
+    ///
+    /// The type of the returned handle is sf::WindowHandle, which is a typedef to the handle type defined by the OS.
+    /// You shouldn't need to use this function, unless you have very specific stuff to implement that SFML
+    /// doesn't support, or implement a temporary workaround until a bug is fixed.
+    pub fn handle(&self) -> Handle {
+        unsafe { ffi::sfWindow_getSystemHandle(self.window) }
+    }
+
     ///  Pop the event on top of event queue, if any, and return it
     ///
     /// This function is not blocking: if there's no pending event then

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -124,10 +124,10 @@ impl Window {
 
     /// Get the OS-specific handle of the window.
     ///
-    /// The type of the returned handle is sf::WindowHandle, which is a typedef to the handle type defined by the OS.
+    /// The type of the returned handle is Handle, which is a typedef to the handle type defined by the OS.
     /// You shouldn't need to use this function, unless you have very specific stuff to implement that SFML
     /// doesn't support, or implement a temporary workaround until a bug is fixed.
-    pub fn handle(&self) -> Handle {
+    pub fn system_handle(&self) -> Handle {
         unsafe { ffi::sfWindow_getSystemHandle(self.window) }
     }
 


### PR DESCRIPTION
This PR adds the ability to retrieve the SystemHandle from Window and RenderWindow.