### PR TITLE
Implement vector operations that are in main SFML Vector2.ini

### DIFF
--- a/examples/pong.rs
+++ b/examples/pong.rs
@@ -54,7 +54,7 @@ fn main() {
 
     // Create the left paddle
     let mut left_paddle = RectangleShape::new();
-    left_paddle.set_size(paddle_size - 3.);
+    left_paddle.set_size(paddle_size - Vector2f::new(3., 3.));
     left_paddle.set_outline_thickness(3.);
     left_paddle.set_outline_color(Color::BLACK);
     left_paddle.set_fill_color(Color::rgb(100, 100, 200));
@@ -62,7 +62,7 @@ fn main() {
 
     // Create the right paddle
     let mut right_paddle = RectangleShape::new();
-    right_paddle.set_size(paddle_size - 3.);
+    right_paddle.set_size(paddle_size - Vector2f::new(3., 3.));
     right_paddle.set_outline_thickness(3.);
     right_paddle.set_outline_color(Color::BLACK);
     right_paddle.set_fill_color(Color::rgb(200, 100, 100));

--- a/src/system/vector2.rs
+++ b/src/system/vector2.rs
@@ -139,13 +139,7 @@ impl<T: Div<Output = T> + CheckedDiv> Vector2<T> {
     pub fn cwise_checked_div(self, rhs: Self) -> Option<Vector2<T>> {
         let x = self.x.checked_div(&rhs.x);
         let y = self.y.checked_div(&rhs.y);
-        if x.is_none() || y.is_none() {
-            return None;
-        }
-        Some(Vector2 {
-            x: x.unwrap(),
-            y: y.unwrap(),
-        })
+        x.zip(y).map(|(x, y)| Vector2 { x, y })
     }
 }
 


### PR DESCRIPTION
Here is a link to file we need to match:
https://github.com/SFML/SFML/blob/master/include/SFML/System/Vector2.inl

Mul, and Div impl needed to be changed to match Main SFML a bit more.
Added cwise_mul and cwise_div because that was what Div and Mul
originally inteded to do.

Added dot, perpendicular, length_sq, and cross because they were simple
to implement, and I believe they should be in rust-sfml also.