### PR TITLE
Added primitive number data type conversion for vec2, vec3, and Rect.

### DIFF
--- a/src/graphics/rect.rs
+++ b/src/graphics/rect.rs
@@ -58,9 +58,9 @@ macro_rules! lossy_from_impls {
         }
     )*}
 }
-
+// float -> float (differently size)
 lossy_from_impls!(f32, f64; f64, f32);
-
+// f32 -> integer
 lossy_from_impls!(
 f32, i8;
 f32, i16;
@@ -73,7 +73,10 @@ f32, u16;
 f32, u32;
 f32, u64;
 f32, u128;
-f32, usize;
+f32, usize
+);
+// integer -> f32
+lossy_from_impls!(
 i8, f32;
 i16, f32;
 i32, f32;
@@ -87,7 +90,7 @@ u64, f32;
 u128, f32;
 usize, f32
 );
-
+// f64 -> integer
 lossy_from_impls!(
 f64, i8;
 f64, i16;
@@ -100,7 +103,10 @@ f64, u16;
 f64, u32;
 f64, u64;
 f64, u128;
-f64, usize;
+f64, usize
+);
+// integer -> f64
+lossy_from_impls!(
 i8, f64;
 i16, f64;
 i32, f64;
@@ -125,7 +131,7 @@ macro_rules! from_impls {
         }
     )*}
 }
-
+// unsigned -> signed
 from_impls!(
 u8, i16;
 u8, i32;
@@ -137,6 +143,32 @@ u16, i128;
 u32, i64;
 u32, i128;
 u64, i128
+);
+// unsigned -> unsigned (different unsize)
+from_impls!(
+u8, u16;
+u8, u32;
+u8, u64;
+u8, u128;
+u16, u32;
+u16, u64;
+u16, u128;
+u32, u64;
+u32, u128;
+u64, u128
+);
+// signed -> signed (different size)
+from_impls!(
+i8, i16;
+i8, i32;
+i8, i64;
+i8, i128;
+i16, i32;
+i16, i64;
+i16, i128;
+i32, i64;
+i32, i128;
+i64, i128
 );
 
 macro_rules! try_from_impls {
@@ -151,8 +183,9 @@ macro_rules! try_from_impls {
         }
     )*}
 }
