### PR TITLE
Add associated DEFAULT const member to RenderStates

### DIFF
--- a/src/graphics/blend_mode.rs
+++ b/src/graphics/blend_mode.rs
@@ -9,14 +9,14 @@ use crate::graphics::csfml_graphics_sys as ffi;
 /// A blend mode determines how the colors of an object you draw are mixed with the colors that
 /// are already in the buffer.
 ///
-/// The type is composed of 6 components, each of which has its own public field:
+/// The type is composed of 6 components
 ///
-/// - Color Source Factor (`color_src_factor`)
-/// - Color Destination Factor (`color_dst_factor`)
-/// - Color Blend Equation (`color_equation`)
-/// - Alpha Source Factor (`alpha_src_factor`)
-/// - Alpha Destination Factor (`alpha_dst_factor`)
-/// - Alpha Blend Equation (`alpha_equation`)
+/// - Color Source Factor
+/// - Color Destination Factor
+/// - Color Blend Equation
+/// - Alpha Source Factor
+/// - Alpha Destination Factor
+/// - Alpha Blend Equation
 ///
 /// The source factor specifies how the pixel you are drawing contributes to the final color.
 /// The destination factor specifies how the pixel already drawn in the buffer contributes to
@@ -34,8 +34,8 @@ use crate::graphics::csfml_graphics_sys as ffi;
 /// being + or - operators):
 ///
 /// ```ignore
-/// dst.rgb = color_src_factor * src.rgb (color_equation) color_dst_factor * dst.rgb
-/// dst.a   = alpha_src_factor * src.a   (alpha_equation) alpha_dst_factor * dst.a
+/// dst.rgb = colorSrcFactor * src.rgb (colorEquation) colorDstFactor * dst.rgb
+/// dst.a   = alphaSrcFactor * src.a   (alphaEquation) alphaDstFactor * dst.a
 /// ```
 ///
 /// All factors and colors are represented as floating point numbers between 0 and 1.
@@ -48,22 +48,9 @@ use crate::graphics::csfml_graphics_sys as ffi;
 /// [`Drawable`]: crate::graphics::Drawable
 /// [`RenderStates`]: crate::graphics::RenderStates
 /// [`RenderTarget::draw`]: crate::graphics::RenderTarget::draw
-#[derive(Clone, PartialEq, Eq, Debug, Copy)]
-#[repr(C)]
-pub struct BlendMode {
-    /// Source blending factor for the color channels.
-    pub color_src_factor: Factor,
-    /// Destination blending factor for the color channels.
-    pub color_dst_factor: Factor,
-    /// Blending equation for the color channels.
-    pub color_equation: Equation,
-    /// Source blending factor for the alpha channel.
-    pub alpha_src_factor: Factor,
-    /// Destination blending factor for the alpha channel.
-    pub alpha_dst_factor: Factor,
-    /// Blending equation for the alpha channel.
-    pub alpha_equation: Equation,
-}
+#[derive(Clone, Debug, Copy)]
+#[repr(transparent)]
+pub struct BlendMode(ffi::sfBlendMode);
 
 impl Default for BlendMode {
     /// Default blending mode is alpha blending.
@@ -127,55 +114,55 @@ impl BlendMode {
         alpha_dst: Factor,
         alpha_equ: Equation,
     ) -> Self {
-        BlendMode {
-            color_src_factor: col_src,
-            color_dst_factor: col_dst,
-            color_equation: col_equ,
-            alpha_src_factor: alpha_src,
-            alpha_dst_factor: alpha_dst,
-            alpha_equation: alpha_equ,
-        }
+        Self(ffi::sfBlendMode {
+            colorSrcFactor: col_src as _,
+            colorDstFactor: col_dst as _,
+            colorEquation: col_equ as _,
+            alphaSrcFactor: alpha_src as _,
+            alphaDstFactor: alpha_dst as _,
+            alphaEquation: alpha_equ as _,
+        })
     }
-    pub(super) fn raw(&self) -> ffi::sfBlendMode {
-        unsafe { ::std::mem::transmute(*self) }
+    pub(super) const fn raw(&self) -> ffi::sfBlendMode {
+        self.0
     }
     /// "Alpha" blend mode
-    pub const ALPHA: BlendMode = BlendMode {
-        color_src_factor: Factor::SrcAlpha,
-        color_dst_factor: Factor::OneMinusSrcAlpha,
-        color_equation: Equation::Add,
-        alpha_src_factor: Factor::One,
-        alpha_dst_factor: Factor::OneMinusSrcAlpha,
-        alpha_equation: Equation::Add,
-    };
+    pub const ALPHA: Self = Self(ffi::sfBlendMode {
+        colorSrcFactor: Factor::SrcAlpha as _,
+        colorDstFactor: Factor::OneMinusSrcAlpha as _,
+        colorEquation: Equation::Add as _,
+        alphaSrcFactor: Factor::One as _,
+        alphaDstFactor: Factor::OneMinusSrcAlpha as _,
+        alphaEquation: Equation::Add as _,
+    });
 
     /// "Add" blend mode
-    pub const ADD: BlendMode = BlendMode {
-        color_src_factor: Factor::SrcAlpha,
-        color_dst_factor: Factor::One,
-        color_equation: Equation::Add,
-        alpha_src_factor: Factor::One,
-        alpha_dst_factor: Factor::One,
-        alpha_equation: Equation::Add,
-    };
+    pub const ADD: BlendMode = Self(ffi::sfBlendMode {
+        colorSrcFactor: Factor::SrcAlpha as _,
+        colorDstFactor: Factor::One as _,
+        colorEquation: Equation::Add as _,
+        alphaSrcFactor: Factor::One as _,
+        alphaDstFactor: Factor::One as _,
+        alphaEquation: Equation::Add as _,
+    });
 
     /// "Multiply" blend mode
-    pub const MULTIPLY: BlendMode = BlendMode {
-        color_src_factor: Factor::DstColor,
-        color_dst_factor: Factor::Zero,
-        color_equation: Equation::Add,
-        alpha_src_factor: Factor::DstColor,
-        alpha_dst_factor: Factor::Zero,
-        alpha_equation: Equation::Add,
-    };
+    pub const MULTIPLY: BlendMode = Self(ffi::sfBlendMode {
+        colorSrcFactor: Factor::DstColor as _,
+        colorDstFactor: Factor::Zero as _,
+        colorEquation: Equation::Add as _,
+        alphaSrcFactor: Factor::DstColor as _,
+        alphaDstFactor: Factor::Zero as _,
+        alphaEquation: Equation::Add as _,
+    });
 
     /// "None" blend mode
-    pub const NONE: BlendMode = BlendMode {
-        color_src_factor: Factor::One,
-        color_dst_factor: Factor::Zero,
-        color_equation: Equation::Add,
-        alpha_src_factor: Factor::One,
-        alpha_dst_factor: Factor::Zero,
-        alpha_equation: Equation::Add,
-    };
+    pub const NONE: BlendMode = Self(ffi::sfBlendMode {
+        colorSrcFactor: Factor::One as _,
+        colorDstFactor: Factor::Zero as _,
+        colorEquation: Equation::Add as _,
+        alphaSrcFactor: Factor::One as _,
+        alphaDstFactor: Factor::Zero as _,
+        alphaEquation: Equation::Add as _,
+    });
 }

--- a/src/graphics/render_states.rs
+++ b/src/graphics/render_states.rs
@@ -116,19 +116,24 @@ impl<'texture, 'shader, 'shader_texture> RenderStates<'texture, 'shader, 'shader
     }
 }
 
