### PR TITLE
Added deserializer to rect

### DIFF
--- a/src/graphics/rect.rs
+++ b/src/graphics/rect.rs
@@ -1,5 +1,6 @@
 use num_traits::AsPrimitive;
-
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use crate::system::Vector2;
 use std::{
     convert::TryInto,
@@ -11,6 +12,7 @@ use crate::ffi;
 /// Utility type for manipulating 2D axis-aligned rectangles.
 #[repr(C)]
 #[derive(Clone, PartialEq, Eq, Debug, Copy, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Rect<T> {
     /// Left coordinate of the rectangle.
     pub left: T,


### PR DESCRIPTION
Saw deserializer added for Vector. Thought it should go with Rect. My reasoning is that I want to save Rects in JSONs for UI and other niceties.

Also, it is good to be consistent. If Vector2 and Vector3 have this functionality, so should Rect, since it is also a simple data type.