### PR TITLE
Added documentation for LD_LIBRARY_PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - `Default` impl for `Color` (transparent)
+- Linking Documentation for `LD_LIBRARY_PATH` 
 
 ### Changed
 - Methods that used to take `&Rect` now take `Rect` by value

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,10 @@
 //! - `SFML_INCLUDE_DIR`. Set this to the `include` folder of your SFML location.
 //! - `SFML_LIBS_DIR`. Set this to the `lib` folder of your SFML location.
 //!
+//! Linux users may also have to set this environment variable to help your binary find the
+//! shared object files.
+//! - `LD_LIBRARY_PATH`. Set this to the `lib` folder of your SFML location.
+//!
 //! # !! Thread safety warning !!
 //!
 //! rust-sfml strives to be memory-safe, as a Rust library should be, but currently there is no


### PR DESCRIPTION
Had an issue linking after setting the include and lib path as suggested by the rust docs. After I read the C++ SFML docs on linking, I fixed my problem. 

Would be nice to have added documentation just in case we or someone else runs into this in the future.