-
-try_from_impls!(i8, u8, TryFromIntError;
+// signed -> unsigned
+try_from_impls!(
+i8, u8, TryFromIntError;
 i8, u16, TryFromIntError;
 i8, u32, TryFromIntError;
 i8, u64, TryFromIntError;
@@ -189,7 +222,7 @@ isize, u64, TryFromIntError;
 isize, u128, TryFromIntError;
 isize, usize, TryFromIntError
 );
-
+// unsigned -> signed
 try_from_impls!(
 u8, i8, TryFromIntError;
 u8, isize, TryFromIntError;
@@ -218,7 +251,42 @@ usize, i64, TryFromIntError;
 usize, i128, TryFromIntError;
 usize, isize, TryFromIntError
 );
-
+// unsigned -> unsigned (different size)
+try_from_impls!(
+u16, u8, TryFromIntError;
+u32, u16, TryFromIntError;
+u32, u8, TryFromIntError;
+u64, u32, TryFromIntError;
+u64, u16, TryFromIntError;
+u64, u8, TryFromIntError;
+u128, u64, TryFromIntError;
+u128, u32, TryFromIntError;
+u128, u16, TryFromIntError;
+u128, u8, TryFromIntError;
+usize, u8, TryFromIntError;
+usize, u16, TryFromIntError;
+usize, u32, TryFromIntError;
+usize, u64, TryFromIntError;
+usize, u128, TryFromIntError
+);
+// signed -> signed (different size)
+try_from_impls!(
+i16, i8, TryFromIntError;
+i32, i16, TryFromIntError;
+i32, i8, TryFromIntError;
+i64, i32, TryFromIntError;
+i64, i16, TryFromIntError;
+i64, i8, TryFromIntError;
+i128, i64, TryFromIntError;
+i128, i32, TryFromIntError;
+i128, i16, TryFromIntError;
+i128, i8, TryFromIntError;
+isize, i8, TryFromIntError;
+isize, i16, TryFromIntError;
+isize, i32, TryFromIntError;
+isize, i64, TryFromIntError;
+isize, i128, TryFromIntError
+);
 impl<T> Rect<T> {
     /// Construct a rectangle from its coordinates.
     pub const fn new(left: T, top: T, width: T, height: T) -> Self {
@@ -406,6 +474,32 @@ mod test {
         u128, i64;
         u128, i128
         );
+
+        test_try_froms!(
+        i16, i8;
+        i32, i16;
+        i32, i8;
+        i64, i32;
+        i64, i16;
+        i64, i8;
+        i128, i64;
+        i128, i32;
+        i128, i16;
+        i128, i8
+        );
+
+        test_try_froms!(
+        u16, u8;
+        u32, u16;
+        u32, u8;
+        u64, u32;
+        u64, u16;
+        u64, u8;
+        u128, u64;
+        u128, u32;
+        u128, u16;
+        u128, u8
+        );
     }
 
     #[test]
@@ -431,6 +525,32 @@ mod test {
         u32, i128;
         u64, i128
                 );
+
+        test_froms!(
+        u8, u16;
+        u8, u32;
+        u8, u64;
+        u8, u128;
+        u16, u32;
+        u16, u64;
+        u16, u128;
+        u32, u64;
+        u32, u128;
+        u64, u128
+        );
+
+        test_froms!(
+        i8, i16;
+        i8, i32;
+        i8, i64;
+        i8, i128;
+        i16, i32;
+        i16, i64;
+        i16, i128;
+        i32, i64;
+        i32, i128;
+        i64, i128
+        );
     }
 
     #[test]

--- a/src/graphics/rect.rs
+++ b/src/graphics/rect.rs
@@ -1,5 +1,9 @@
 use crate::system::Vector2;
-use std::ops::{Add, Sub};
+use std::{
+    convert::{TryFrom, TryInto},
+    num::TryFromIntError,
+    ops::{Add, Sub},
+};
 
 use crate::ffi;
 
@@ -21,6 +25,199 @@ pub struct Rect<T> {
 pub type IntRect = Rect<i32>;
 /// A [`Rect`] of `f32`.
 pub type FloatRect = Rect<f32>;
+
+pub trait LossyFrom<T> {
+    fn lossy_from(v: T) -> Self;
+}
+
+pub trait LossyInto<T> {
+    fn lossy_into(self) -> T;
+}
+
+impl<T, U> LossyInto<U> for T
+where
+    U: LossyFrom<T>,
+{
+    fn lossy_into(self) -> U {
+        U::lossy_from(self)
+    }
+}
+
+macro_rules! lossy_from_impls {
+    ($( $from:ty, $to:ty );*) => {$(
+        impl LossyFrom<Rect<$from>> for Rect<$to> {
+            #[inline]
+            fn lossy_from(r: Rect<$from>) -> Rect<$to> {
+                Rect {
+                    top: r.top as $to,
+                    left: r.left as $to,
+                    width: r.width as $to,
+                    height: r.height as $to,
+                }
+            }
+        }
+    )*}
+}
+
+lossy_from_impls!(f32, f64; f64, f32);
+
+lossy_from_impls!(
+f32, i8;
+f32, i16;
+f32, i32;
+f32, i64;
+f32, i128;
+f32, isize;
+f32, u8;
+f32, u16;
+f32, u32;
+f32, u64;
+f32, u128;
+f32, usize;
+i8, f32;
+i16, f32;
+i32, f32;
+i64, f32;
+i128, f32;
+isize, f32;
+u8, f32;
+u16, f32;
+u32, f32;
+u64, f32;
+u128, f32;
+usize, f32
+);
+
+lossy_from_impls!(
+f64, i8;
+f64, i16;
+f64, i32;
+f64, i64;
+f64, i128;
+f64, isize;
+f64, u8;
+f64, u16;
+f64, u32;
+f64, u64;
+f64, u128;
+f64, usize;
+i8, f64;
+i16, f64;
+i32, f64;
+i64, f64;
+i128, f64;
+isize, f64;
+u8, f64;
+u16, f64;
+u32, f64;
+u64, f64;
+u128, f64;
+usize, f64
+);
+
+macro_rules! from_impls {
+    ($( $from:ty, $to:ty );*) => {$(
+        impl From<Rect<$from>> for Rect<$to> {
+            #[inline]
+            fn from(r: Rect<$from>) -> Rect<$to> {
+                Rect { top:r.top.into(), left: r.left.into(), width: r.width.into(), height: r.height.into() }
+            }
+        }
+    )*}
+}
+
+from_impls!(
+u8, i16;
+u8, i32;
+u8, i64;
+u8, i128;
+u16, i32;
+u16, i64;
+u16, i128;
+u32, i64;
+u32, i128;
+u64, i128
+);
+
+macro_rules! try_from_impls {
+    ($( $from:ty, $to:ty, $from_err: ty );*) => {$(
+        impl TryFrom<Rect<$from>> for Rect<$to> {
+            type Error = $from_err;
+
+            #[inline]
+            fn try_from(r: Rect<$from>) -> Result<Rect<$to>, Self::Error> {
+                Ok(Rect{ top: r.top.try_into()?, left: r.left.try_into()?, width: r.width.try_into()?, height: r.height.try_into()? })
+            }
+        }
+    )*}
+}
+
+try_from_impls!(i8, u8, TryFromIntError;
+i8, u16, TryFromIntError;
+i8, u32, TryFromIntError;
+i8, u64, TryFromIntError;
+i8, u128, TryFromIntError;
+i8, usize, TryFromIntError;
+i16, u8, TryFromIntError;
+i16, u16, TryFromIntError;
+i16, u32, TryFromIntError;
+i16, u64, TryFromIntError;
+i16, u128, TryFromIntError;
+i16, usize, TryFromIntError;
+i32, u8, TryFromIntError;
+i32, u16, TryFromIntError;
+i32, u32, TryFromIntError;
+i32, u64, TryFromIntError;
+i32, u128, TryFromIntError;
+i32, usize, TryFromIntError;
+i64, u8, TryFromIntError;
+i64, u16, TryFromIntError;
+i64, u32, TryFromIntError;
+i64, u64, TryFromIntError;
+i64, u128, TryFromIntError;
+i64, usize, TryFromIntError;
+i128, u8, TryFromIntError;
+i128, u16, TryFromIntError;
+i128, u32, TryFromIntError;
+i128, u64, TryFromIntError;
+i128, u128, TryFromIntError;
+i128, usize, TryFromIntError;
+isize, u8, TryFromIntError;
+isize, u16, TryFromIntError;
+isize, u32, TryFromIntError;
+isize, u64, TryFromIntError;
+isize, u128, TryFromIntError;
+isize, usize, TryFromIntError
+);
+
+try_from_impls!(
+u8, i8, TryFromIntError;
+u8, isize, TryFromIntError;
+u16, i8, TryFromIntError;
+u16, i16, TryFromIntError;
+u16, isize, TryFromIntError;
+u32, i8, TryFromIntError;
+u32, i16, TryFromIntError;
+u32, i32, TryFromIntError;
+u32, isize, TryFromIntError;
+u64, i8, TryFromIntError;
+u64, i16, TryFromIntError;
+u64, i32, TryFromIntError;
+u64, i64, TryFromIntError;
+u64, isize, TryFromIntError;
+u128, i8, TryFromIntError;
+u128, i16, TryFromIntError;
+u128, i32, TryFromIntError;
+u128, i64, TryFromIntError;
+u128, i128, TryFromIntError;
+u128, isize, TryFromIntError;
+usize, i8, TryFromIntError;
+usize, i16, TryFromIntError;
+usize, i32, TryFromIntError;
+usize, i64, TryFromIntError;
+usize, i128, TryFromIntError;
+usize, isize, TryFromIntError
+);
 
 impl<T> Rect<T> {
     /// Construct a rectangle from its coordinates.
@@ -143,5 +340,160 @@ impl FloatRect {
             width: raw.width,
             height: raw.height,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn try_from() {
+        macro_rules! test_try_froms {
+            ($( $from:ty, $to:ty);*) => {$(
+                let from: Rect<$from> = Rect { top: 0, left: 0, width: 0, height: 0 };
+                let to: Result<Rect<$to>, TryFromIntError> = from.try_into();
+                assert!(to.is_ok());
+
+                let from: Rect<$from> = Rect { top: <$from>::MAX, left: <$from>::MIN, width: 0, height: 0 };
+                let to: Result<Rect<$to>, TryFromIntError> = from.try_into();
+                assert!(to.is_err());
+            )*}
+        }
+
+        test_try_froms!(
+        i8, u8;
+        i8, u16;
+        i8, u32;
+        i8, u64;
+        i8, u128;
+        i16, u8;
+        i16, u16;
+        i16, u32;
+        i16, u64;
+        i16, u128;
+        i32, u8;
+        i32, u16;
+        i32, u32;
+        i32, u64;
+        i32, u128;
+        i64, u8;
+        i64, u16;
+        i64, u32;
+        i64, u64;
+        i64, u128;
+        i128, u8;
+        i128, u16;
+        i128, u32;
+        i128, u64;
+        i128, u128
+        );
+
+        test_try_froms!(
+        u8, i8;
+        u16, i8;
+        u16, i16;
+        u32, i8;
+        u32, i16;
+        u32, i32;
+        u64, i8;
+        u64, i16;
+        u64, i32;
+        u64, i64;
+        u128, i8;
+        u128, i16;
+        u128, i32;
+        u128, i64;
+        u128, i128
+        );
+    }
+
+    #[test]
+    fn from() {
+        macro_rules! test_froms {
+            ($( $from:ty, $to:ty);*) => {$(
+                let from: Rect<$from> = Rect { top: 0, left: 0, width: 0, height: 0 };
+                let _to: Rect<$to> = from.into();
+                let from: Rect<$from> = Rect { top: <$from>::MAX, left: <$from>::MIN, width: 0, height: 0 };
+                let _to: Rect<$to> = from.into();
+            )*}
+        }
+
+        test_froms!(
+        u8, i16;
+        u8, i32;
+        u8, i64;
+        u8, i128;
+        u16, i32;
+        u16, i64;
+        u16, i128;
+        u32, i64;
+        u32, i128;
+        u64, i128
+                );
+    }
+
+    #[test]
+    fn lossy_from() {
+        macro_rules! test_lossy_froms {
+            ($( $from:ty, $to:ty);*) => {$(
+                let from: Rect<$from> = Rect{ top: <$from>::MAX, left: <$from>::MIN, width: <$from>::MAX, height: <$from>::MIN};
+                let _to: Rect<$to> = from.lossy_into();
+            )*}
+        }
+
+        test_lossy_froms!(
+        f32, i8;
+        f32, i16;
+        f32, i32;
+        f32, i64;
+        f32, i128;
+        f32, isize;
+        f32, u8;
+        f32, u16;
+        f32, u32;
+        f32, u64;
+        f32, u128;
+        f32, usize;
+        i8, f32;
+        i16, f32;
+        i32, f32;
+        i64, f32;
+        i128, f32;
+        isize, f32;
+        u8, f32;
+        u16, f32;
+        u32, f32;
+        u64, f32;
+        u128, f32;
+        usize, f32
+        );
+        test_lossy_froms!(
+        f64, i8;
+        f64, i16;
+        f64, i32;
+        f64, i64;
+        f64, i128;
+        f64, isize;
+        f64, u8;
+        f64, u16;
+        f64, u32;
+        f64, u64;
+        f64, u128;
+        f64, usize;
+        i8, f64;
+        i16, f64;
+        i32, f64;
+        i64, f64;
+        i128, f64;
+        isize, f64;
+        u8, f64;
+        u16, f64;
+        u32, f64;
+        u64, f64;
+        u128, f64;
+        usize, f64
+        );
+        test_lossy_froms!(f32, f64; f64, f32);
     }
 }

--- a/src/system/vector2.rs
+++ b/src/system/vector2.rs
@@ -1,4 +1,8 @@
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use std::{
+    convert::{TryFrom, TryInto},
+    num::TryFromIntError,
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+};
 
 /// Utility type for manipulating 2-dimensional vectors.
 ///
@@ -65,6 +69,197 @@ impl<T> From<(T, T)> for Vector2<T> {
         Self { x: src.0, y: src.1 }
     }
 }
+
+pub trait LossyFrom<T> {
+    fn lossy_from(v: T) -> Self;
+}
+
+pub trait LossyInto<T> {
+    fn lossy_into(self) -> T;
+}
+
+impl<T, U> LossyInto<U> for T
+where
+    U: LossyFrom<T>,
+{
+    fn lossy_into(self) -> U {
+        U::lossy_from(self)
+    }
+}
+
+macro_rules! lossy_from_impls {
+    ($( $from:ty, $to:ty );*) => {$(
+        impl LossyFrom<Vector2<$from>> for Vector2<$to> {
+            #[inline]
+            fn lossy_from(v: Vector2<$from>) -> Vector2<$to> {
+                Vector2 {
+                    x: v.x as $to,
+                    y: v.y as $to
+                }
+            }
+        }
+    )*}
+}
+
+lossy_from_impls!(f32, f64; f64, f32);
+
+lossy_from_impls!(
+f32, i8;
+f32, i16;
+f32, i32;
+f32, i64;
+f32, i128;
+f32, isize;
+f32, u8;
+f32, u16;
+f32, u32;
+f32, u64;
+f32, u128;
+f32, usize;
+i8, f32;
+i16, f32;
+i32, f32;
+i64, f32;
+i128, f32;
+isize, f32;
+u8, f32;
+u16, f32;
+u32, f32;
+u64, f32;
+u128, f32;
+usize, f32
+);
+
+lossy_from_impls!(
+f64, i8;
+f64, i16;
+f64, i32;
+f64, i64;
+f64, i128;
+f64, isize;
+f64, u8;
+f64, u16;
+f64, u32;
+f64, u64;
+f64, u128;
+f64, usize;
+i8, f64;
+i16, f64;
+i32, f64;
+i64, f64;
+i128, f64;
+isize, f64;
+u8, f64;
+u16, f64;
+u32, f64;
+u64, f64;
+u128, f64;
+usize, f64
+);
+
+macro_rules! from_impls {
+    ($( $from:ty, $to:ty );*) => {$(
+        impl From<Vector2<$from>> for Vector2<$to> {
+            #[inline]
+            fn from(v: Vector2<$from>) -> Vector2<$to> {
+                Vector2{ x:v.x.into(), y: v.y.into() }
+            }
+        }
+    )*}
+}
+
+from_impls!(
+u8, i16;
+u8, i32;
+u8, i64;
+u8, i128;
+u16, i32;
+u16, i64;
+u16, i128;
+u32, i64;
+u32, i128;
+u64, i128
+);
+
+macro_rules! try_from_impls {
+    ($( $from:ty, $to:ty, $from_err: ty );*) => {$(
+        impl TryFrom<Vector2<$from>> for Vector2<$to> {
+            type Error = $from_err;
+
+            #[inline]
+            fn try_from(v: Vector2<$from>) -> Result<Vector2<$to>, Self::Error> {
+                Ok(Vector2{ x: v.x.try_into()?, y: v.y.try_into()? })
+            }
+        }
+    )*}
+}
+
+try_from_impls!(i8, u8, TryFromIntError;
+i8, u16, TryFromIntError;
+i8, u32, TryFromIntError;
+i8, u64, TryFromIntError;
+i8, u128, TryFromIntError;
+i8, usize, TryFromIntError;
+i16, u8, TryFromIntError;
+i16, u16, TryFromIntError;
+i16, u32, TryFromIntError;
+i16, u64, TryFromIntError;
+i16, u128, TryFromIntError;
+i16, usize, TryFromIntError;
+i32, u8, TryFromIntError;
+i32, u16, TryFromIntError;
+i32, u32, TryFromIntError;
+i32, u64, TryFromIntError;
+i32, u128, TryFromIntError;
+i32, usize, TryFromIntError;
+i64, u8, TryFromIntError;
+i64, u16, TryFromIntError;
+i64, u32, TryFromIntError;
+i64, u64, TryFromIntError;
+i64, u128, TryFromIntError;
+i64, usize, TryFromIntError;
+i128, u8, TryFromIntError;
+i128, u16, TryFromIntError;
+i128, u32, TryFromIntError;
+i128, u64, TryFromIntError;
+i128, u128, TryFromIntError;
+i128, usize, TryFromIntError;
+isize, u8, TryFromIntError;
+isize, u16, TryFromIntError;
+isize, u32, TryFromIntError;
+isize, u64, TryFromIntError;
+isize, u128, TryFromIntError;
+isize, usize, TryFromIntError
+);
+
+try_from_impls!(
+u8, i8, TryFromIntError;
+u8, isize, TryFromIntError;
+u16, i8, TryFromIntError;
+u16, i16, TryFromIntError;
+u16, isize, TryFromIntError;
+u32, i8, TryFromIntError;
+u32, i16, TryFromIntError;
+u32, i32, TryFromIntError;
+u32, isize, TryFromIntError;
+u64, i8, TryFromIntError;
+u64, i16, TryFromIntError;
+u64, i32, TryFromIntError;
+u64, i64, TryFromIntError;
+u64, isize, TryFromIntError;
+u128, i8, TryFromIntError;
+u128, i16, TryFromIntError;
+u128, i32, TryFromIntError;
+u128, i64, TryFromIntError;
+u128, i128, TryFromIntError;
+u128, isize, TryFromIntError;
+usize, i8, TryFromIntError;
+usize, i16, TryFromIntError;
+usize, i32, TryFromIntError;
+usize, i64, TryFromIntError;
+usize, i128, TryFromIntError;
+usize, isize, TryFromIntError
+);
 
 macro_rules! impl_ops {
     ( $_trait:ident, $_func:ident, $( $_type:ty ),+ ) => {
@@ -217,5 +412,160 @@ impl Vector2f {
     }
     pub(crate) fn from_raw(raw: crate::ffi::sfVector2f) -> Self {
         Self { x: raw.x, y: raw.y }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn try_from() {
+        macro_rules! test_try_froms {
+            ($( $from:ty, $to:ty);*) => {$(
+                let from: Vector2<$from> = Vector2 { x: 0, y: 0 };
+                let to: Result<Vector2<$to>, TryFromIntError> = from.try_into();
+                assert!(to.is_ok());
+
+                let from: Vector2<$from> = Vector2 { x: <$from>::MAX, y: <$from>::MIN };
+                let to: Result<Vector2<$to>, TryFromIntError> = from.try_into();
+                assert!(to.is_err());
+            )*}
+        }
+
+        test_try_froms!(
+        i8, u8;
+        i8, u16;
+        i8, u32;
+        i8, u64;
+        i8, u128;
+        i16, u8;
+        i16, u16;
+        i16, u32;
+        i16, u64;
+        i16, u128;
+        i32, u8;
+        i32, u16;
+        i32, u32;
+        i32, u64;
+        i32, u128;
+        i64, u8;
+        i64, u16;
+        i64, u32;
+        i64, u64;
+        i64, u128;
+        i128, u8;
+        i128, u16;
+        i128, u32;
+        i128, u64;
+        i128, u128
+        );
+
+        test_try_froms!(
+        u8, i8;
+        u16, i8;
+        u16, i16;
+        u32, i8;
+        u32, i16;
+        u32, i32;
+        u64, i8;
+        u64, i16;
+        u64, i32;
+        u64, i64;
+        u128, i8;
+        u128, i16;
+        u128, i32;
+        u128, i64;
+        u128, i128
+        );
+    }
+
+    #[test]
+    fn from() {
+        macro_rules! test_froms {
+            ($( $from:ty, $to:ty);*) => {$(
+                let from: Vector2<$from> = Vector2 { x: 0, y: 0 };
+                let _to: Vector2<$to> = from.into();
+                let from: Vector2<$from> = Vector2 { x: <$from>::MAX, y: <$from>::MIN };
+                let _to: Vector2<$to> = from.into();
+            )*}
+        }
+
+        test_froms!(
+        u8, i16;
+        u8, i32;
+        u8, i64;
+        u8, i128;
+        u16, i32;
+        u16, i64;
+        u16, i128;
+        u32, i64;
+        u32, i128;
+        u64, i128
+                );
+    }
+
+    #[test]
+    fn lossy_from() {
+        macro_rules! test_lossy_froms {
+            ($( $from:ty, $to:ty);*) => {$(
+                let from: Vector2<$from> = Vector2{ x: <$from>::MAX, y: <$from>::MIN};
+                let _to: Vector2<$to> = from.lossy_into();
+            )*}
+        }
+
+        test_lossy_froms!(
+        f32, i8;
+        f32, i16;
+        f32, i32;
+        f32, i64;
+        f32, i128;
+        f32, isize;
+        f32, u8;
+        f32, u16;
+        f32, u32;
+        f32, u64;
+        f32, u128;
+        f32, usize;
+        i8, f32;
+        i16, f32;
+        i32, f32;
+        i64, f32;
+        i128, f32;
+        isize, f32;
+        u8, f32;
+        u16, f32;
+        u32, f32;
+        u64, f32;
+        u128, f32;
+        usize, f32
+        );
+        test_lossy_froms!(
+        f64, i8;
+        f64, i16;
+        f64, i32;
+        f64, i64;
+        f64, i128;
+        f64, isize;
+        f64, u8;
+        f64, u16;
+        f64, u32;
+        f64, u64;
+        f64, u128;
+        f64, usize;
+        i8, f64;
+        i16, f64;
+        i32, f64;
+        i64, f64;
+        i128, f64;
+        isize, f64;
+        u8, f64;
+        u16, f64;
+        u32, f64;
+        u64, f64;
+        u128, f64;
+        usize, f64
+        );
+        test_lossy_froms!(f32, f64; f64, f32);
     }
 }

--- a/src/system/vector2.rs
+++ b/src/system/vector2.rs
@@ -100,9 +100,9 @@ macro_rules! lossy_from_impls {
         }
     )*}
 }
-
+// float -> float (differently size)
 lossy_from_impls!(f32, f64; f64, f32);
-
+// f32 -> integer
 lossy_from_impls!(
 f32, i8;
 f32, i16;
@@ -115,7 +115,10 @@ f32, u16;
 f32, u32;
 f32, u64;
 f32, u128;
-f32, usize;
+f32, usize
+);
+// integer -> f32
+lossy_from_impls!(
 i8, f32;
 i16, f32;
 i32, f32;
@@ -129,7 +132,7 @@ u64, f32;
 u128, f32;
 usize, f32
 );
-
+// f64 -> integer
 lossy_from_impls!(
 f64, i8;
 f64, i16;
@@ -142,7 +145,10 @@ f64, u16;
 f64, u32;
 f64, u64;
 f64, u128;
-f64, usize;
+f64, usize
+);
+// integer -> f64
+lossy_from_impls!(
 i8, f64;
 i16, f64;
 i32, f64;
@@ -167,7 +173,7 @@ macro_rules! from_impls {
         }
     )*}
 }
