### PR TITLE
Vertex buffer new and clone now return with errors instead of panicing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ optional = true
 [dependencies.link-cplusplus]
 version = "1.0"
 
+[dependencies.anyhow]
+version = "1.0.57"
+
 [build-dependencies]
 cc = "1.0.67"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ optional = true
 [dependencies.link-cplusplus]
 version = "1.0"
 
-[dependencies.anyhow]
-version = "1.0.57"
+[dependencies.thiserror]
+version = "1.0.31"
 
 [build-dependencies]
 cc = "1.0.67"

--- a/examples/vertex-buffers.rs
+++ b/examples/vertex-buffers.rs
@@ -15,7 +15,13 @@ fn main() {
     window.set_vertical_sync_enabled(true);
 
     let mut vertex_buffer =
-        VertexBuffer::new(PrimitiveType::LINE_STRIP, 6, VertexBufferUsage::STATIC);
+        match VertexBuffer::new(PrimitiveType::LINE_STRIP, 6, VertexBufferUsage::STATIC) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("{}", e);
+                std::process::exit(10);
+            }
+        };
 
     let vertices = [
         Vertex::with_pos_color((20.0, 30.0).into(), Color::GREEN),


### PR DESCRIPTION
The user should be the ones that define when and where the API crashes.
A panic in the API is unwarrented.

The added package (anyhow) is for easy error handling / messaging. This package
is used by many people.