### PR TITLE
fetching position and size implemented for Rect

### DIFF
--- a/src/graphics/rect.rs
+++ b/src/graphics/rect.rs
@@ -84,6 +84,16 @@ impl<T> Rect<T> {
             height: self.height.as_(),
         }
     }
+
+    /// Get the position of the rectangle's top-left corner
+    pub fn position(self) -> Vector2<T> {
+        Vector2::new(self.left, self.top)
+    }
+
+    /// Get the size of the rectangle
+    pub fn size(self) -> Vector2<T> {
+        Vector2::new(self.width, self.height)
+    }
 }
 
 impl<T: PartialOrd + Add<Output = T> + Sub<Output = T> + Copy> Rect<T> {


### PR DESCRIPTION
This feature is not implemented for Rust 2.5, but it is on their main
repository. I thought it was a convenient feature to have regardless of
not being on SFML stable.

Pretty sure it will be out for sfml3