### PR TITLE
Added serializer for SFML keys, buttons, and mouse wheel

### DIFF
--- a/src/ffi/window.rs
+++ b/src/ffi/window.rs
@@ -2,6 +2,8 @@ use std::os::raw::c_ulong;
 
 use crate::ffi::system::sfString;
 pub use crate::ffi::*;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 decl_opaque! {
     sfCursor;
@@ -284,6 +286,7 @@ pub enum JoystickAxis {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MouseWheel {
     VerticalWheel,
     HorizontalWheel,
@@ -292,6 +295,7 @@ pub enum MouseWheel {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MouseButton {
     Left,
     Right,
@@ -304,6 +308,7 @@ pub enum MouseButton {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Key {
     Unknown = -1,
     A = 0,


### PR DESCRIPTION
I was trying to add custom control bindings for my app. I noticed that
if the Key, Button, and MouseWheel enums derived Serializer and Deserializer, it would help ALOT
  
  
  I understand if you don't accept this PR. This is quite niche, and I could do a custom serializer for this.