### PR TITLE
Support for static linking on Windows and Linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,7 @@ fn main() {
     println!("cargo:rerun-if-changed=CSFML");
     println!("cargo:rerun-if-env-changed=SFML_INCLUDE_DIR");
     println!("cargo:rerun-if-env-changed=SFML_LIBS_DIR");
+    println!("cargo:rerun-if-env-changed=SFML_STATIC");
     let mut build = cc::Build::new();
     build
         .cpp(true)
@@ -17,7 +18,8 @@ fn main() {
         println!("cargo:warning=Custom SFML include dir: {}", sfml_inc_dir);
         build.include(sfml_inc_dir);
     }
-    if env::var("SFML_STATIC").is_ok() {
+    let static_linking = env::var("SFML_STATIC").is_ok();
+    if static_linking {
         println!("cargo:warning=Linking SFML statically");
         build.define("SFML_STATIC", None)
             .static_crt(true);
@@ -98,17 +100,32 @@ fn main() {
         println!("cargo:rustc-link-search=native={}", libs_dir);
     }
     println!("cargo:rustc-link-lib=static=rcsfml");
-    println!("cargo:rustc-link-lib=static=sfml-system-s");
-    if feat_audio {
-        println!("cargo:rustc-link-lib=static=sfml-audio-s");
-    }
-    if feat_window {
-        println!("LINKING WINDOW",);
-        println!("cargo:rustc-link-lib=static=sfml-window-s");
-    }
-    if feat_graphics {
-        println!("LINKING GRAPHICS",);
-        println!("cargo:rustc-link-lib=static=sfml-graphics-s");
+    if static_linking {
+        println!("cargo:rustc-link-lib=static=sfml-system-s");
+        if feat_audio {
+            println!("cargo:rustc-link-lib=static=sfml-audio-s");
+        }
+        if feat_window {
+            println!("LINKING WINDOW",);
+            println!("cargo:rustc-link-lib=static=sfml-window-s");
+        }
+        if feat_graphics {
+            println!("LINKING GRAPHICS",);
+            println!("cargo:rustc-link-lib=static=sfml-graphics-s");
+        }
+    } else {
+        println!("cargo:rustc-link-lib=dylib=sfml-system");
+        if feat_audio {
+            println!("cargo:rustc-link-lib=dylib=sfml-audio");
+        }
+        if feat_window {
+            println!("LINKING WINDOW",);
+            println!("cargo:rustc-link-lib=dylib=sfml-window");
+        }
+        if feat_graphics {
+            println!("LINKING GRAPHICS",);
+            println!("cargo:rustc-link-lib=dylib=sfml-graphics");
+        }
     }
     #[cfg(windows)]  // i'll figure out linux later
     if env::var("SFML_STATIC").is_ok() {

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,11 @@ fn main() {
         println!("cargo:warning=Custom SFML include dir: {}", sfml_inc_dir);
         build.include(sfml_inc_dir);
     }
+    if env::var("SFML_STATIC").is_ok() {
+        println!("cargo:warning=Linking SFML statically");
+        build.define("SFML_STATIC", None)
+            .static_crt(true);
+    }
     let feat_audio = env::var("CARGO_FEATURE_AUDIO").is_ok();
     let feat_window = env::var("CARGO_FEATURE_WINDOW").is_ok();
     let feat_graphics = env::var("CARGO_FEATURE_GRAPHICS").is_ok();
@@ -93,16 +98,40 @@ fn main() {
         println!("cargo:rustc-link-search=native={}", libs_dir);
     }
     println!("cargo:rustc-link-lib=static=rcsfml");
-    println!("cargo:rustc-link-lib=dylib=sfml-system");
+    println!("cargo:rustc-link-lib=static=sfml-system-s");
     if feat_audio {
-        println!("cargo:rustc-link-lib=dylib=sfml-audio");
+        println!("cargo:rustc-link-lib=static=sfml-audio-s");
     }
     if feat_window {
         println!("LINKING WINDOW",);
-        println!("cargo:rustc-link-lib=dylib=sfml-window");
+        println!("cargo:rustc-link-lib=static=sfml-window-s");
     }
     if feat_graphics {
         println!("LINKING GRAPHICS",);
-        println!("cargo:rustc-link-lib=dylib=sfml-graphics");
+        println!("cargo:rustc-link-lib=static=sfml-graphics-s");
+    }
+    #[cfg(windows)]  // i'll figure out linux later
+    if env::var("SFML_STATIC").is_ok() {
+        // if let Ok(win10_sdk_libs_dir) = env::var("SFML_WIN10_SDK_LIBS_DIR") {
+        //     println!("cargo:warning=Windows 10 SDK libs dir: {}", win10_sdk_libs_dir);
+        //     println!("cargo:rustc-link-search=native={}", win10_sdk_libs_dir);
+        // }
+        println!("cargo:rustc-link-lib=dylib=winmm");
+        println!("cargo:rustc-link-lib=dylib=user32");
+        if feat_window {
+            println!("cargo:rustc-link-lib=dylib=opengl32");
+            println!("cargo:rustc-link-lib=dylib=gdi32");
+        }
+        if feat_graphics {
+            println!("cargo:rustc-link-lib=static=freetype");
+        }
+        if feat_audio {
+            println!("cargo:rustc-link-lib=static=openal32");
+            println!("cargo:rustc-link-lib=static=flac");
+            println!("cargo:rustc-link-lib=static=vorbisenc");
+            println!("cargo:rustc-link-lib=static=vorbisfile");
+            println!("cargo:rustc-link-lib=static=vorbis");
+            println!("cargo:rustc-link-lib=static=ogg");
+        }
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -127,12 +127,9 @@ fn main() {
             println!("cargo:rustc-link-lib=dylib=sfml-graphics");
         }
     }
-    #[cfg(windows)]  // i'll figure out linux later
-    if env::var("SFML_STATIC").is_ok() {
-        // if let Ok(win10_sdk_libs_dir) = env::var("SFML_WIN10_SDK_LIBS_DIR") {
-        //     println!("cargo:warning=Windows 10 SDK libs dir: {}", win10_sdk_libs_dir);
-        //     println!("cargo:rustc-link-search=native={}", win10_sdk_libs_dir);
-        // }
+
+    #[cfg(windows)]
+    if static_linking {
         println!("cargo:rustc-link-lib=dylib=winmm");
         println!("cargo:rustc-link-lib=dylib=user32");
         if feat_window {
@@ -141,6 +138,28 @@ fn main() {
         }
         if feat_graphics {
             println!("cargo:rustc-link-lib=static=freetype");
+        }
+        if feat_audio {
+            println!("cargo:rustc-link-lib=static=openal32");
+            println!("cargo:rustc-link-lib=static=flac");
+            println!("cargo:rustc-link-lib=static=vorbisenc");
+            println!("cargo:rustc-link-lib=static=vorbisfile");
+            println!("cargo:rustc-link-lib=static=vorbis");
+            println!("cargo:rustc-link-lib=static=ogg");
+        }
+    }
+
+    #[cfg(all(unix, target_os = "linux"))]
+    if static_linking {
+        println!("cargo:rustc-link-lib=dylib=udev");
+        if feat_window {
+            println!("cargo:rustc-link-lib=dylib=GL");
+            println!("cargo:rustc-link-lib=dylib=X11");
+            println!("cargo:rustc-link-lib=dylib=Xcursor");
+            println!("cargo:rustc-link-lib=dylib=Xrandr");
+        }
+        if feat_graphics {
+            println!("cargo:rustc-link-lib=dylib=freetype");
         }
         if feat_audio {
             println!("cargo:rustc-link-lib=static=openal32");


### PR DESCRIPTION
This pull request adds support for statically linking SFML for Windows (MSVC) and Linux, which can be activated by setting the `SFML_STATIC` environment variable.

This works by linking all dependencies of SFML into `rust-sfml`, which is the correct way to do static linking according to [the SFML FAQ](https://www.sfml-dev.org/faq.php#build-link-static).

I have used this successfully to build statically-linked executables for the `x86_64-pc-windows-msvc` and `x86_64-unknown-linux-gnu` targets. No other targets have been tested and are not likely to work without further changes.

On Linux, SFML must be built from source with the `BUILD_SHARED_LIBS` CMake option set to false, since most SFML packages do not include static libraries.