-
+// unsigned -> signed
 from_impls!(
 u8, i16;
 u8, i32;
@@ -179,6 +185,32 @@ u16, i128;
 u32, i64;
 u32, i128;
 u64, i128
+);
+// unsigned -> unsigned (different unsize)
+from_impls!(
+u8, u16;
+u8, u32;
+u8, u64;
+u8, u128;
+u16, u32;
+u16, u64;
+u16, u128;
+u32, u64;
+u32, u128;
+u64, u128
+);
+// signed -> signed (different size)
+from_impls!(
+i8, i16;
+i8, i32;
+i8, i64;
+i8, i128;
+i16, i32;
+i16, i64;
+i16, i128;
+i32, i64;
+i32, i128;
+i64, i128
 );
 
 macro_rules! try_from_impls {
@@ -193,8 +225,9 @@ macro_rules! try_from_impls {
         }
     )*}
 }
-
-try_from_impls!(i8, u8, TryFromIntError;
+// signed -> unsigned
+try_from_impls!(
+i8, u8, TryFromIntError;
 i8, u16, TryFromIntError;
 i8, u32, TryFromIntError;
 i8, u64, TryFromIntError;
@@ -231,7 +264,7 @@ isize, u64, TryFromIntError;
 isize, u128, TryFromIntError;
 isize, usize, TryFromIntError
 );
-
+// unsigned -> signed
 try_from_impls!(
 u8, i8, TryFromIntError;
 u8, isize, TryFromIntError;
@@ -259,6 +292,42 @@ usize, i32, TryFromIntError;
 usize, i64, TryFromIntError;
 usize, i128, TryFromIntError;
 usize, isize, TryFromIntError
+);
+// unsigned -> unsigned (different size)
+try_from_impls!(
+u16, u8, TryFromIntError;
+u32, u16, TryFromIntError;
+u32, u8, TryFromIntError;
+u64, u32, TryFromIntError;
+u64, u16, TryFromIntError;
+u64, u8, TryFromIntError;
+u128, u64, TryFromIntError;
+u128, u32, TryFromIntError;
+u128, u16, TryFromIntError;
+u128, u8, TryFromIntError;
+usize, u8, TryFromIntError;
+usize, u16, TryFromIntError;
+usize, u32, TryFromIntError;
+usize, u64, TryFromIntError;
+usize, u128, TryFromIntError
+);
+// signed -> signed (different size)
+try_from_impls!(
+i16, i8, TryFromIntError;
+i32, i16, TryFromIntError;
+i32, i8, TryFromIntError;
+i64, i32, TryFromIntError;
+i64, i16, TryFromIntError;
+i64, i8, TryFromIntError;
+i128, i64, TryFromIntError;
+i128, i32, TryFromIntError;
+i128, i16, TryFromIntError;
+i128, i8, TryFromIntError;
+isize, i8, TryFromIntError;
+isize, i16, TryFromIntError;
+isize, i32, TryFromIntError;
+isize, i64, TryFromIntError;
+isize, i128, TryFromIntError
 );
 
 macro_rules! impl_ops {
@@ -478,6 +547,32 @@ mod test {
         u128, i64;
         u128, i128
         );
+
+        test_try_froms!(
+        i16, i8;
+        i32, i16;
+        i32, i8;
+        i64, i32;
+        i64, i16;
+        i64, i8;
+        i128, i64;
+        i128, i32;
+        i128, i16;
+        i128, i8
+        );
+
+        test_try_froms!(
+        u16, u8;
+        u32, u16;
+        u32, u8;
+        u64, u32;
+        u64, u16;
+        u64, u8;
+        u128, u64;
+        u128, u32;
+        u128, u16;
+        u128, u8
+        );
     }
 
     #[test]
@@ -503,6 +598,32 @@ mod test {
         u32, i128;
         u64, i128
                 );
+
+        test_froms!(
+        u8, u16;
+        u8, u32;
+        u8, u64;
+        u8, u128;
+        u16, u32;
+        u16, u64;
+        u16, u128;
+        u32, u64;
+        u32, u128;
+        u64, u128
+        );
+
+        test_froms!(
+        i8, i16;
+        i8, i32;
+        i8, i64;
+        i8, i128;
+        i16, i32;
+        i16, i64;
+        i16, i128;
+        i32, i64;
+        i32, i128;
+        i64, i128
+        );
     }
 
     #[test]

