### PR TITLE
Post-increment index in ConvexShapePoints iterator

### DIFF
--- a/src/graphics/convex_shape.rs
+++ b/src/graphics/convex_shape.rs
@@ -260,13 +260,14 @@ impl Iterator for ConvexShapePoints {
         if self.pos == point_count {
             None
         } else {
-            self.pos += 1;
-            unsafe {
-                Some(Vector2f::from_raw(ffi::sfConvexShape_getPoint(
+            let point = unsafe {
+                Vector2f::from_raw(ffi::sfConvexShape_getPoint(
                     self.convex_shape,
                     self.pos as usize,
-                )))
-            }
+                ))
+            };
+            self.pos += 1;
+            Some(point)
         }
     }
 }


### PR DESCRIPTION
The iterator for `ConvexShape::points()` would increment the current
index *first* and use that to access the point, which causes it to skip
the first one and result in an invalid read for the last one. This
changes it to increment the index *after* getting the point at that
index.

Fixes https://github.com/jeremyletang/rust-sfml/issues/251