### PR TITLE
Added default type to Color. Default type is transparent

### DIFF
--- a/src/graphics/color.rs
+++ b/src/graphics/color.rs
@@ -15,7 +15,7 @@ use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 /// let color3 = Color::GREEN; // from one of the associated color constants
 /// ```
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 pub struct Color {
     /// Red component
     pub r: u8,


### PR DESCRIPTION
deriving default creates a white transparent `Color`

Idea is to allow easy vector creations. Without a default color, creating vectors of some type can be a bit more clunky.