### PR TITLE
[WIP] thread safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ audio = ["csfml-audio-sys"]
 # Used to skip running certain tests on CI, since it's running in a headless environment.
 ci-headless = []
 
+[dependencies.once_cell]
+version = "1.4"
+
 [dependencies.widestring]
 version = "0.4.0"
 optional = true

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     sf_bool_ext::SfBoolExt,
     system::{SfStrConv, Vector2f, Vector2i, Vector2u},
+    thread_safety,
     window::{ContextSettings, Cursor, Event, Handle, Style, VideoMode},
 };
 use csfml_system_sys::*;
@@ -47,6 +48,8 @@ impl RenderWindow {
         style: Style,
         settings: &ContextSettings,
     ) -> RenderWindow {
+        thread_safety::set_window_thread();
+
         title.with_as_sfstr(|sfstr| {
             let sf_render_win: *mut ffi::sfRenderWindow = unsafe {
                 ffi::sfRenderWindow_createUnicode(
@@ -80,6 +83,8 @@ impl RenderWindow {
     /// * settings - Additional settings for the underlying OpenGL context
     #[must_use]
     pub unsafe fn from_handle(handle: Handle, settings: &ContextSettings) -> RenderWindow {
+        thread_safety::set_window_thread();
+
         let sf_render_win: *mut ffi::sfRenderWindow =
             ffi::sfRenderWindow_createFromHandle(handle, &settings.raw());
         assert!(!sf_render_win.is_null(), "Failed to create Window");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ extern crate bitflags;
 extern crate csfml_system_sys;
 #[cfg(feature = "window")]
 extern crate csfml_window_sys;
+extern crate once_cell;
 
 #[cfg(any(feature = "graphics", feature = "audio"))]
 mod inputstream;
@@ -64,3 +65,5 @@ pub mod graphics;
 pub mod system;
 #[cfg(feature = "window")]
 pub mod window;
+
+mod thread_safety;

--- a/src/thread_safety.rs
+++ b/src/thread_safety.rs
@@ -12,20 +12,8 @@ pub(super) fn set_window_thread() {
         None => WINDOW_THREAD.set(current_id).unwrap(),
         Some(id) => {
             if *id != current_id {
-                panic!("Opening Windows in multiple threads is not supported.")
+                panic!("Graphics/windowing functionality is only supported on the same thread.");
             }
-        }
-    }
-}
-
-// asserts that the either current thread is WINDOW_THREAD, or that WINDOW_THREAD is unset
-pub(super) fn assert_window_thread(func_name: &str) {
-    if let Some(&id) = WINDOW_THREAD.get() {
-        if id != current().id() {
-            panic!(
-                "{} has to be called in the same thread as the RenderWindow!",
-                func_name
-            );
         }
     }
 }

--- a/src/thread_safety.rs
+++ b/src/thread_safety.rs
@@ -1,0 +1,31 @@
+use once_cell::sync::OnceCell;
+use std::thread::{current, ThreadId};
+
+// this WINDOW_THREAD is the only thread allowed to contain RenderWindows.
+static WINDOW_THREAD: OnceCell<ThreadId> = OnceCell::new();
+
+// sets WINDOW_THREAD to the current thread.
+// panics if WINDOW_THREAD is already assigned to another thread.
+pub(super) fn set_window_thread() {
+    let current_id = current().id();
+    match WINDOW_THREAD.get() {
+        None => WINDOW_THREAD.set(current_id).unwrap(),
+        Some(id) => {
+            if *id != current_id {
+                panic!("Opening Windows in multiple threads is not supported.")
+            }
+        }
+    }
+}
+
+// asserts that the either current thread is WINDOW_THREAD, or that WINDOW_THREAD is unset
+pub(super) fn assert_window_thread(func_name: &str) {
+    if let Some(&id) = WINDOW_THREAD.get() {
+        if id != current().id() {
+            panic!(
+                "{} has to be called in the same thread as the RenderWindow!",
+                func_name
+            );
+        }
+    }
+}

--- a/src/window/keyboard.rs
+++ b/src/window/keyboard.rs
@@ -1,4 +1,4 @@
-use crate::sf_bool_ext::SfBoolExt;
+use crate::{sf_bool_ext::SfBoolExt, thread_safety};
 use csfml_window_sys as ffi;
 
 /// Key codes known to SFML.
@@ -127,6 +127,8 @@ impl Key {
     /// triggered.
     #[must_use]
     pub fn is_pressed(self) -> bool {
+        thread_safety::assert_window_thread("Key::is_pressed()");
+
         unsafe { ffi::sfKeyboard_isKeyPressed(self as _) }.to_bool()
     }
 }

--- a/src/window/keyboard.rs
+++ b/src/window/keyboard.rs
@@ -127,7 +127,7 @@ impl Key {
     /// triggered.
     #[must_use]
     pub fn is_pressed(self) -> bool {
-        thread_safety::assert_window_thread("Key::is_pressed()");
+        thread_safety::set_window_thread();
 
         unsafe { ffi::sfKeyboard_isKeyPressed(self as _) }.to_bool()
     }

--- a/src/window/mouse.rs
+++ b/src/window/mouse.rs
@@ -29,7 +29,7 @@
 //! window.set_mouse_position(Vector2i::new(100, 200));
 //! ```
 
-use crate::{sf_bool_ext::SfBoolExt, system::Vector2i};
+use crate::{sf_bool_ext::SfBoolExt, system::Vector2i, thread_safety};
 use csfml_window_sys as ffi;
 
 /// Mouse buttons.
@@ -77,6 +77,8 @@ impl Button {
     /// triggered.
     #[must_use]
     pub fn is_pressed(self) -> bool {
+        thread_safety::assert_window_thread("Button::is_pressed()");
+
         unsafe { ffi::sfMouse_isButtonPressed(self.raw()) }.to_bool()
     }
     fn raw(self) -> ffi::sfMouseButton {

--- a/src/window/mouse.rs
+++ b/src/window/mouse.rs
@@ -77,7 +77,7 @@ impl Button {
     /// triggered.
     #[must_use]
     pub fn is_pressed(self) -> bool {
-        thread_safety::assert_window_thread("Button::is_pressed()");
+        thread_safety::set_window_thread();
 
         unsafe { ffi::sfMouse_isButtonPressed(self.raw()) }.to_bool()
     }

--- a/src/window/video_mode.rs
+++ b/src/window/video_mode.rs
@@ -79,7 +79,7 @@ impl VideoMode {
     /// return the urrent desktop video mode
     #[must_use]
     pub fn desktop_mode() -> Self {
-        thread_safety::assert_window_thread("VideoMode::desktop_mode()");
+        thread_safety::set_window_thread();
 
         unsafe { Self::from_raw(ffi::sfVideoMode_getDesktopMode()) }
     }

--- a/src/window/video_mode.rs
+++ b/src/window/video_mode.rs
@@ -1,4 +1,4 @@
-use crate::sf_bool_ext::SfBoolExt;
+use crate::{sf_bool_ext::SfBoolExt, thread_safety};
 use csfml_window_sys as ffi;
 
 /// `VideoMode` defines a video mode (width, height, bpp)
@@ -79,6 +79,8 @@ impl VideoMode {
     /// return the urrent desktop video mode
     #[must_use]
     pub fn desktop_mode() -> Self {
+        thread_safety::assert_window_thread("VideoMode::desktop_mode()");
+
         unsafe { Self::from_raw(ffi::sfVideoMode_getDesktopMode()) }
     }
 

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -1,6 +1,7 @@
 use crate::{
     sf_bool_ext::SfBoolExt,
     system::{SfStrConv, Vector2i, Vector2u},
+    thread_safety,
     window::{ContextSettings, Cursor, Event, Style, VideoMode},
 };
 use csfml_system_sys::sfBool;
@@ -86,6 +87,8 @@ impl Window {
         style: Style,
         settings: &ContextSettings,
     ) -> Window {
+        thread_safety::set_window_thread();
+
         let sf_win: *mut ffi::sfWindow = unsafe {
             title.with_as_sfstr(|sfstr| {
                 ffi::sfWindow_createUnicode(
@@ -117,6 +120,8 @@ impl Window {
     /// * settings - Additional settings for the underlying OpenGL context
     #[must_use]
     pub unsafe fn from_handle(handle: Handle, settings: &ContextSettings) -> Window {
+        thread_safety::set_window_thread();
+
         let sf_win: *mut ffi::sfWindow = ffi::sfWindow_createFromHandle(handle, &settings.raw());
         assert!(!sf_win.is_null(), "Failed to create Window");
         Window { window: sf_win }


### PR DESCRIPTION
This adds the `thread_safety::assert_window_thread`-function, which panics if called from some other thread than the window-thread.
There is still a lot of room for experimentation in order to find out what functions should call `thread_safety::assert_window_thread`, or whether this mechanism is too restrictive or relaxed.
cc #226