### PR TITLE
Add derive `Hash` to joystick axis

### DIFF
--- a/src/window/joystick.rs
+++ b/src/window/joystick.rs
@@ -62,7 +62,7 @@ pub const BUTTON_COUNT: u32 = 32;
 pub const AXIS_COUNT: u32 = 8;
 
 /// Axes supported by SFML joysticks
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Copy)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Copy, Hash)]
 #[repr(transparent)]
 pub struct Axis(pub(super) ffi::sfJoystickAxis);
 


### PR DESCRIPTION
The joystick axis struct is similar to the keyboard key struct which
already derives `Hash`