-impl<'texture, 'shader, 'shader_texture> Default
-    for RenderStates<'texture, 'shader, 'shader_texture>
-{
+impl RenderStates<'static, 'static, 'static> {
+    /// The default render state.
+    ///
+    /// This can be used in a const context, unlike the [`Default`] implementation.
+    pub const DEFAULT: Self = Self {
+        repr: ffi::sfRenderStates {
+            blendMode: BlendMode::ALPHA.raw(),
+            transform: Transform::IDENTITY.raw(),
+            texture: ptr::null(),
+            shader: ptr::null(),
+        },
+        _texture: PhantomData,
+        _shader: PhantomData,
+    };
+}
+
+impl Default for RenderStates<'static, 'static, 'static> {
     fn default() -> Self {
-        Self {
-            repr: ffi::sfRenderStates {
-                blendMode: BlendMode::default().raw(),
-                transform: Transform::default().raw(),
-                texture: ptr::null(),
-                shader: ptr::null(),
-            },
-            _texture: PhantomData,
-            _shader: PhantomData,
-        }
+        Self::DEFAULT
     }
 }

--- a/src/graphics/render_texture.rs
+++ b/src/graphics/render_texture.rs
@@ -194,7 +194,7 @@ impl RenderTarget for RenderTexture {
         }
     }
     fn draw(&mut self, object: &dyn Drawable) {
-        object.draw(self, &RenderStates::default());
+        object.draw(self, &RenderStates::DEFAULT);
     }
     fn draw_with_renderstates(&mut self, object: &dyn Drawable, render_states: &RenderStates) {
         object.draw(self, render_states);

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -488,7 +488,7 @@ impl RenderTarget for RenderWindow {
         unsafe { Vector2u::from_raw(ffi::sfRenderWindow_getSize(self.render_window)) }
     }
     fn draw(&mut self, object: &dyn Drawable) {
-        object.draw(self, &RenderStates::default());
+        object.draw(self, &RenderStates::DEFAULT);
     }
     fn draw_with_renderstates(&mut self, object: &dyn Drawable, render_states: &RenderStates) {
         object.draw(self, render_states);

--- a/src/graphics/transform.rs
+++ b/src/graphics/transform.rs
@@ -166,8 +166,8 @@ impl Transform {
     pub fn transform_rect(&self, rectangle: &FloatRect) -> FloatRect {
         unsafe { FloatRect::from_raw(ffi::sfTransform_transformRect(&self.0, rectangle.raw())) }
     }
-    pub(crate) fn raw(self) -> ffi::sfTransform {
-        unsafe { std::mem::transmute(self) }
+    pub(crate) const fn raw(self) -> ffi::sfTransform {
+        self.0
     }
 }
 

--- a/src/graphics/vertex.rs
+++ b/src/graphics/vertex.rs
@@ -34,7 +34,7 @@ use crate::{
 ///     Vertex::new(Vector2f::new(100.,   0.), Color::RED, Vector2f::new(10.,  0.)),
 /// ];
 /// // draw it
-/// window.draw_primitives(&vertices, PrimitiveType::Quads, &RenderStates::default());
+/// window.draw_primitives(&vertices, PrimitiveType::Quads, &RenderStates::DEFAULT);
 /// ```
 ///
 /// Note: although texture coordinates are supposed to be an integer amount of pixels,


### PR DESCRIPTION
Passing this const default instead of &Default::default() in the
RenderTarget::draw impls greatly cuts down on the generated assembly.

It seems that with &Default::default(), a new default instance was
constructed in-place every time.