--- a/src/system/vector3.rs
+++ b/src/system/vector3.rs
@@ -95,9 +95,9 @@ macro_rules! lossy_from_impls {
         }
     )*}
 }
-
+// float -> float (differently size)
 lossy_from_impls!(f32, f64; f64, f32);
-
+// f32 -> integer
 lossy_from_impls!(
 f32, i8;
 f32, i16;
@@ -110,7 +110,10 @@ f32, u16;
 f32, u32;
 f32, u64;
 f32, u128;
-f32, usize;
+f32, usize
+);
+// integer -> f32
+lossy_from_impls!(
 i8, f32;
 i16, f32;
 i32, f32;
@@ -124,7 +127,7 @@ u64, f32;
 u128, f32;
 usize, f32
 );
-
+// f64 -> integer
 lossy_from_impls!(
 f64, i8;
 f64, i16;
@@ -137,7 +140,10 @@ f64, u16;
 f64, u32;
 f64, u64;
 f64, u128;
-f64, usize;
+f64, usize
+);
+// integer -> f64
+lossy_from_impls!(
 i8, f64;
 i16, f64;
 i32, f64;
@@ -162,7 +168,7 @@ macro_rules! from_impls {
         }
     )*}
 }
-
+// unsigned -> signed
 from_impls!(
 u8, i16;
 u8, i32;
@@ -174,6 +180,32 @@ u16, i128;
 u32, i64;
 u32, i128;
 u64, i128
+);
+// unsigned -> unsigned (different unsize)
+from_impls!(
+u8, u16;
+u8, u32;
+u8, u64;
+u8, u128;
+u16, u32;
+u16, u64;
+u16, u128;
+u32, u64;
+u32, u128;
+u64, u128
+);
+// signed -> signed (different size)
+from_impls!(
+i8, i16;
+i8, i32;
+i8, i64;
+i8, i128;
+i16, i32;
+i16, i64;
+i16, i128;
+i32, i64;
+i32, i128;
+i64, i128
 );
 
 macro_rules! try_from_impls {
@@ -188,7 +220,7 @@ macro_rules! try_from_impls {
         }
     )*}
 }
