### PR TITLE
Make enum CursorType Hashable

### DIFF
--- a/src/ffi/window.rs
+++ b/src/ffi/window.rs
@@ -34,7 +34,7 @@ decl_opaque! {
 /// * These cursor types are undocumented so may not be available on all versions,
 /// but have been tested on 10.13
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 pub enum sfCursorType {
     Arrow,


### PR DESCRIPTION
My inspiration for doing this is to allow me to create a hashmap of cursors
in my resource manager, with relevant keys rather than using custom
keys.