### PR TITLE
Implementing RcTexture and RcSprite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - `Default` impl for `Color` (transparent)
 - Linking Documentation for `LD_LIBRARY_PATH` 
+- RcTexture and RcSprite with examples in rc-resources.rs
 
 ### Changed
 - Methods that used to take `&Rect` now take `Rect` by value

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,4 +132,8 @@ required-features = ["window"]
 name = "joystick"
 required-features = ["window"]
 
+[[example]]
+name = "rc-resources"
+required-features = ["graphics", "window"]
+
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "zlib-acknowledgement"
 keywords = ["sfml", "multimedia", "game"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.66"
 
 [features]
 default = ["graphics", "audio"]

--- a/examples/rc-resources.rs
+++ b/examples/rc-resources.rs
@@ -14,11 +14,11 @@ struct FloatingSprite {
 }
 
 impl FloatingSprite {
-    fn new(sprite: RcSprite, up: bool, left: bool, speed: f32) -> Self {
+    fn new(texture: &RcTexture, up: bool, left: bool, speed: f32) -> Self {
         Self {
             up,
             left,
-            sprite,
+            sprite: RcSprite::with_texture(&texture),
             speed,
         }
     }
@@ -28,6 +28,7 @@ impl FloatingSprite {
     }
 
     fn move_sprites(&mut self, window_size: Vector2f) {
+        // Modify the sprite position freely
         if self.sprite.position().y <= 0f32 {
             self.up = false;
         }
@@ -55,13 +56,18 @@ fn main() {
     let mut window =
         RenderWindow::new((800, 600), "SFML window", Style::CLOSE, &Default::default());
     window.set_framerate_limit(60);
+
+    // Create a new texture.
     let texture = RcTexture::from_file(example_res!("logo.png")).unwrap();
+
+    // Load many sprites with no lifetime contingencies
     let mut floating_sprites = Vec::from([
-        FloatingSprite::new(RcSprite::with_texture(&texture), true, true, 1f32),
-        FloatingSprite::new(RcSprite::with_texture(&texture), true, false, 1.5f32),
-        FloatingSprite::new(RcSprite::with_texture(&texture), false, true, 2f32),
-        FloatingSprite::new(RcSprite::with_texture(&texture), false, false, 2.5f32),
+        FloatingSprite::new(&texture, true, true, 1f32),
+        FloatingSprite::new(&texture, true, false, 1.5f32),
+        FloatingSprite::new(&texture, false, true, 2f32),
+        FloatingSprite::new(&texture, false, false, 2.5f32),
     ]);
+
     while window.is_open() {
         while let Some(event) = window.poll_event() {
             match event {
@@ -69,11 +75,15 @@ fn main() {
                 _ => {}
             }
         }
+
+        // Update floating_sprite positions so they move around on the screen
         for floating_sprite in &mut floating_sprites {
             floating_sprite.move_sprites(Vector2f::new(800f32, 600f32));
         }
 
         window.clear(Color::BLACK);
+
+        // Fetch and draw all the sprites in floating_sprites
         for floating_sprite in &floating_sprites {
             window.draw(floating_sprite.sprite());
         }

--- a/examples/rc-resources.rs
+++ b/examples/rc-resources.rs
@@ -18,7 +18,7 @@ impl FloatingSprite {
         Self {
             up,
             left,
-            sprite: RcSprite::with_texture(&texture),
+            sprite: RcSprite::with_texture(texture),
             speed,
         }
     }
@@ -70,9 +70,8 @@ fn main() {
 
     while window.is_open() {
         while let Some(event) = window.poll_event() {
-            match event {
-                Event::Closed => window.close(),
-                _ => {}
+            if event == Event::Closed {
+                window.close();
             }
         }
 

--- a/examples/rc-resources.rs
+++ b/examples/rc-resources.rs
@@ -1,6 +1,9 @@
-use sfml::graphics::{Color, RcSprite, RcTexture, RenderTarget, RenderWindow, Transformable};
-use sfml::system::Vector2f;
-use sfml::window::{Event, Style};
+use sfml::{
+    graphics::{Color, RcSprite, RcTexture, RenderTarget, RenderWindow, Transformable},
+    system::Vector2f,
+    window::{Event, Style},
+};
+
 include!("../example_common.rs");
 
 struct FloatingSprite {

--- a/examples/rc_sprites.rs
+++ b/examples/rc_sprites.rs
@@ -1,0 +1,79 @@
+use sfml::graphics::{Color, RcSprite, RcTexture, RenderTarget, RenderWindow, Transformable};
+use sfml::system::Vector2f;
+use sfml::window::{Event, Style};
+include!("../example_common.rs");
+
+struct FloatingSprite {
+    up: bool,
+    left: bool,
+    sprite: RcSprite,
+    speed: f32,
+}
+
+impl FloatingSprite {
+    fn new(sprite: RcSprite, up: bool, left: bool, speed: f32) -> Self {
+        Self {
+            up,
+            left,
+            sprite,
+            speed,
+        }
+    }
+
+    fn sprite(&self) -> &RcSprite {
+        &self.sprite
+    }
+
+    fn move_sprites(&mut self, window_size: Vector2f) {
+        if self.sprite.position().y <= 0f32 {
+            self.up = false;
+        }
+        if self.sprite.position().y + self.sprite.global_bounds().height >= window_size.y {
+            self.up = true;
+        }
+        if self.sprite.position().x <= 0f32 {
+            self.left = false;
+        }
+        if self.sprite.position().x + self.sprite.global_bounds().width >= window_size.x {
+            self.left = true;
+        }
+
+        self.sprite.set_position(
+            self.sprite.position()
+                + Vector2f::new(
+                    if self.left { -self.speed } else { self.speed },
+                    if self.up { -self.speed } else { self.speed },
+                ),
+        );
+    }
+}
+
+fn main() {
+    let mut window =
+        RenderWindow::new((800, 600), "SFML window", Style::CLOSE, &Default::default());
+    window.set_framerate_limit(60);
+    let texture = RcTexture::from_file(example_res!("logo.png")).unwrap();
+    let mut floating_sprites = Vec::from([
+        FloatingSprite::new(RcSprite::with_texture(&texture), true, true, 1f32),
+        FloatingSprite::new(RcSprite::with_texture(&texture), true, false, 1.5f32),
+        FloatingSprite::new(RcSprite::with_texture(&texture), false, true, 2f32),
+        FloatingSprite::new(RcSprite::with_texture(&texture), false, false, 2.5f32),
+    ]);
+    while window.is_open() {
+        while let Some(event) = window.poll_event() {
+            match event {
+                Event::Closed => window.close(),
+                _ => {}
+            }
+        }
+        for floating_sprite in &mut floating_sprites {
+            floating_sprite.move_sprites(Vector2f::new(800f32, 600f32));
+        }
+
+        window.clear(Color::BLACK);
+        for floating_sprite in &floating_sprites {
+            window.draw(floating_sprite.sprite());
+        }
+        window.display();
+    }
+}

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -12,6 +12,8 @@ pub use self::{
     glyph::Glyph,
     image::Image,
     primitive_type::PrimitiveType,
+    rc_sprite::RcSprite,
+    rc_texture::RcTexture,
     rect::{FloatRect, IntRect, Rect},
     rectangle_shape::RectangleShape,
     render_states::RenderStates,
@@ -43,6 +45,8 @@ pub mod glsl;
 mod glyph;
 mod image;
 mod primitive_type;
+mod rc_sprite;
+mod rc_texture;
 mod rect;
 mod rectangle_shape;
 mod render_states;

--- a/src/graphics/rc_sprite.rs
+++ b/src/graphics/rc_sprite.rs
@@ -1,0 +1,188 @@
+use crate::{
+    ffi::graphics as ffi,
+    graphics::{
+        Color, Drawable, FloatRect, IntRect, RcTexture, RenderStates, RenderTarget, Texture,
+        Transform, Transformable,
+    },
+    sf_box::SfBox,
+    system::Vector2f,
+};
+use std::{
+    cell::RefCell,
+    ptr::{self, NonNull},
+    rc::Weak,
+};
+
+#[derive(Debug)]
+pub struct RcSprite {
+    sprite: NonNull<ffi::sfSprite>,
+    texture: Weak<RefCell<SfBox<Texture>>>,
+}
+
+impl RcSprite {
+    #[must_use]
+    pub fn new() -> Self {
+        let sp = unsafe { ffi::sfSprite_create() };
+        Self {
+            sprite: NonNull::new(sp).expect("Failed to create Sprite"),
+            texture: Weak::new(),
+        }
+    }
+
+    fn texture_exists(&self) -> bool {
+        self.texture.strong_count() != 0
+    }
+
+    fn set_rc_texture(&mut self, texture: &RcTexture) {
+        self.texture = texture.downgrade()
+    }
+
+    #[must_use]
+    pub fn with_texture(texture: &RcTexture) -> RcSprite {
+        let mut sprite = Self::new();
+        sprite.set_texture(&texture, true);
+        sprite
+    }
+
+    #[must_use]
+    pub fn with_texture_and_rect(texture: &RcTexture, rect: IntRect) -> RcSprite {
+        let mut sprite = Self::with_texture(texture);
+        sprite.set_texture_rect(rect);
+        sprite
+    }
+
+    #[must_use]
+    pub fn set_texture(&mut self, texture: &RcTexture, reset_rect: bool) {
+        self.set_rc_texture(&texture);
+        let raw_texture = unsafe {
+            (*self.texture.upgrade().unwrap().as_ptr())
+                .0
+                .as_ptr()
+                .cast_const()
+        };
+        unsafe { ffi::sfSprite_setTexture(self.sprite.as_ptr(), raw_texture, reset_rect) };
+    }
+
+    pub fn disable_texture(&mut self) {
+        unsafe { ffi::sfSprite_setTexture(self.sprite.as_ptr(), ptr::null_mut(), true) };
+        self.texture = Weak::new();
+    }
+
+    pub fn set_color(&mut self, color: Color) {
+        unsafe { ffi::sfSprite_setColor(self.sprite.as_ptr(), color) }
+    }
+
+    #[must_use]
+    pub fn texture<'s>(&'s self) -> Option<&'s Texture> {
+        if self.texture_exists() {
+            Some(unsafe { &*(*(self.texture.as_ptr())).as_ptr() })
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    pub fn color(&self) -> Color {
+        unsafe { ffi::sfSprite_getColor(self.sprite.as_ptr()) }
+    }
+
+    #[must_use]
+    pub fn local_bounds(&self) -> FloatRect {
+        unsafe { ffi::sfSprite_getLocalBounds(self.sprite.as_ptr()) }
+    }
+
+    #[must_use]
+    pub fn global_bounds(&self) -> FloatRect {
+        unsafe { ffi::sfSprite_getGlobalBounds(self.sprite.as_ptr()) }
+    }
+
+    #[must_use]
+    pub fn texture_rect(&self) -> IntRect {
+        unsafe { ffi::sfSprite_getTextureRect(self.sprite.as_ptr()) }
+    }
+
+    pub fn set_texture_rect(&mut self, rect: IntRect) {
+        unsafe { ffi::sfSprite_setTextureRect(self.sprite.as_ptr(), rect) }
+    }
+
+    pub(super) fn raw(&self) -> *const ffi::sfSprite {
+        self.sprite.as_ptr()
+    }
+}
+
+impl Default for RcSprite {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clone for RcSprite {
+    /// Return a new Sprite or panic! if there is not enough memory
+    fn clone(&self) -> RcSprite {
+        let sp = unsafe { ffi::sfSprite_copy(self.sprite.as_ptr()) };
+        RcSprite {
+            sprite: NonNull::new(sp).expect("Failed to copy Sprite"),
+            texture: self.texture.clone(),
+        }
+    }
+}
+
+impl Drawable for RcSprite {
+    fn draw<'a: 'shader, 'texture, 'shader, 'shader_texture>(
+        &'a self,
+        target: &mut dyn RenderTarget,
+        states: &RenderStates<'texture, 'shader, 'shader_texture>,
+    ) {
+        if self.texture_exists() {
+            target.draw_rc_sprite(self, states)
+        }
+    }
+}
+
+impl Transformable for RcSprite {
+    fn set_position<P: Into<Vector2f>>(&mut self, position: P) {
+        unsafe { ffi::sfSprite_setPosition(self.sprite.as_ptr(), position.into()) }
+    }
+    fn set_rotation(&mut self, angle: f32) {
+        unsafe { ffi::sfSprite_setRotation(self.sprite.as_ptr(), angle) }
+    }
+    fn set_scale<S: Into<Vector2f>>(&mut self, scale: S) {
+        unsafe { ffi::sfSprite_setScale(self.sprite.as_ptr(), scale.into()) }
+    }
+    fn set_origin<O: Into<Vector2f>>(&mut self, origin: O) {
+        unsafe { ffi::sfSprite_setOrigin(self.sprite.as_ptr(), origin.into()) }
+    }
+    fn position(&self) -> Vector2f {
+        unsafe { ffi::sfSprite_getPosition(self.sprite.as_ptr()) }
+    }
+    fn rotation(&self) -> f32 {
+        unsafe { ffi::sfSprite_getRotation(self.sprite.as_ptr()) }
+    }
+    fn get_scale(&self) -> Vector2f {
+        unsafe { ffi::sfSprite_getScale(self.sprite.as_ptr()) }
+    }
+    fn origin(&self) -> Vector2f {
+        unsafe { ffi::sfSprite_getOrigin(self.sprite.as_ptr()) }
+    }
+    fn move_<O: Into<Vector2f>>(&mut self, offset: O) {
+        unsafe { ffi::sfSprite_move(self.sprite.as_ptr(), offset.into()) }
+    }
+    fn rotate(&mut self, angle: f32) {
+        unsafe { ffi::sfSprite_rotate(self.sprite.as_ptr(), angle) }
+    }
+    fn scale<F: Into<Vector2f>>(&mut self, factors: F) {
+        unsafe { ffi::sfSprite_scale(self.sprite.as_ptr(), factors.into()) }
+    }
+    fn transform(&self) -> &Transform {
+        unsafe { &*ffi::sfSprite_getTransform(self.sprite.as_ptr()) }
+    }
+    fn inverse_transform(&self) -> &Transform {
+        unsafe { &*ffi::sfSprite_getInverseTransform(self.sprite.as_ptr()) }
+    }
+}
+
+impl Drop for RcSprite {
+    fn drop(&mut self) {
+        unsafe { ffi::sfSprite_destroy(self.sprite.as_ptr()) }
+    }
+}

--- a/src/graphics/rc_sprite.rs
+++ b/src/graphics/rc_sprite.rs
@@ -7,12 +7,23 @@ use crate::{
     sf_box::SfBox,
     system::Vector2f,
 };
-use std::{
-    cell::RefCell,
-    ptr::{self, NonNull},
-    rc::Weak,
-};
+use std::{cell::RefCell, ptr::NonNull, rc::Weak};
 
+const ERROR_MSG: &str = "Sprite does not hold a texture. Ignoring transformation!";
+const RETURN_ERROR_MSG: &str = "Sprite does not hold a texture. Returning default value!";
+const PANIC_ERROR_MSG: &str = "Sprite does not hold a texture! Return value cannot be discerned!";
+
+/// Drawable representation of a texture
+///
+/// Sprite is a drawable type that allows to easily
+/// display a [`RcTexture`] (or a part of it) on a render target.
+///
+/// __Note:__
+/// This is an improvement upon the Sprite module which dissallows seperation from the texture
+/// lifetime. The RcSprite allows from complete seperation from the RcTexture while still
+/// referencing it. Underneath, it uses reference counting to ensure that the RcTexture is alive and
+/// well, and will throw errors messages if you try to perform function on the sprite while the
+/// RcTexture is no longer alive.
 #[derive(Debug)]
 pub struct RcSprite {
     sprite: NonNull<ffi::sfSprite>,
@@ -20,6 +31,7 @@ pub struct RcSprite {
 }
 
 impl RcSprite {
+    /// Create a new sprite
     #[must_use]
     pub fn new() -> Self {
         let sp = unsafe { ffi::sfSprite_create() };
@@ -37,6 +49,7 @@ impl RcSprite {
         self.texture = texture.downgrade()
     }
 
+    /// Create a new sprite with a texture
     #[must_use]
     pub fn with_texture(texture: &RcTexture) -> RcSprite {
         let mut sprite = Self::new();
@@ -44,6 +57,7 @@ impl RcSprite {
         sprite
     }
 
+    /// Create a new sprite with a texture and a source rectangle
     #[must_use]
     pub fn with_texture_and_rect(texture: &RcTexture, rect: IntRect) -> RcSprite {
         let mut sprite = Self::with_texture(texture);
@@ -51,7 +65,24 @@ impl RcSprite {
         sprite
     }
 
-    #[must_use]
+    /// Change the source texture of a sprite
+    ///
+    /// The texture argument refers to a texture that must
+    /// exist as long as the sprite uses it. Indeed, the sprite
+    /// doesn't store its own copy of the texture, but rather keeps
+    /// a pointer to the one that you passed to this function.
+    /// If the source texture is destroyed and the sprite tries to
+    /// use it, the behaviour is undefined.
+    /// If `reset_rect` is true, the [`texture_rect`] property of
+    /// the sprite is automatically adjusted to the size of the new
+    /// texture. If it is false, the texture rect is left unchanged.
+    ///
+    /// [`texture_rect`]: Sprite::texture_rect
+    ///
+    /// # Arguments
+    /// * `texture` - New texture
+    /// * `reset_rect` - Should the texture rect be reset to the size
+    /// of the new texture?
     pub fn set_texture(&mut self, texture: &RcTexture, reset_rect: bool) {
         self.set_rc_texture(&texture);
         let raw_texture = unsafe {
@@ -63,15 +94,30 @@ impl RcSprite {
         unsafe { ffi::sfSprite_setTexture(self.sprite.as_ptr(), raw_texture, reset_rect) };
     }
 
-    pub fn disable_texture(&mut self) {
-        unsafe { ffi::sfSprite_setTexture(self.sprite.as_ptr(), ptr::null_mut(), true) };
-        self.texture = Weak::new();
-    }
-
+    /// Set the global color of a sprite
+    ///
+    /// This color is modulated (multiplied) with the sprite's
+    /// texture. It can be used to colorize the sprite, or change
+    /// its global opacity.
+    /// By default, the sprite's color is opaque white.
+    ///
+    /// # Arguments
+    /// * color - New color of the sprite
     pub fn set_color(&mut self, color: Color) {
+        if !self.texture_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
         unsafe { ffi::sfSprite_setColor(self.sprite.as_ptr(), color) }
     }
 
+    /// Get the source texture of a sprite
+    ///
+    /// If the sprite has no source texture, None is returned.
+    /// You can't
+    /// modify the texture when you retrieve it with this function.
+    ///
+    /// Return an Option to the sprite's texture
     #[must_use]
     pub fn texture<'s>(&'s self) -> Option<&'s Texture> {
         if self.texture_exists() {
@@ -81,27 +127,79 @@ impl RcSprite {
         }
     }
 
+    /// Get the global color of a sprite
+    ///
+    /// Return the global color of the sprite
     #[must_use]
     pub fn color(&self) -> Color {
+        if !self.texture_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
         unsafe { ffi::sfSprite_getColor(self.sprite.as_ptr()) }
     }
 
+    /// Get the local bounding rectangle of a sprite
+    ///
+    /// The returned rectangle is in local coordinates, which means
+    /// that it ignores the transformations (translation, rotation,
+    /// scale, ...) that are applied to the entity.
+    /// In other words, this function returns the bounds of the
+    /// entity in the entity's coordinate system.
+    ///
+    /// Return the local bounding rectangle of the entity
     #[must_use]
     pub fn local_bounds(&self) -> FloatRect {
+        if !self.texture_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
         unsafe { ffi::sfSprite_getLocalBounds(self.sprite.as_ptr()) }
     }
 
+    /// Get the global bounding rectangle of a sprite
+    ///
+    /// The returned rectangle is in global coordinates, which means
+    /// that it takes in account the transformations (translation,
+    /// rotation, scale, ...) that are applied to the entity.
+    /// In other words, this function returns the bounds of the
+    /// sprite in the global 2D world's coordinate system.
+    ///
+    /// Return the global bounding rectangle of the entity
     #[must_use]
     pub fn global_bounds(&self) -> FloatRect {
+        if !self.texture_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
         unsafe { ffi::sfSprite_getGlobalBounds(self.sprite.as_ptr()) }
     }
 
+    /// Get the sub-rectangle of the texture displayed by a sprite
+    ///
+    /// Return the texture rectangle of the sprite
     #[must_use]
     pub fn texture_rect(&self) -> IntRect {
+        if !self.texture_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
         unsafe { ffi::sfSprite_getTextureRect(self.sprite.as_ptr()) }
     }
 
+    /// Set the sub-rectangle of the texture that a sprite will display
+    ///
+    /// The texture rect is useful when you don't want to display
+    /// the whole texture, but rather a part of it.
+    /// By default, the texture rect covers the entire texture.
+    ///
+    /// # Arguments
+    /// * rectangle - Rectangle defining the region of the texture to display
     pub fn set_texture_rect(&mut self, rect: IntRect) {
+        if !self.texture_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
         unsafe { ffi::sfSprite_setTextureRect(self.sprite.as_ptr(), rect) }
     }
 
@@ -141,42 +239,92 @@ impl Drawable for RcSprite {
 
 impl Transformable for RcSprite {
     fn set_position<P: Into<Vector2f>>(&mut self, position: P) {
+        if !self.texture_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
         unsafe { ffi::sfSprite_setPosition(self.sprite.as_ptr(), position.into()) }
     }
     fn set_rotation(&mut self, angle: f32) {
+        if !self.texture_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
         unsafe { ffi::sfSprite_setRotation(self.sprite.as_ptr(), angle) }
     }
     fn set_scale<S: Into<Vector2f>>(&mut self, scale: S) {
+        if !self.texture_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
         unsafe { ffi::sfSprite_setScale(self.sprite.as_ptr(), scale.into()) }
     }
     fn set_origin<O: Into<Vector2f>>(&mut self, origin: O) {
+        if !self.texture_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
         unsafe { ffi::sfSprite_setOrigin(self.sprite.as_ptr(), origin.into()) }
     }
     fn position(&self) -> Vector2f {
+        if !self.texture_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
         unsafe { ffi::sfSprite_getPosition(self.sprite.as_ptr()) }
     }
     fn rotation(&self) -> f32 {
+        if !self.texture_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
         unsafe { ffi::sfSprite_getRotation(self.sprite.as_ptr()) }
     }
     fn get_scale(&self) -> Vector2f {
+        if !self.texture_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
         unsafe { ffi::sfSprite_getScale(self.sprite.as_ptr()) }
     }
     fn origin(&self) -> Vector2f {
+        if !self.texture_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
         unsafe { ffi::sfSprite_getOrigin(self.sprite.as_ptr()) }
     }
     fn move_<O: Into<Vector2f>>(&mut self, offset: O) {
+        if !self.texture_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
         unsafe { ffi::sfSprite_move(self.sprite.as_ptr(), offset.into()) }
     }
     fn rotate(&mut self, angle: f32) {
+        if !self.texture_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
         unsafe { ffi::sfSprite_rotate(self.sprite.as_ptr(), angle) }
     }
     fn scale<F: Into<Vector2f>>(&mut self, factors: F) {
+        if !self.texture_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
         unsafe { ffi::sfSprite_scale(self.sprite.as_ptr(), factors.into()) }
     }
     fn transform(&self) -> &Transform {
+        if !self.texture_exists() {
+            panic!("{}", PANIC_ERROR_MSG);
+        }
         unsafe { &*ffi::sfSprite_getTransform(self.sprite.as_ptr()) }
     }
     fn inverse_transform(&self) -> &Transform {
+        if !self.texture_exists() {
+            panic!("{}", PANIC_ERROR_MSG);
+        }
         unsafe { &*ffi::sfSprite_getInverseTransform(self.sprite.as_ptr()) }
     }
 }

--- a/src/graphics/rc_sprite.rs
+++ b/src/graphics/rc_sprite.rs
@@ -20,10 +20,10 @@ const PANIC_ERROR_MSG: &str = "Sprite does not hold a texture! Return value cann
 ///
 /// __Note:__
 /// This is an improvement upon the Sprite module which dissallows seperation from the texture
-/// lifetime. The RcSprite allows from complete seperation from the RcTexture while still
-/// referencing it. Underneath, it uses reference counting to ensure that the RcTexture is alive and
+/// lifetime. The `RcSprite` allows from complete seperation from the `RcTexture` while still
+/// referencing it. Underneath, it uses reference counting to ensure that the `RcTexture` is alive and
 /// well, and will throw errors messages if you try to perform function on the sprite while the
-/// RcTexture is no longer alive.
+/// `RcTexture` is no longer alive.
 #[derive(Debug)]
 pub struct RcSprite {
     sprite: NonNull<ffi::sfSprite>,
@@ -53,7 +53,7 @@ impl RcSprite {
     #[must_use]
     pub fn with_texture(texture: &RcTexture) -> RcSprite {
         let mut sprite = Self::new();
-        sprite.set_texture(&texture, true);
+        sprite.set_texture(texture, true);
         sprite
     }
 
@@ -84,7 +84,7 @@ impl RcSprite {
     /// * `reset_rect` - Should the texture rect be reset to the size
     /// of the new texture?
     pub fn set_texture(&mut self, texture: &RcTexture, reset_rect: bool) {
-        self.set_rc_texture(&texture);
+        self.set_rc_texture(texture);
         let raw_texture = unsafe {
             (*self.texture.upgrade().unwrap().as_ptr())
                 .0
@@ -119,7 +119,7 @@ impl RcSprite {
     ///
     /// Return an Option to the sprite's texture
     #[must_use]
-    pub fn texture<'s>(&'s self) -> Option<&'s Texture> {
+    pub fn texture(&self) -> Option<&Texture> {
         if self.texture_exists() {
             Some(unsafe { &*(*(self.texture.as_ptr())).as_ptr() })
         } else {

--- a/src/graphics/rc_texture.rs
+++ b/src/graphics/rc_texture.rs
@@ -11,6 +11,43 @@ use std::{
     rc::Rc,
 };
 
+/// [`Image`] living on the graphics card that can be used for drawing.
+///
+/// `RcTexture` stores pixels that can be drawn, with a rc_sprite for example.
+///
+/// A texture lives in the graphics card memory, therefore it is very fast to draw a
+/// texture to a render target,
+/// or copy a render target to a texture (the graphics card can access both directly).
+///
+/// Being stored in the graphics card memory has some drawbacks.
+/// A texture cannot be manipulated as freely as a [`Image`],
+/// you need to prepare the pixels first and then upload them to the texture in a
+/// single operation (see the various update methods below).
+///
+/// `RcTexture` makes it easy to convert from/to [`Image`],
+/// but keep in mind that these calls require transfers between the graphics card and
+/// the central memory, therefore they are slow operations.
+///
+/// A texture can be loaded from an image, but also directly from a file/memory/stream.
+/// The necessary shortcuts are defined so that you don't need an image first for the
+/// most common cases.
+/// However, if you want to perform some modifications on the pixels before creating the
+/// final texture, you can load your file to a [`Image`], do whatever you need with the pixels,
+/// and then call [`RcTexture::load_from_image`].
+///
+/// Since they live in the graphics card memory,
+/// the pixels of a texture cannot be accessed without a slow copy first.
+/// And they cannot be accessed individually.
+/// Therefore, if you need to read the texture's pixels (like for pixel-perfect collisions),
+/// it is recommended to store the collision information separately,
+/// for example in an array of booleans.
+///
+/// Like [`Image`], `RcTexture` can handle a unique internal representation of pixels,
+/// which is RGBA 32 bits.
+/// This means that a pixel must be composed of
+/// 8 bits red, green, blue and alpha channels – just like a [`Color`].
+///
+/// [`Color`]: crate::graphics::Color
 #[derive(Debug)]
 pub struct RcTexture {
     texture: Rc<RefCell<SfBox<Texture>>>,
@@ -319,8 +356,6 @@ impl ToOwned for RcTexture {
     }
 }
 
-// It is safe to dispose of RcTexture as there is now way to create a strong reference to the
-// RefCell
 impl Dispose for RcTexture {
     unsafe fn dispose(&mut self) {
         self.texture.borrow_mut().dispose();

--- a/src/graphics/rc_texture.rs
+++ b/src/graphics/rc_texture.rs
@@ -13,7 +13,7 @@ use std::{
 
 /// [`Image`] living on the graphics card that can be used for drawing.
 ///
-/// `RcTexture` stores pixels that can be drawn, with a rc_sprite for example.
+/// `RcTexture` stores pixels that can be drawn, with a `RcSprite` for example.
 ///
 /// A texture lives in the graphics card memory, therefore it is very fast to draw a
 /// texture to a render target,
@@ -177,7 +177,7 @@ impl RcTexture {
     /// # Arguments
     /// * image - Image to upload to the texture
     pub fn load_from_image(&mut self, image: &Image, area: IntRect) -> LoadResult<()> {
-        self.texture.borrow_mut().load_from_image(&image, area)
+        self.texture.borrow_mut().load_from_image(image, area)
     }
 
     /// Update a part of the texture from the contents of a window.
@@ -217,7 +217,7 @@ impl RcTexture {
     /// No additional check is performed on the size of the image, passing an invalid combination
     /// of image size and offset will lead to an _undefined behavior_.
     pub unsafe fn update_from_image(&mut self, image: &Image, x: u32, y: u32) {
-        self.texture.borrow_mut().update_from_image(&image, x, y)
+        self.texture.borrow_mut().update_from_image(image, x, y)
     }
 
     /// Update a part of this texture from another texture.
@@ -229,9 +229,7 @@ impl RcTexture {
     /// passing an invalid combination of texture size and offset will
     /// lead to an _undefined behavior_.
     pub unsafe fn update_from_texture(&mut self, texture: &Texture, x: u32, y: u32) {
-        self.texture
-            .borrow_mut()
-            .update_from_texture(&texture, x, y)
+        self.texture.borrow_mut().update_from_texture(texture, x, y)
     }
 
     /// Update a part of the texture from an array of pixels.

--- a/src/graphics/rc_texture.rs
+++ b/src/graphics/rc_texture.rs
@@ -1,0 +1,328 @@
+use crate::{
+    graphics::{Image, IntRect, RenderWindow, Texture},
+    sf_box::{Dispose, SfBox},
+    system::Vector2u,
+    window::Window,
+    LoadResult,
+};
+use std::{
+    cell::RefCell,
+    io::{Read, Seek},
+    rc::Rc,
+};
+
+#[derive(Debug)]
+pub struct RcTexture {
+    texture: Rc<RefCell<SfBox<Texture>>>,
+}
+
+impl RcTexture {
+    /// Return the size of the texture
+    ///
+    /// Return the Size in pixels
+    #[must_use]
+    pub fn size(&self) -> Vector2u {
+        self.texture.borrow().size()
+    }
+    /// Tell whether the smooth filter is enabled or not for a texture
+    ///
+    /// Return true if smoothing is enabled, false if it is disabled
+    #[must_use]
+    pub fn is_smooth(&self) -> bool {
+        self.texture.borrow().is_smooth()
+    }
+    /// Tell whether a texture is repeated or not
+    ///
+    /// Return frue if repeat mode is enabled, false if it is disabled
+    #[must_use]
+    pub fn is_repeated(&self) -> bool {
+        self.texture.borrow().is_repeated()
+    }
+    /// Copy a texture's pixels to an image
+    ///
+    /// Return an image containing the texture's pixels
+    #[must_use]
+    pub fn copy_to_image(&self) -> Option<Image> {
+        self.texture.borrow().copy_to_image()
+    }
+    /// Tell whether the texture source is converted from sRGB or not.
+    #[must_use]
+    pub fn is_srgb(&self) -> bool {
+        self.texture.borrow().is_srgb()
+    }
+    /// Get the underlying OpenGL handle of the texture.
+    ///
+    /// You shouldn't need to use this function, unless you have very specific stuff to implement
+    /// that SFML doesn't support, or implement a temporary workaround until a bug is fixed.
+    #[must_use]
+    pub fn native_handle(&self) -> u32 {
+        self.texture.borrow().native_handle()
+    }
+
+    /// Bind a texture for rendering
+    ///
+    /// This function is not part of the graphics API, it mustn't be
+    /// used when drawing SFML entities. It must be used only if you
+    /// mix `Texture` with OpenGL code.
+    pub fn bind(&self) {
+        self.texture.borrow().bind()
+    }
+
+    /// Create a new texture
+    ///
+    /// Returns `None` on failure.
+    #[must_use]
+    pub fn new() -> Option<RcTexture> {
+        Some(RcTexture {
+            texture: Rc::new(RefCell::new(Texture::new()?)),
+        })
+    }
+
+    /// Create the texture.
+    ///
+    /// If this function fails, the texture is left unchanged.
+    ///
+    /// Returns whether creation was successful.
+    #[must_use = "Check if texture was created successfully"]
+    pub fn create(&mut self, width: u32, height: u32) -> bool {
+        self.texture.borrow_mut().create(width, height)
+    }
+
+    /// Load texture from memory
+    ///
+    /// The `area` argument can be used to load only a sub-rectangle of the whole image.
+    /// If you want the entire image then use a default [`IntRect`].
+    /// If the area rectangle crosses the bounds of the image,
+    /// it is adjusted to fit the image size.
+    ///
+    /// # Arguments
+    /// * mem - Pointer to the file data in memory
+    /// * area - Area of the image to load
+    pub fn load_from_memory(&mut self, mem: &[u8], area: IntRect) -> LoadResult<()> {
+        self.texture.borrow_mut().load_from_memory(mem, area)
+    }
+
+    /// Load texture from a stream (a struct implementing Read + Seek)
+    ///
+    /// The `area` argument can be used to load only a sub-rectangle of the whole image.
+    /// If you want the entire image then use a default [`IntRect`].
+    /// If the area rectangle crosses the bounds of the image,
+    /// it is adjusted to fit the image size.
+    ///
+    /// # Arguments
+    /// * stream - Your struct, implementing Read and Seek
+    /// * area - Area of the image to load
+    pub fn load_from_stream<T: Read + Seek>(
+        &mut self,
+        stream: &mut T,
+        area: IntRect,
+    ) -> LoadResult<()> {
+        self.texture.borrow_mut().load_from_stream(stream, area)
+    }
+
+    /// Load texture from a file
+    ///
+    /// # Arguments
+    /// * filename - Path of the image file to load
+    pub fn load_from_file(&mut self, filename: &str, area: IntRect) -> LoadResult<()> {
+        self.texture.borrow_mut().load_from_file(filename, area)
+    }
+
+    /// Convenience method to easily create and load a `Texture` from a file.
+    pub fn from_file(filename: &str) -> LoadResult<RcTexture> {
+        Ok(RcTexture {
+            texture: Rc::new(RefCell::new(Texture::from_file(filename)?)),
+        })
+    }
+
+    /// Load texture from an image
+    ///
+    /// # Arguments
+    /// * image - Image to upload to the texture
+    pub fn load_from_image(&mut self, image: &Image, area: IntRect) -> LoadResult<()> {
+        self.texture.borrow_mut().load_from_image(&image, area)
+    }
+
+    /// Update a part of the texture from the contents of a window.
+    ///
+    /// This function does nothing if either the texture or the window was not previously created.
+    ///
+    /// # Safety
+    /// No additional check is performed on the size of the window, passing an invalid combination
+    /// of window size and offset will lead to an _undefined behavior_.
+    pub unsafe fn update_from_window(&mut self, window: &Window, x: u32, y: u32) {
+        self.texture.borrow_mut().update_from_window(window, x, y)
+    }
+
+    /// Update a part of the texture from the contents of a render window.
+    ///
+    /// This function does nothing if either the texture or the window was not previously created.
+    ///
+    /// # Safety
+    /// No additional check is performed on the size of the window, passing an invalid combination
+    /// of window size and offset will lead to an _undefined behavior_.
+    pub unsafe fn update_from_render_window(
+        &mut self,
+        render_window: &RenderWindow,
+        x: u32,
+        y: u32,
+    ) {
+        self.texture
+            .borrow_mut()
+            .update_from_render_window(render_window, x, y)
+    }
+
+    /// Update a part of the texture from an image.
+    ///
+    /// This function does nothing if the texture was not previously created.
+    ///
+    /// # Safety
+    /// No additional check is performed on the size of the image, passing an invalid combination
+    /// of image size and offset will lead to an _undefined behavior_.
+    pub unsafe fn update_from_image(&mut self, image: &Image, x: u32, y: u32) {
+        self.texture.borrow_mut().update_from_image(&image, x, y)
+    }
+
+    /// Update a part of this texture from another texture.
+    ///
+    /// This function does nothing if either texture was not previously created.
+    ///
+    /// # Safety
+    /// No additional check is performed on the size of the texture,
+    /// passing an invalid combination of texture size and offset will
+    /// lead to an _undefined behavior_.
+    pub unsafe fn update_from_texture(&mut self, texture: &Texture, x: u32, y: u32) {
+        self.texture
+            .borrow_mut()
+            .update_from_texture(&texture, x, y)
+    }
+
+    /// Update a part of the texture from an array of pixels.
+    ///
+    /// The size of the pixel array must match the width and height arguments,
+    /// and it must contain 32-bits RGBA pixels.
+    ///
+    /// This function does nothing if pixels is null or if the texture was not previously created.
+    ///
+    /// # Safety
+    ///
+    /// No additional check is performed on the size of the pixel array or the bounds of the
+    /// area to update, passing invalid arguments will lead to an _undefined behavior_.
+    pub unsafe fn update_from_pixels(
+        &mut self,
+        pixels: &[u8],
+        width: u32,
+        height: u32,
+        x: u32,
+        y: u32,
+    ) {
+        self.texture
+            .borrow_mut()
+            .update_from_pixels(pixels, width, height, x, y)
+    }
+
+    /// Enable or disable the smooth filter on a texture
+    ///
+    /// # Arguments
+    /// * smooth - true to enable smoothing, false to disable it
+    pub fn set_smooth(&mut self, smooth: bool) {
+        self.texture.borrow_mut().set_smooth(smooth)
+    }
+
+    /// Enable or disable repeating for a texture
+    ///
+    /// epeating is involved when using texture coordinates
+    /// outside the texture rectangle [0, 0, width, height].
+    /// In this case, if repeat mode is enabled, the whole texture
+    /// will be repeated as many times as needed to reach the
+    /// coordinate (for example, if the X texture coordinate is
+    /// 3 * width, the texture will be repeated 3 times).
+    /// If repeat mode is disabled, the "extra space" will instead
+    /// be filled with border pixels.
+    /// Warning: on very old graphics cards, white pixels may appear
+    /// when the texture is repeated. With such cards, repeat mode
+    /// can be used reliably only if the texture has power-of-two
+    /// dimensions (such as 256x128).
+    /// Repeating is disabled by default.
+    ///
+    /// # Arguments
+    /// * repeated  - true to repeat the texture, false to disable repeating
+    pub fn set_repeated(&mut self, repeated: bool) {
+        self.texture.borrow_mut().set_repeated(repeated)
+    }
+
+    /// Get the maximum texture size allowed
+    ///
+    /// Return the maximum size allowed for textures, in pixels
+    #[must_use]
+    pub fn maximum_size() -> u32 {
+        Texture::maximum_size()
+    }
+
+    /// Enable or disable conversion from sRGB.
+    ///
+    /// When providing texture data from an image file or memory, it can either be stored in a
+    /// linear color space or an sRGB color space. Most digital images account for gamma correction
+    /// already, so they would need to be "uncorrected" back to linear color space before being
+    /// processed by the hardware. The hardware can automatically convert it from the sRGB
+    /// color space to a linear color space when it gets sampled. When the rendered image gets
+    /// output to the final framebuffer, it gets converted back to sRGB.
+    ///
+    /// After enabling or disabling sRGB conversion, make sure to reload the texture data in
+    /// order for the setting to take effect.
+    ///
+    /// This option is only useful in conjunction with an sRGB capable framebuffer.
+    /// This can be requested during window creation.
+    pub fn set_srgb(&mut self, srgb: bool) {
+        self.texture.borrow_mut().set_srgb(srgb)
+    }
+
+    /// Generate a mipmap using the current texture data.
+    ///
+    /// Mipmaps are pre-computed chains of optimized textures. Each level of texture in a mipmap
+    /// is generated by halving each of the previous level's dimensions. This is done until the
+    /// final level has the size of 1x1. The textures generated in this process may make use of
+    /// more advanced filters which might improve the visual quality of textures when they are
+    /// applied to objects much smaller than they are. This is known as minification. Because
+    /// fewer texels (texture elements) have to be sampled from when heavily minified, usage of
+    /// mipmaps can also improve rendering performance in certain scenarios.
+    ///
+    /// Mipmap generation relies on the necessary OpenGL extension being available.
+    /// If it is unavailable or generation fails due to another reason, this function will return
+    /// false. Mipmap data is only valid from the time it is generated until the next time the base
+    /// level image is modified, at which point this function will have to be called again to
+    /// regenerate it.
+    ///
+    /// Returns true if mipmap generation was successful, false if unsuccessful.
+    pub fn generate_mipmap(&mut self) -> bool {
+        self.texture.borrow_mut().generate_mipmap()
+    }
+    /// Swap the contents of this texture with those of another.
+    pub fn swap(&mut self, other: &mut Texture) {
+        self.texture.borrow_mut().swap(other)
+    }
+
+    /// INTERNAL FUNCTION ONLY
+    /// Allows other rc variants to request a weak pointer to the texture
+    pub(super) fn downgrade(&self) -> std::rc::Weak<RefCell<SfBox<Texture>>> {
+        Rc::downgrade(&self.texture)
+    }
+}
+
+impl ToOwned for RcTexture {
+    type Owned = Self;
+
+    fn to_owned(&self) -> Self {
+        RcTexture {
+            texture: Rc::new(RefCell::new(self.texture.borrow().to_owned())),
+        }
+    }
+}
+
+// It is safe to dispose of RcTexture as there is now way to create a strong reference to the
+// RefCell
+impl Dispose for RcTexture {
+    unsafe fn dispose(&mut self) {
+        self.texture.borrow_mut().dispose();
+    }
+}

--- a/src/graphics/render_target.rs
+++ b/src/graphics/render_target.rs
@@ -1,6 +1,6 @@
 use crate::{
     graphics::{
-        CircleShape, Color, ConvexShape, CustomShape, Drawable, IntRect, PrimitiveType,
+        CircleShape, Color, ConvexShape, CustomShape, Drawable, IntRect, PrimitiveType, RcSprite,
         RectangleShape, RenderStates, Sprite, Text, Vertex, VertexBuffer, View,
     },
     system::{Vector2f, Vector2i, Vector2u},
@@ -209,6 +209,9 @@ pub trait RenderTarget {
 
     /// Draw Sprite
     fn draw_sprite(&self, sprite: &Sprite, rs: &RenderStates);
+
+    /// Draw RcSprite
+    fn draw_rc_sprite(&self, sprite: &RcSprite, rs: &RenderStates);
 
     /// Draw `CircleShape`
     fn draw_circle_shape(&self, circle_shape: &CircleShape, rs: &RenderStates);

--- a/src/graphics/render_target.rs
+++ b/src/graphics/render_target.rs
@@ -210,7 +210,7 @@ pub trait RenderTarget {
     /// Draw Sprite
     fn draw_sprite(&self, sprite: &Sprite, rs: &RenderStates);
 
-    /// Draw RcSprite
+    /// Draw `RcSprite`
     fn draw_rc_sprite(&self, sprite: &RcSprite, rs: &RenderStates);
 
     /// Draw `CircleShape`

--- a/src/graphics/render_texture.rs
+++ b/src/graphics/render_texture.rs
@@ -1,7 +1,7 @@
 use crate::{
     ffi::graphics as ffi,
     graphics::{
-        CircleShape, Color, ConvexShape, CustomShape, Drawable, IntRect, PrimitiveType,
+        CircleShape, Color, ConvexShape, CustomShape, Drawable, IntRect, PrimitiveType, RcSprite,
         RectangleShape, RenderStates, RenderTarget, Sprite, Text, Texture, Vertex, VertexBuffer,
         View,
     },
@@ -169,6 +169,9 @@ impl RenderTarget for RenderTexture {
         unsafe { ffi::sfRenderTexture_drawShape(self.render_texture, shape.raw(), rs) }
     }
     fn draw_sprite(&self, sprite: &Sprite, rs: &RenderStates) {
+        unsafe { ffi::sfRenderTexture_drawSprite(self.render_texture, sprite.raw(), rs) }
+    }
+    fn draw_rc_sprite(&self, sprite: &RcSprite, rs: &RenderStates) {
         unsafe { ffi::sfRenderTexture_drawSprite(self.render_texture, sprite.raw(), rs) }
     }
     fn draw_circle_shape(&self, circle_shape: &CircleShape, rs: &RenderStates) {

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -3,7 +3,7 @@ use std::ptr::NonNull;
 use crate::{
     ffi::graphics as ffi,
     graphics::{
-        CircleShape, Color, ConvexShape, CustomShape, Drawable, IntRect, PrimitiveType,
+        CircleShape, Color, ConvexShape, CustomShape, Drawable, IntRect, PrimitiveType, RcSprite,
         RectangleShape, RenderStates, RenderTarget, Sprite, Text, Vertex, VertexBuffer, View,
     },
     system::{SfStrConv, Vector2f, Vector2i, Vector2u},
@@ -702,6 +702,11 @@ impl RenderTarget for RenderWindow {
         }
     }
     fn draw_sprite(&self, sprite: &Sprite, render_states: &RenderStates) {
+        unsafe {
+            ffi::sfRenderWindow_drawSprite(self.render_window.as_ptr(), sprite.raw(), render_states)
+        }
+    }
+    fn draw_rc_sprite(&self, sprite: &RcSprite, render_states: &RenderStates) {
         unsafe {
             ffi::sfRenderWindow_drawSprite(self.render_window.as_ptr(), sprite.raw(), render_states)
         }


### PR DESCRIPTION
Inspiration for this was to allow sprites and texture lifetimes to separate from each other. Currently, the lifetimes do not qualify for texture and sprites to be discontinuous, and it is challenging to program complicated resource management systems around this contingency. 

This PR will allow users to safely separate textures and sprites without too much worry about UB. This setup is more synonymous with the main SFML setup.

NOTE: Main SFML considers using sprites while the texture object is NULL as UB.


The only real issue is the transform functions:

If I do not prevent users from transforming a sprite while the texture is not alive, then according to eXplOit3r, that is UB. If I do prevent users from transforming a sprite while the texture is not alive, then transformations will seemingly disappear. Right now (with the current PR), RcSprite will do UB if the texture is not alive. This doesn't mean it will crash, but I simply do not know what the sprite will do if a transformation is done while the texture is not alive. I do know that setPosition won't crash, but I have not tested all the other transformations nor do I think we should. 


There are many solutions to this problem:

1. Prevent transformations if the texture is no longer alive
2. Warn users in the documentation that modifying a RcSprite is UB if the RcTexture is no longer alive, and simply blame the user for not reading the documentation.
3. Setup tests to see which RcSprite transformation functions display malicious UB while the RcTexture is no longer alive.
4. Use strong pointers (Rc) to the texture pointer inside RcSprite. This will allow the deletion of RcTexture because the underlying texture will still be alive, and will only die once all RcSprite objects that point to that texture have also died. This would allow RcSprite to continue to safely draw, transform, etc., but this is very much against the grain of SFML. Doing this would essentially change the behavior sprites exhibit from the main SFML. NOTE: The `disable_texture` function would have to go if we want to do this as this would allow users to perform UB, or we could just warn and blame the users for incorrectly using this function.
5. Return a result on transformations as to whether they were successful. This would require adding some error handling to the transform functions and returning a result for EVERY transform function. This sounds like a pain and will make the interface ugly to work with.

My suggested option is 2