-
+// signed -> unsigned
 try_from_impls!(i8, u8, TryFromIntError;
 i8, u16, TryFromIntError;
 i8, u32, TryFromIntError;
@@ -226,7 +258,7 @@ isize, u64, TryFromIntError;
 isize, u128, TryFromIntError;
 isize, usize, TryFromIntError
 );
-
+// unsigned -> signed
 try_from_impls!(
 u8, i8, TryFromIntError;
 u8, isize, TryFromIntError;
@@ -254,6 +286,42 @@ usize, i32, TryFromIntError;
 usize, i64, TryFromIntError;
 usize, i128, TryFromIntError;
 usize, isize, TryFromIntError
+);
+// unsigned -> unsigned (different size)
+try_from_impls!(
+u16, u8, TryFromIntError;
+u32, u16, TryFromIntError;
+u32, u8, TryFromIntError;
+u64, u32, TryFromIntError;
+u64, u16, TryFromIntError;
+u64, u8, TryFromIntError;
+u128, u64, TryFromIntError;
+u128, u32, TryFromIntError;
+u128, u16, TryFromIntError;
+u128, u8, TryFromIntError;
+usize, u8, TryFromIntError;
+usize, u16, TryFromIntError;
+usize, u32, TryFromIntError;
+usize, u64, TryFromIntError;
+usize, u128, TryFromIntError
+);
+// signed -> signed (different size)
+try_from_impls!(
+i16, i8, TryFromIntError;
+i32, i16, TryFromIntError;
+i32, i8, TryFromIntError;
+i64, i32, TryFromIntError;
+i64, i16, TryFromIntError;
+i64, i8, TryFromIntError;
+i128, i64, TryFromIntError;
+i128, i32, TryFromIntError;
+i128, i16, TryFromIntError;
+i128, i8, TryFromIntError;
+isize, i8, TryFromIntError;
+isize, i16, TryFromIntError;
+isize, i32, TryFromIntError;
+isize, i64, TryFromIntError;
+isize, i128, TryFromIntError
 );
 
 macro_rules! impl_ops {
@@ -476,6 +544,32 @@ mod test {
         u128, i64;
         u128, i128
         );
+
+        test_try_froms!(
+        i16, i8;
+        i32, i16;
+        i32, i8;
+        i64, i32;
+        i64, i16;
+        i64, i8;
+        i128, i64;
+        i128, i32;
+        i128, i16;
+        i128, i8
+        );
+
+        test_try_froms!(
+        u16, u8;
+        u32, u16;
+        u32, u8;
+        u64, u32;
+        u64, u16;
+        u64, u8;
+        u128, u64;
+        u128, u32;
+        u128, u16;
+        u128, u8
+        );
     }
 
     #[test]
@@ -501,6 +595,32 @@ mod test {
         u32, i128;
         u64, i128
                 );
+
+        test_froms!(
+        u8, u16;
+        u8, u32;
+        u8, u64;
+        u8, u128;
+        u16, u32;
+        u16, u64;
+        u16, u128;
+        u32, u64;
+        u32, u128;
+        u64, u128
+        );
+
+        test_froms!(
+        i8, i16;
+        i8, i32;
+        i8, i64;
+        i8, i128;
+        i16, i32;
+        i16, i64;
+        i16, i128;
+        i32, i64;
+        i32, i128;
+        i64, i128
+        );
     }
 
     #[test]

--- a/src/system/vector3.rs
+++ b/src/system/vector3.rs
@@ -1,4 +1,8 @@
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use std::{
+    convert::{TryFrom, TryInto},
+    num::TryFromIntError,
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+};
 
 /// Utility type for manipulating 3-dimensional vectors.
 ///
@@ -59,6 +63,198 @@ impl<T> Vector3<T> {
 pub type Vector3f = Vector3<f32>;
 /// [`Vector3`] with `i32` coordinates.
 pub type Vector3i = Vector3<i32>;
+
+pub trait LossyFrom<T> {
+    fn lossy_from(v: T) -> Self;
+}
+
+pub trait LossyInto<T> {
+    fn lossy_into(self) -> T;
+}
+
+impl<T, U> LossyInto<U> for T
+where
+    U: LossyFrom<T>,
+{
+    fn lossy_into(self) -> U {
+        U::lossy_from(self)
+    }
+}
+
+macro_rules! lossy_from_impls {
+    ($( $from:ty, $to:ty );*) => {$(
+        impl LossyFrom<Vector3<$from>> for Vector3<$to> {
+            #[inline]
+            fn lossy_from(v: Vector3<$from>) -> Vector3<$to> {
+                Vector3 {
+                    x: v.x as $to,
+                    y: v.y as $to,
+                    z: v.z as $to
+                }
+            }
+        }
+    )*}
+}
+
+lossy_from_impls!(f32, f64; f64, f32);
+
+lossy_from_impls!(
+f32, i8;
+f32, i16;
+f32, i32;
+f32, i64;
+f32, i128;
+f32, isize;
+f32, u8;
+f32, u16;
+f32, u32;
+f32, u64;
+f32, u128;
+f32, usize;
+i8, f32;
+i16, f32;
+i32, f32;
+i64, f32;
+i128, f32;
+isize, f32;
+u8, f32;
+u16, f32;
+u32, f32;
+u64, f32;
+u128, f32;
+usize, f32
+);
+
+lossy_from_impls!(
+f64, i8;
+f64, i16;
+f64, i32;
+f64, i64;
+f64, i128;
+f64, isize;
+f64, u8;
+f64, u16;
+f64, u32;
+f64, u64;
+f64, u128;
+f64, usize;
+i8, f64;
+i16, f64;
+i32, f64;
+i64, f64;
+i128, f64;
+isize, f64;
+u8, f64;
+u16, f64;
+u32, f64;
+u64, f64;
+u128, f64;
+usize, f64
+);
+
+macro_rules! from_impls {
+    ($( $from:ty, $to:ty );*) => {$(
+        impl From<Vector3<$from>> for Vector3<$to> {
+            #[inline]
+            fn from(v: Vector3<$from>) -> Vector3<$to> {
+                Vector3{ x:v.x.into(), y: v.y.into(), z: v.z.into() }
+            }
+        }
+    )*}
+}
+
+from_impls!(
+u8, i16;
+u8, i32;
+u8, i64;
+u8, i128;
+u16, i32;
+u16, i64;
+u16, i128;
+u32, i64;
+u32, i128;
+u64, i128
+);
+
+macro_rules! try_from_impls {
+    ($( $from:ty, $to:ty, $from_err: ty );*) => {$(
+        impl TryFrom<Vector3<$from>> for Vector3<$to> {
+            type Error = $from_err;
+
+            #[inline]
+            fn try_from(v: Vector3<$from>) -> Result<Vector3<$to>, Self::Error> {
+                Ok(Vector3{ x: v.x.try_into()?, y: v.y.try_into()?, z: v.z.try_into()? })
+            }
+        }
+    )*}
+}
+
+try_from_impls!(i8, u8, TryFromIntError;
+i8, u16, TryFromIntError;
+i8, u32, TryFromIntError;
+i8, u64, TryFromIntError;
+i8, u128, TryFromIntError;
+i8, usize, TryFromIntError;
+i16, u8, TryFromIntError;
+i16, u16, TryFromIntError;
+i16, u32, TryFromIntError;
+i16, u64, TryFromIntError;
+i16, u128, TryFromIntError;
+i16, usize, TryFromIntError;
+i32, u8, TryFromIntError;
+i32, u16, TryFromIntError;
+i32, u32, TryFromIntError;
+i32, u64, TryFromIntError;
+i32, u128, TryFromIntError;
+i32, usize, TryFromIntError;
+i64, u8, TryFromIntError;
+i64, u16, TryFromIntError;
+i64, u32, TryFromIntError;
+i64, u64, TryFromIntError;
+i64, u128, TryFromIntError;
+i64, usize, TryFromIntError;
+i128, u8, TryFromIntError;
+i128, u16, TryFromIntError;
+i128, u32, TryFromIntError;
+i128, u64, TryFromIntError;
+i128, u128, TryFromIntError;
+i128, usize, TryFromIntError;
+isize, u8, TryFromIntError;
+isize, u16, TryFromIntError;
+isize, u32, TryFromIntError;
+isize, u64, TryFromIntError;
+isize, u128, TryFromIntError;
+isize, usize, TryFromIntError
+);
+
+try_from_impls!(
+u8, i8, TryFromIntError;
+u8, isize, TryFromIntError;
+u16, i8, TryFromIntError;
+u16, i16, TryFromIntError;
+u16, isize, TryFromIntError;
+u32, i8, TryFromIntError;
+u32, i16, TryFromIntError;
+u32, i32, TryFromIntError;
+u32, isize, TryFromIntError;
+u64, i8, TryFromIntError;
+u64, i16, TryFromIntError;
+u64, i32, TryFromIntError;
+u64, i64, TryFromIntError;
+u64, isize, TryFromIntError;
+u128, i8, TryFromIntError;
+u128, i16, TryFromIntError;
+u128, i32, TryFromIntError;
+u128, i64, TryFromIntError;
+u128, i128, TryFromIntError;
+u128, isize, TryFromIntError;
+usize, i8, TryFromIntError;
+usize, i16, TryFromIntError;
+usize, i32, TryFromIntError;
+usize, i64, TryFromIntError;
+usize, i128, TryFromIntError;
+usize, isize, TryFromIntError
+);
 
 macro_rules! impl_ops {
     ( $_trait:ident, $_func:ident, $( $_type:ty ),+ ) => {
@@ -214,5 +410,160 @@ impl Vector3f {
             y: raw.y,
             z: raw.z,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn try_from() {
+        macro_rules! test_try_froms {
+            ($( $from:ty, $to:ty);*) => {$(
+                let from: Vector3<$from> = Vector3 { x: 0, y: 0, z: 0 };
+                let to: Result<Vector3<$to>, TryFromIntError> = from.try_into();
+                assert!(to.is_ok());
+
+                let from: Vector3<$from> = Vector3 { x: <$from>::MAX, y: <$from>::MIN, z: 0 };
+                let to: Result<Vector3<$to>, TryFromIntError> = from.try_into();
+                assert!(to.is_err());
+            )*}
+        }
+
+        test_try_froms!(
+        i8, u8;
+        i8, u16;
+        i8, u32;
+        i8, u64;
+        i8, u128;
+        i16, u8;
+        i16, u16;
+        i16, u32;
+        i16, u64;
+        i16, u128;
+        i32, u8;
+        i32, u16;
+        i32, u32;
+        i32, u64;
+        i32, u128;
+        i64, u8;
+        i64, u16;
+        i64, u32;
+        i64, u64;
+        i64, u128;
+        i128, u8;
+        i128, u16;
+        i128, u32;
+        i128, u64;
+        i128, u128
+        );
+
+        test_try_froms!(
+        u8, i8;
+        u16, i8;
+        u16, i16;
+        u32, i8;
+        u32, i16;
+        u32, i32;
+        u64, i8;
+        u64, i16;
+        u64, i32;
+        u64, i64;
+        u128, i8;
+        u128, i16;
+        u128, i32;
+        u128, i64;
+        u128, i128
+        );
+    }
+
+    #[test]
+    fn from() {
+        macro_rules! test_froms {
+            ($( $from:ty, $to:ty);*) => {$(
+                let from: Vector3<$from> = Vector3 { x: 0, y: 0, z: 0 };
+                let _to: Vector3<$to> = from.into();
+                let from: Vector3<$from> = Vector3 { x: <$from>::MAX, y: <$from>::MIN, z: 0 };
+                let _to: Vector3<$to> = from.into();
+            )*}
+        }
+
+        test_froms!(
+        u8, i16;
+        u8, i32;
+        u8, i64;
+        u8, i128;
+        u16, i32;
+        u16, i64;
+        u16, i128;
+        u32, i64;
+        u32, i128;
+        u64, i128
+                );
+    }
+
+    #[test]
+    fn lossy_from() {
+        macro_rules! test_lossy_froms {
+            ($( $from:ty, $to:ty);*) => {$(
+                let from: Vector3<$from> = Vector3{ x: <$from>::MAX, y: <$from>::MIN, z: <$from>::MAX};
+                let _to: Vector3<$to> = from.lossy_into();
+            )*}
+        }
+
+        test_lossy_froms!(
+        f32, i8;
+        f32, i16;
+        f32, i32;
+        f32, i64;
+        f32, i128;
+        f32, isize;
+        f32, u8;
+        f32, u16;
+        f32, u32;
+        f32, u64;
+        f32, u128;
+        f32, usize;
+        i8, f32;
+        i16, f32;
+        i32, f32;
+        i64, f32;
+        i128, f32;
+        isize, f32;
+        u8, f32;
+        u16, f32;
+        u32, f32;
+        u64, f32;
+        u128, f32;
+        usize, f32
+        );
+        test_lossy_froms!(
+        f64, i8;
+        f64, i16;
+        f64, i32;
+        f64, i64;
+        f64, i128;
+        f64, isize;
+        f64, u8;
+        f64, u16;
+        f64, u32;
+        f64, u64;
+        f64, u128;
+        f64, usize;
+        i8, f64;
+        i16, f64;
+        i32, f64;
+        i64, f64;
+        i128, f64;
+        isize, f64;
+        u8, f64;
+        u16, f64;
+        u32, f64;
+        u64, f64;
+        u128, f64;
+        usize, f64
+        );
+        test_lossy_froms!(f32, f64; f64, f32);
     }
 }


### PR DESCRIPTION
Easy conversions between all numeric primitive data types for vec2, vec3, and
Rect are now implemented with either lossy_from/lossy_into,
try_from/try_into, or from/into.

lossy_from/lossy_into is performed when converting between floating
point and integers. This case silently fails on overflow / etc.. Hence
"lossy".

try_from/try_into returns a result on with passing being the vector with
the preferred data type, and failing returning a TryFromIntError.

from/into are performed on cases where the into wraps the from entirely
and is completely safe to convert between the two. These special cases
are conversions from a unsigned integer into a signed integer with more
bits. (i.e. u8 is safe to convert into i16, i32, i64, and i128).