### PR TITLE
Added RcText and RcFont. They follow the SAME exact principles as sprites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+
+### Added
+- Added `RcFont` and `RcText` for reference counted text (see `examples/rc-resources.rs`)
+
 ### Changed
 - Update `RcSprite` and `RcTexture` documentation.
 

--- a/examples/rc-resources.rs
+++ b/examples/rc-resources.rs
@@ -1,54 +1,99 @@
 use sfml::{
-    graphics::{Color, RcSprite, RcTexture, RenderTarget, RenderWindow, Transformable},
+    graphics::{
+        Color, RcFont, RcSprite, RcText, RcTexture, RenderTarget, RenderWindow, Transformable,
+    },
     system::Vector2f,
     window::{Event, Style},
 };
 
 include!("../example_common.rs");
 
-struct FloatingSprite {
+struct FloatingResource {
     up: bool,
     left: bool,
+    render_sprite: bool,
     sprite: RcSprite,
+    text: RcText,
     speed: f32,
 }
 
-impl FloatingSprite {
-    fn new(texture: &RcTexture, up: bool, left: bool, speed: f32) -> Self {
+impl FloatingResource {
+    fn with_texture(texture: &RcTexture, up: bool, left: bool, speed: f32) -> Self {
         Self {
             up,
             left,
             sprite: RcSprite::with_texture(texture),
+            text: Default::default(),
             speed,
+            render_sprite: true,
         }
     }
 
-    fn sprite(&self) -> &RcSprite {
-        &self.sprite
+    fn with_font(font: &RcFont, up: bool, left: bool, speed: f32) -> Self {
+        Self {
+            up,
+            left,
+            sprite: Default::default(),
+            text: RcText::new("SFML", font, 32),
+            speed,
+            render_sprite: false,
+        }
     }
 
-    fn move_sprites(&mut self, window_size: Vector2f) {
-        // Modify the sprite position freely
-        if self.sprite.position().y <= 0f32 {
-            self.up = false;
+    fn render(&self, window: &mut RenderWindow) {
+        if self.render_sprite {
+            window.draw(&self.sprite)
+        } else {
+            window.draw(&self.text)
         }
-        if self.sprite.position().y + self.sprite.global_bounds().height >= window_size.y {
-            self.up = true;
-        }
-        if self.sprite.position().x <= 0f32 {
-            self.left = false;
-        }
-        if self.sprite.position().x + self.sprite.global_bounds().width >= window_size.x {
-            self.left = true;
-        }
+    }
 
-        self.sprite.set_position(
-            self.sprite.position()
-                + Vector2f::new(
-                    if self.left { -self.speed } else { self.speed },
-                    if self.up { -self.speed } else { self.speed },
-                ),
-        );
+    fn move_resources(&mut self, window_size: Vector2f) {
+        if self.render_sprite {
+            // Modify the sprite position freely
+            if self.sprite.position().y <= 0f32 {
+                self.up = false;
+            }
+            if self.sprite.position().y + self.sprite.global_bounds().height >= window_size.y {
+                self.up = true;
+            }
+            if self.sprite.position().x <= 0f32 {
+                self.left = false;
+            }
+            if self.sprite.position().x + self.sprite.global_bounds().width >= window_size.x {
+                self.left = true;
+            }
+
+            self.sprite.set_position(
+                self.sprite.position()
+                    + Vector2f::new(
+                        if self.left { -self.speed } else { self.speed },
+                        if self.up { -self.speed } else { self.speed },
+                    ),
+            );
+        } else {
+            // Modify the sprite position freely
+            if self.text.position().y <= 0f32 {
+                self.up = false;
+            }
+            if self.text.position().y + self.text.global_bounds().height >= window_size.y {
+                self.up = true;
+            }
+            if self.text.position().x <= 0f32 {
+                self.left = false;
+            }
+            if self.text.position().x + self.text.global_bounds().width >= window_size.x {
+                self.left = true;
+            }
+
+            self.text.set_position(
+                self.text.position()
+                    + Vector2f::new(
+                        if self.left { -self.speed } else { self.speed },
+                        if self.up { -self.speed } else { self.speed },
+                    ),
+            );
+        }
     }
 }
 
@@ -60,12 +105,19 @@ fn main() {
     // Create a new texture.
     let texture = RcTexture::from_file(example_res!("logo.png")).unwrap();
 
-    // Load many sprites with no lifetime contingencies
-    let mut floating_sprites = Vec::from([
-        FloatingSprite::new(&texture, true, true, 1f32),
-        FloatingSprite::new(&texture, true, false, 1.5f32),
-        FloatingSprite::new(&texture, false, true, 2f32),
-        FloatingSprite::new(&texture, false, false, 2.5f32),
+    // Create a new font.
+    let font = RcFont::from_file(example_res!("sansation.ttf")).unwrap();
+
+    // Load many resources with no lifetime contingencies
+    let mut floating_resources = Vec::from([
+        FloatingResource::with_texture(&texture, true, true, 1f32),
+        FloatingResource::with_texture(&texture, true, false, 1.5f32),
+        FloatingResource::with_texture(&texture, false, true, 2f32),
+        FloatingResource::with_texture(&texture, false, false, 2.5f32),
+        FloatingResource::with_font(&font, true, true, 1.25f32),
+        FloatingResource::with_font(&font, true, true, 1.75f32),
+        FloatingResource::with_font(&font, true, true, 2.25f32),
+        FloatingResource::with_font(&font, true, true, 2.75f32),
     ]);
 
     while window.is_open() {
@@ -75,16 +127,16 @@ fn main() {
             }
         }
 
-        // Update floating_sprite positions so they move around on the screen
-        for floating_sprite in &mut floating_sprites {
-            floating_sprite.move_sprites(Vector2f::new(800f32, 600f32));
+        // Update floating_resource positions so they move around on the screen
+        for floating_resource in &mut floating_resources {
+            floating_resource.move_resources(Vector2f::new(800f32, 600f32));
         }
 
         window.clear(Color::BLACK);
 
-        // Fetch and draw all the sprites in floating_sprites
-        for floating_sprite in &floating_sprites {
-            window.draw(floating_sprite.sprite());
+        // Fetch and draw all the sprites in floating_resources
+        for floating_resource in &floating_resources {
+            floating_resource.render(&mut window);
         }
         window.display();
     }

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -14,6 +14,8 @@ pub use self::{
     primitive_type::PrimitiveType,
     rc_sprite::RcSprite,
     rc_texture::RcTexture,
+    rc_font::RcFont,
+    rc_text::RcText,
     rect::{FloatRect, IntRect, Rect},
     rectangle_shape::RectangleShape,
     render_states::RenderStates,
@@ -45,6 +47,8 @@ pub mod glsl;
 mod glyph;
 mod image;
 mod primitive_type;
+mod rc_font;
+mod rc_text;
 mod rc_sprite;
 mod rc_texture;
 mod rect;

--- a/src/graphics/rc_font.rs
+++ b/src/graphics/rc_font.rs
@@ -1,0 +1,286 @@
+use crate::{
+    graphics::{font::Info, Font, Glyph, Texture},
+    sf_box::{Dispose, SfBox},
+};
+use std::{
+    cell::RefCell,
+    io::{Read, Seek},
+    rc::Rc,
+};
+
+/// Type for loading and manipulating character fonts.
+///
+/// Fonts can be loaded from a file, from memory or from a custom stream,
+/// and supports the most common types of fonts.
+///
+/// See the [`from_file`] function for the complete list of supported formats.
+///
+/// [`from_file`]: RcFont::from_file
+///
+/// Once it is loaded, a `RcFont` instance provides three types of information about the font:
+///
+/// - Global metrics, such as the line spacing
+/// - Per-glyph metrics, such as bounding box or kerning
+/// - Pixel representation of glyphs
+///
+/// Fonts alone are not very useful: they hold the font data but cannot make anything useful of it.
+/// To do so you need to use the [`RcText`] type, which is able to properly output text with
+/// several options such as character size, style, color, position, rotation, etc.
+/// This separation allows more flexibility and better performances:
+/// indeed a `RcFont` is a heavy resource, and any operation on it is
+/// slow (often too slow for real-time applications).
+/// On the other side, a [`RcText`] is a lightweight object which can combine the
+/// glyphs data and metrics of a `RcFont` to display any text on a render target.
+/// Note that it is also possible to bind several [`RcText`] instances to the same `RcFont`.
+///
+/// It is important to note that the [`RcText`] instance doesn't copy the font that it uses,
+/// it only keeps a reference to it.
+/// Thus, a `RcFont` must not be destructed while it is used by a
+/// [`RcText`] (i.e. never write a function that uses a local `RcFont` instance for creating a text).
+///
+/// Apart from loading font files, and passing them to instances of [`RcText`],
+/// you should normally not have to deal directly with this type.
+/// However, it may be useful to access the font metrics or rasterized glyphs for advanced usage.
+///
+/// Note that if the font is a bitmap font, it is not scalable,
+/// thus not all requested sizes will be available to use.
+/// This needs to be taken into consideration when using [`RcText`].
+/// If you need to display text of a certain size, make sure the corresponding bitmap font that
+/// supports that size is used.
+///
+/// [`RcText`]: crate::graphics::RcText
+#[derive(Debug)]
+pub struct RcFont {
+    font: Rc<RefCell<SfBox<Font>>>,
+}
+
+impl RcFont {
+    /// Get the kerning value corresponding to a given pair of characters in a font
+    ///
+    /// # Arguments
+    /// * first - Unicode code point of the first character
+    /// * second - Unicode code point of the second character
+    /// * characterSize - Character size, in pixels
+    ///
+    /// Return the kerning offset, in pixels
+    ///
+    /// # Usage Example
+    ///
+    /// ```
+    /// # use sfml::graphics::RcFont;
+    /// # let font = RcFont::from_file("examples/resources/sansation.ttf").unwrap();
+    /// let kerning = font.kerning(0, 0, 32);
+    /// assert_eq!(kerning, 0.);
+    /// ```
+    #[must_use]
+    pub fn kerning(&self, first: u32, second: u32, character_size: u32) -> f32 {
+        self.font.borrow().kerning(first, second, character_size)
+    }
+
+    /// Get the line spacing value
+    ///
+    /// # Arguments
+    /// * characterSize - Character size, in pixels
+    ///
+    /// Return the line spacing, in pixels
+    ///
+    /// # Usage Example
+    ///
+    /// ```
+    /// # use sfml::graphics::RcFont;
+    /// # let font = RcFont::from_file("examples/resources/sansation.ttf").unwrap();
+    /// let line_spacing = font.line_spacing(32);
+    /// assert_eq!(line_spacing, 35.);
+    /// ```
+    #[must_use]
+    pub fn line_spacing(&self, character_size: u32) -> f32 {
+        self.font.borrow().line_spacing(character_size)
+    }
+
+    /// Get a glyph in a font
+    ///
+    /// # Arguments
+    /// * codePoint - Unicode code point of the character to get
+    /// * characterSize - Character size, in pixels
+    /// * bold - Retrieve the bold version or the regular one?
+    ///
+    /// Return the corresponding glyph
+    ///
+    /// # Usage Example
+    ///
+    /// ```no_run
+    /// # use sfml::graphics::RcFont;
+    /// # let font = RcFont::from_file("examples/resources/sansation.ttf").unwrap();
+    /// let glyph = font.glyph(41, 32, false, 5.);
+    /// # use sfml::graphics::Rect;
+    /// assert_eq!(glyph.bounds(), Rect::new(0., -23., 17., 39.));
+    /// ```
+    #[must_use]
+    pub fn glyph(
+        &self,
+        codepoint: u32,
+        character_size: u32,
+        bold: bool,
+        outline_thickness: f32,
+    ) -> Glyph {
+        self.font
+            .borrow()
+            .glyph(codepoint, character_size, bold, outline_thickness)
+    }
+
+    /// Returns the font information.
+    ///
+    /// # Usage Example
+    ///
+    /// ```
+    /// # use sfml::graphics::RcFont;
+    /// let font = RcFont::from_file("examples/resources/sansation.ttf").unwrap();
+    /// let font_info = font.info();
+    /// assert_eq!(font_info.family, "Sansation");
+    /// ```
+    #[must_use]
+    pub fn info(&self) -> Info {
+        self.font.borrow().info()
+    }
+
+    /// Returns the position of the underline.
+    ///
+    /// # Usage Example
+    ///
+    /// ```
+    /// # use sfml::graphics::RcFont;
+    /// # let font = RcFont::from_file("examples/resources/sansation.ttf").unwrap();
+    /// let underline_position = font.underline_position(32);
+    /// assert_eq!(underline_position, 3.734375);
+    /// ```
+    #[must_use]
+    pub fn underline_position(&self, character_size: u32) -> f32 {
+        self.font.borrow().underline_position(character_size)
+    }
+
+    /// Returns the thickness of the underline.
+    ///
+    /// # Usage Example
+    ///
+    /// ```
+    /// # use sfml::graphics::RcFont;
+    /// # let font = RcFont::from_file("examples/resources/sansation.ttf").unwrap();
+    /// let underline_thickness = font.underline_thickness(32);
+    /// assert_eq!(underline_thickness, 2.34375);
+    /// ```
+    #[must_use]
+    pub fn underline_thickness(&self, character_size: u32) -> f32 {
+        self.font.borrow().underline_thickness(character_size)
+    }
+
+    /// Load the font from a file.
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF, OpenType, SFNT, X11 PCF,
+    /// Windows FNT, BDF, PFR and Type 42.
+    /// Note that this function know nothing about the standard fonts installed on the
+    /// user's system, thus you can't load them directly.
+    ///
+    /// # Warning
+    /// SFML cannot preload all the font data in this function,
+    /// so the file has to remain accessible until the `RcFont` object loads a new font or
+    /// is destroyed.
+    ///
+    /// # Usage Example
+    ///
+    /// ```
+    /// # use sfml::graphics::RcFont;
+    /// let font = match RcFont::from_file("examples/resources/sansation.ttf") {
+    ///     Some(font) => font,
+    ///     None => {
+    ///         panic!("Failed to read font file!");
+    ///     }
+    /// };
+    /// ```
+    #[must_use]
+    pub fn from_file(filename: &str) -> Option<Self> {
+        Some(RcFont {
+            font: Rc::new(RefCell::new(Font::from_file(filename)?)),
+        })
+    }
+
+    /// Load the font from a custom stream.
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF, OpenType, SFNT, X11 PCF,
+    /// Windows FNT, BDF, PFR and Type 42.
+    ///
+    /// # Safety
+    /// SFML cannot preload all the font data in this function, so the stream has to remain
+    /// accessible until the `RcFont` object loads a new font or is destroyed.
+    ///
+    /// # Returns
+    /// True if loading succeeded, false if it failed
+    ///
+    /// # See also
+    /// [`RcFont::from_file`], [`RcFont::from_memory`]
+    pub unsafe fn from_stream<T: Read + Seek>(stream: &mut T) -> Option<Self> {
+        Some(RcFont {
+            font: Rc::new(RefCell::new(Font::from_stream(stream)?)),
+        })
+    }
+
+    /// Load the font from a file in memory.
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF, OpenType, SFNT, X11 PCF,
+    /// Windows FNT, BDF, PFR and Type 42.
+    ///
+    /// # Safety
+    /// SFML cannot preload all the font data in this function, so the buffer pointed by `memory`
+    /// has to remain valid until the `RcFont` object loads a new font or is destroyed.
+    ///
+    /// # Returns
+    /// True if loading succeeded, false if it failed
+    ///
+    /// See also
+    /// [`RcFont::from_file`], [`RcFont::from_stream`]
+    #[must_use]
+    pub unsafe fn from_memory(memory: &[u8]) -> Option<Self> {
+        Some(RcFont {
+            font: Rc::new(RefCell::new(Font::from_memory(memory)?)),
+        })
+    }
+
+    /// Get the texture containing the glyphs of a given size in a font
+    ///
+    /// # Arguments
+    /// * `character_size` - Character size, in pixels
+    ///
+    /// # Usage Example
+    ///
+    /// ```no_run
+    /// # use sfml::graphics::RcFont;
+    /// # let font = RcFont::from_file("examples/resources/sansation.ttf").unwrap();
+    /// let texture = font.texture(32);
+    /// # use sfml::system::Vector2;
+    /// assert_eq!(texture.size(), Vector2::new(128, 128));
+    /// ```
+    #[must_use]
+    pub fn texture(&self, character_size: u32) -> &Texture {
+        unsafe { (**self.font.as_ptr()).texture(character_size) }
+    }
+
+    /// INTERNAL FUNCTION ONLY
+    /// Allows other rc variants to request a weak pointer to the texture
+    pub(super) fn downgrade(&self) -> std::rc::Weak<RefCell<SfBox<Font>>> {
+        Rc::downgrade(&self.font)
+    }
+}
+
+impl ToOwned for RcFont {
+    type Owned = RcFont;
+    fn to_owned(&self) -> Self {
+        RcFont {
+            font: Rc::new(RefCell::new(self.font.borrow().to_owned())),
+        }
+    }
+}
+
+impl Dispose for RcFont {
+    unsafe fn dispose(&mut self) {
+        self.font.borrow_mut().dispose()
+    }
+}

--- a/src/graphics/rc_text.rs
+++ b/src/graphics/rc_text.rs
@@ -1,0 +1,489 @@
+use crate::{
+    ffi::graphics as ffi,
+    graphics::{
+        Color, Drawable, FloatRect, Font, RcFont, RenderStates, RenderTarget, TextStyle, Transform,
+        Transformable,
+    },
+    sf_box::SfBox,
+    system::{SfStr, SfStrConv, Vector2f},
+};
+use std::{cell::RefCell, ptr::NonNull, rc::Weak};
+
+const ERROR_MSG: &str = "Text does not hold a font. Ignoring transformation!";
+const RETURN_ERROR_MSG: &str = "Text does not hold a font. Returning default value!";
+const PANIC_ERROR_MSG: &str = "Text does not hold a font! Return value cannot be discerned!";
+
+/// Graphical text
+///
+/// `RcText` is a drawable type that allows to easily
+/// display some text with custom style and color on a render target.
+///
+/// __Note:__
+/// Currently, it is not feasible to store text long term.
+/// A common pattern with rust-sfml is to create a `Text` right before you start drawing,
+/// and draw all the text you want with it. You can change its properties using
+/// `set_font`, `set_position`, `set_string`, etc., before drawing it, as many times as you need
+/// to.
+/// This is an improvement upon the [`sfml::graphics::Text`] module which dissallows seperation from the [`Font`]
+/// lifetime. The `RcText` allows for complete seperation from the [`RcFont`] while still
+/// referencing it. Underneath, it uses reference counting to ensure that the [`RcFont`] is alive,
+/// and will throw errors messages if you try to perform function on the sprite while the
+/// [`RcFont`] is no longer alive. the only functions that allow usage while the [`RcFont`] is not alive are
+/// `set_string`, `string`, `character_size`, `set_style`, `set_font`, `set_character_size`, `style`, `font`,
+/// `fill-color`, `outline_color`, `outline_thickness`, `line_spacing`, `set_line_spacing`, `letter_spacing`,
+/// `set_letter_spacing`
+#[derive(Debug)]
+pub struct RcText {
+    text: NonNull<ffi::sfText>,
+    font: Weak<RefCell<SfBox<Font>>>,
+}
+
+impl RcText {
+    /// Create a new `RcText` with initialized value
+    ///
+    /// Default value for characterSize on SFML is 30.
+    ///
+    /// # Arguments
+    /// * string - The string of the `RcText`
+    /// * font - The [`RcFont`] to display the `RcText`
+    /// * characterSize - The size of the `RcText`
+    pub fn new<S: SfStrConv>(string: S, font: &RcFont, character_size: u32) -> Self {
+        let mut text = Self::default();
+        text.set_string(string);
+        text.set_font(font);
+        text.set_character_size(character_size);
+        text
+    }
+
+    fn font_exists(&self) -> bool {
+        self.font.strong_count() != 0
+    }
+
+    fn set_rc_font(&mut self, font: &RcFont) {
+        self.font = font.downgrade();
+    }
+
+    /// Set the string of a `RcText`
+    ///
+    /// A `RcText`'s string is empty by default.
+    ///
+    /// # Arguments
+    /// * string - New string
+    pub fn set_string<S: SfStrConv>(&mut self, string: S) {
+        string.with_as_sfstr(|sfstr| unsafe {
+            ffi::sfText_setUnicodeString(self.text.as_ptr(), sfstr.as_ptr());
+        })
+    }
+
+    /// Get the string of a `RcText`
+    #[must_use]
+    pub fn string(&self) -> &SfStr {
+        unsafe {
+            let utf32: *const u32 = ffi::sfText_getUnicodeString(self.text.as_ptr());
+            SfStr::from_ptr_str(utf32)
+        }
+    }
+
+    /// Get the size of the characters
+    ///
+    /// Return the size of the characters
+    #[must_use]
+    pub fn character_size(&self) -> u32 {
+        unsafe { ffi::sfText_getCharacterSize(self.text.as_ptr()) }
+    }
+
+    /// Set the font of the `RcText`
+    ///
+    /// font - New [`RcFont`]
+    pub fn set_font(&mut self, font: &RcFont) {
+        self.set_rc_font(font);
+        unsafe {
+            ffi::sfText_setFont(
+                self.text.as_ptr(),
+                (*self.font.upgrade().unwrap().as_ptr())
+                    .0
+                    .as_ptr()
+                    .cast_const(),
+            )
+        }
+    }
+
+    /// Set the style of a `RcText`
+    ///
+    /// You can pass a combination of one or more styles, for
+    /// example Bold | Italic.
+    /// The default style is Regular.
+    ///
+    /// # Arguments
+    /// * style - New style
+    pub fn set_style(&mut self, style: TextStyle) {
+        unsafe { ffi::sfText_setStyle(self.text.as_ptr(), style.bits()) }
+    }
+
+    /// Set the size of the characters of a `RcText`
+    ///
+    /// The default size is 30.
+    ///
+    /// # Arguments
+    /// * size - The new character size, in pixel
+    pub fn set_character_size(&mut self, size: u32) {
+        unsafe { ffi::sfText_setCharacterSize(self.text.as_ptr(), size) }
+    }
+
+    /// Get the style of a `RcText`
+    ///
+    /// Return the current string style (see Style enum)
+    #[must_use]
+    pub fn style(&self) -> TextStyle {
+        unsafe { TextStyle::from_bits_truncate(ffi::sfText_getStyle(self.text.as_ptr())) }
+    }
+
+    /// Get the Font of a `RcText`
+    /// If the `RcText` has no [`RcFont`] attached, a None is returned.
+    /// The returned pointer is const, which means that you can't
+    /// modify the font when you retrieve it with this function.
+    #[must_use]
+    pub fn font(&self) -> Option<&Font> {
+        if self.font_exists() {
+            Some(unsafe { &*(*(self.font.as_ptr())).as_ptr() })
+        } else {
+            None
+        }
+    }
+
+    /// Set the fill color of the text.
+    ///
+    /// By default, the text's fill color is opaque white. Setting the fill color to a transparent
+    /// color with an outline will cause the outline to be displayed in the fill area of the text.
+    ///
+    /// # Warning
+    /// Function fails, and prints an error message if `RcText`'s font is dead.
+    pub fn set_fill_color(&mut self, color: Color) {
+        if !self.font_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
+        unsafe { ffi::sfText_setFillColor(self.text.as_ptr(), color) }
+    }
+
+    /// Set the thickness of the `RcText`'s outline.
+    ///
+    /// By default, the outline thickness is 0.
+    ///
+    /// Be aware that using a negative value for the outline thickness will cause distorted
+    /// rendering.
+    ///
+    /// # Warning
+    /// Function fails, and prints an error message if `RcText`'s font is dead.
+    pub fn set_outline_thickness(&mut self, thickness: f32) {
+        if !self.font_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
+        unsafe { ffi::sfText_setOutlineThickness(self.text.as_ptr(), thickness) }
+    }
+
+    /// Returns the fill color of the `RcText`.
+    #[must_use]
+    pub fn fill_color(&self) -> Color {
+        unsafe { ffi::sfText_getFillColor(self.text.as_ptr()) }
+    }
+
+    /// Returns the outline color of the `RcText`.
+    #[must_use]
+    pub fn outline_color(&self) -> Color {
+        unsafe { ffi::sfText_getOutlineColor(self.text.as_ptr()) }
+    }
+
+    /// Returns the outline thickness of the `RcText`, in pixels.
+    #[must_use]
+    pub fn outline_thickness(&self) -> f32 {
+        unsafe { ffi::sfText_getOutlineThickness(self.text.as_ptr()) }
+    }
+
+    /// Return the position of the index-th character in a text
+    ///
+    /// This function computes the visual position of a character
+    /// from its index in the string. The returned position is
+    /// in global coordinates (translation, rotation, scale and
+    /// origin are applied).
+    /// If index is out of range, the position of the end of
+    /// the string is returned.
+    ///
+    /// # Arguments
+    /// * index - The index of the character
+    ///
+    /// Return the position of the character
+    ///
+    /// # Warning
+    /// Function fails, returns default, and prints an error message if [`RcFont`] is dead.
+    #[must_use]
+    pub fn find_character_pos(&self, index: usize) -> Vector2f {
+        if !self.font_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
+        unsafe { ffi::sfText_findCharacterPos(self.text.as_ptr(), index) }
+    }
+
+    /// Get the local bounding rectangle of a text
+    ///
+    /// The returned rectangle is in local coordinates, which means
+    /// that it ignores the transformations (translation, rotation,
+    /// scale, ...) that are applied to the entity.
+    /// In other words, this function returns the bounds of the
+    /// entity in the entity's coordinate system.
+    ///
+    /// Return the local bounding rectangle of the entity
+    ///
+    /// # Warning
+    /// Function fails, returns default, and prints an error message if [`RcFont`] is dead.
+    #[must_use]
+    pub fn local_bounds(&self) -> FloatRect {
+        if !self.font_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
+        unsafe { ffi::sfText_getLocalBounds(self.text.as_ptr()) }
+    }
+
+    /// Get the global bounding rectangle of a text
+    ///
+    /// The returned rectangle is in global coordinates, which means
+    /// that it takes in account the transformations (translation,
+    /// rotation, scale, ...) that are applied to the entity.
+    /// In other words, this function returns the bounds of the
+    /// text in the global 2D world's coordinate system.
+    ///
+    /// Return the global bounding rectangle of the entity
+    ///
+    /// # Warning
+    /// Function fails, returns default, and prints an error message if [`RcFont`] is dead.
+    #[must_use]
+    pub fn global_bounds(&self) -> FloatRect {
+        if !self.font_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
+        unsafe { ffi::sfText_getGlobalBounds(self.text.as_ptr()) }
+    }
+
+    /// Get the size of the line spacing factor.
+    #[must_use]
+    pub fn line_spacing(&self) -> f32 {
+        unsafe { ffi::sfText_getLineSpacing(self.text.as_ptr()) }
+    }
+
+    /// Set the line spacing factor.
+    ///
+    /// The default spacing between lines is defined by the font.
+    /// This method enables you to set a factor for the spacing between lines.
+    /// By default the line spacing factor is 1.
+    pub fn set_line_spacing(&mut self, factor: f32) {
+        unsafe { ffi::sfText_setLineSpacing(self.text.as_ptr(), factor) }
+    }
+
+    /// Get the size of the letter spacing factor.
+    #[must_use]
+    pub fn letter_spacing(&self) -> f32 {
+        unsafe { ffi::sfText_getLetterSpacing(self.text.as_ptr()) }
+    }
+
+    /// Set the letter spacing factor.
+    ///
+    /// The default spacing between letters is defined by the font.
+    /// This factor doesn't directly apply to the existing spacing between each character,
+    /// it rather adds a fixed space between them which is calculated from the font metrics and
+    /// the character size. Note that factors below 1 (including negative numbers) bring
+    /// characters closer to each other    
+    pub fn set_letter_spacing(&mut self, factor: f32) {
+        unsafe { ffi::sfText_setLetterSpacing(self.text.as_ptr(), factor) }
+    }
+
+    pub(super) fn raw(&self) -> *const ffi::sfText {
+        self.text.as_ptr()
+    }
+}
+
+impl Default for RcText {
+    fn default() -> Self {
+        let text = unsafe { ffi::sfText_create() };
+        Self {
+            text: NonNull::new(text).expect("Failed to create Text"),
+            font: Weak::new(),
+        }
+    }
+}
+
+impl Clone for RcText {
+    /// Return a new Text or panic! if there is not enough memory
+    fn clone(&self) -> Self {
+        let sp = unsafe { ffi::sfText_copy(self.text.as_ptr()) };
+        Self {
+            text: NonNull::new(sp).expect("Not enough memory to clone Text"),
+            font: self.font.clone(),
+        }
+    }
+}
+
+impl Drawable for RcText {
+    fn draw<'a: 'shader, 'texture, 'shader, 'shader_texture>(
+        &'a self,
+        target: &mut dyn RenderTarget,
+        states: &RenderStates<'texture, 'shader, 'shader_texture>,
+    ) {
+        if self.font_exists() {
+            target.draw_rc_text(self, states)
+        }
+    }
+}
+
+impl Transformable for RcText {
+    /// Reference [`Transformable::set_position`] for additional information
+    ///
+    /// # Warning
+    /// Function fails, and prints an error message if `RcText`'s font is dead.
+    fn set_position<P: Into<Vector2f>>(&mut self, position: P) {
+        if !self.font_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
+        unsafe { ffi::sfText_setPosition(self.text.as_ptr(), position.into()) }
+    }
+    /// Reference [`Transformable::set_rotation`] for additional information
+    ///
+    /// # Warning
+    /// Function fails, and prints an error message if `RcText`'s font is dead.
+    fn set_rotation(&mut self, angle: f32) {
+        if !self.font_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
+        unsafe { ffi::sfText_setRotation(self.text.as_ptr(), angle) }
+    }
+    /// Reference [`Transformable::set_scale`] for additional information
+    ///
+    /// # Warning
+    /// Function fails, and prints an error message if `RcText`'s font is dead.
+    fn set_scale<S: Into<Vector2f>>(&mut self, scale: S) {
+        if !self.font_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
+        unsafe { ffi::sfText_setScale(self.text.as_ptr(), scale.into()) }
+    }
+    /// Reference [`Transformable::set_origin`] for additional information
+    ///
+    /// # Warning
+    /// Function fails, and prints an error message if `RcText`'s font is dead.
+    fn set_origin<O: Into<Vector2f>>(&mut self, origin: O) {
+        if !self.font_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
+        unsafe { ffi::sfText_setOrigin(self.text.as_ptr(), origin.into()) }
+    }
+    /// Reference [`Transformable::position`] for additional information
+    ///
+    /// # Warning
+    /// Function fails, returns default, and prints an error message if [`RcFont`] is dead.
+    fn position(&self) -> Vector2f {
+        if !self.font_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
+        unsafe { ffi::sfText_getPosition(self.text.as_ptr()) }
+    }
+    /// Reference [`Transformable::rotation`] for additional information
+    ///
+    /// # Warning
+    /// Function fails, returns default, and prints an error message if [`RcFont`] is dead.
+    fn rotation(&self) -> f32 {
+        if !self.font_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
+        unsafe { ffi::sfText_getRotation(self.text.as_ptr()) }
+    }
+    /// Reference [`Transformable::get_scale`] for additional information
+    ///
+    /// # Warning
+    /// Function fails, returns default, and prints an error message if [`RcFont`] is dead.
+    fn get_scale(&self) -> Vector2f {
+        if !self.font_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
+        unsafe { ffi::sfText_getScale(self.text.as_ptr()) }
+    }
+    /// Reference [`Transformable::origin`] for additional information
+    ///
+    /// # Warning
+    /// Function fails, returns default, and prints an error message if [`RcFont`] is dead.
+    fn origin(&self) -> Vector2f {
+        if !self.font_exists() {
+            eprintln!("{}", RETURN_ERROR_MSG);
+            return Default::default();
+        }
+        unsafe { ffi::sfText_getOrigin(self.text.as_ptr()) }
+    }
+    /// Reference [`Transformable::move_`] for additional information
+    ///
+    /// # Warning
+    /// Function fails, and prints an error message if `RcText`'s font is dead.
+    fn move_<O: Into<Vector2f>>(&mut self, offset: O) {
+        if !self.font_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
+        unsafe { ffi::sfText_move(self.text.as_ptr(), offset.into()) }
+    }
+    /// Reference [`Transformable::rotate`] for additional information
+    ///
+    /// # Warning
+    /// Function fails, and prints an error message if `RcText`'s font is dead.
+    fn rotate(&mut self, angle: f32) {
+        if !self.font_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
+        unsafe { ffi::sfText_rotate(self.text.as_ptr(), angle) }
+    }
+    /// Reference [`Transformable::scale`] for additional information
+    ///
+    /// # Warning
+    /// Function fails, and prints an error message if `RcText`'s font is dead.
+    fn scale<F: Into<Vector2f>>(&mut self, factors: F) {
+        if !self.font_exists() {
+            eprintln!("{}", ERROR_MSG);
+            return;
+        }
+        unsafe { ffi::sfText_scale(self.text.as_ptr(), factors.into()) }
+    }
+    /// Reference [`Transformable::transform`] for additional information
+    ///
+    /// Panics if font doesn't exist
+    fn transform(&self) -> &Transform {
+        if !self.font_exists() {
+            panic!("{}", PANIC_ERROR_MSG);
+        }
+        unsafe { &*ffi::sfText_getTransform(self.text.as_ptr()) }
+    }
+    /// Reference [`Transformable::inverse_transform`] for additional information
+    ///
+    /// Panics if font doesn't exist
+    fn inverse_transform(&self) -> &Transform {
+        if !self.font_exists() {
+            panic!("{}", PANIC_ERROR_MSG);
+        }
+        unsafe { &*ffi::sfText_getInverseTransform(self.text.as_ptr()) }
+    }
+}
+
+impl Drop for RcText {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::sfText_destroy(self.text.as_ptr());
+        }
+    }
+}

--- a/src/graphics/render_target.rs
+++ b/src/graphics/render_target.rs
@@ -1,7 +1,7 @@
 use crate::{
     graphics::{
         CircleShape, Color, ConvexShape, CustomShape, Drawable, IntRect, PrimitiveType, RcSprite,
-        RectangleShape, RenderStates, Sprite, Text, Vertex, VertexBuffer, View,
+        RcText, RectangleShape, RenderStates, Sprite, Text, Vertex, VertexBuffer, View,
     },
     system::{Vector2f, Vector2i, Vector2u},
 };
@@ -203,6 +203,9 @@ pub trait RenderTarget {
 
     /// Draw Text
     fn draw_text(&self, text: &Text, rs: &RenderStates);
+
+    /// Draw `RcText`
+    fn draw_rc_text(&self, text: &RcText, rs: &RenderStates);
 
     /// Draw Shape
     fn draw_shape(&self, shape: &CustomShape, rs: &RenderStates);

--- a/src/graphics/render_texture.rs
+++ b/src/graphics/render_texture.rs
@@ -2,8 +2,8 @@ use crate::{
     ffi::graphics as ffi,
     graphics::{
         CircleShape, Color, ConvexShape, CustomShape, Drawable, IntRect, PrimitiveType, RcSprite,
-        RectangleShape, RenderStates, RenderTarget, Sprite, Text, Texture, Vertex, VertexBuffer,
-        View,
+        RcText, RectangleShape, RenderStates, RenderTarget, Sprite, Text, Texture, Vertex,
+        VertexBuffer, View,
     },
     system::{Vector2f, Vector2i, Vector2u},
     window::ContextSettings,
@@ -163,6 +163,9 @@ impl RenderTarget for RenderTexture {
         object.draw(self, render_states);
     }
     fn draw_text(&self, text: &Text, rs: &RenderStates) {
+        unsafe { ffi::sfRenderTexture_drawText(self.render_texture, text.raw(), rs) }
+    }
+    fn draw_rc_text(&self, text: &RcText, rs: &RenderStates) {
         unsafe { ffi::sfRenderTexture_drawText(self.render_texture, text.raw(), rs) }
     }
     fn draw_shape(&self, shape: &CustomShape, rs: &RenderStates) {

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -4,7 +4,8 @@ use crate::{
     ffi::graphics as ffi,
     graphics::{
         CircleShape, Color, ConvexShape, CustomShape, Drawable, IntRect, PrimitiveType, RcSprite,
-        RectangleShape, RenderStates, RenderTarget, Sprite, Text, Vertex, VertexBuffer, View,
+        RcText, RectangleShape, RenderStates, RenderTarget, Sprite, Text, Vertex, VertexBuffer,
+        View,
     },
     system::{SfStrConv, Vector2f, Vector2i, Vector2u},
     window::{thread_safety, ContextSettings, Cursor, Event, Handle, Style, VideoMode},
@@ -692,6 +693,11 @@ impl RenderTarget for RenderWindow {
         object.draw(self, render_states);
     }
     fn draw_text(&self, text: &Text, render_states: &RenderStates) {
+        unsafe {
+            ffi::sfRenderWindow_drawText(self.render_window.as_ptr(), text.raw(), render_states)
+        }
+    }
+    fn draw_rc_text(&self, text: &RcText, render_states: &RenderStates) {
         unsafe {
             ffi::sfRenderWindow_drawText(self.render_window.as_ptr(), text.raw(), render_states)
         }


### PR DESCRIPTION
The functions that do not have checks on whether the font exists or not have been pre-checked by me. You can look through https://github.com/SFML/SFML/blob/master/src/SFML/Graphics/Text.cpp to view which methods are safe to perform while the font is dead. They follow the same principle. They set a boolean, m_geometryNeedUpdate, to true and perform the transformations later on (for instance during draw). This PR shouldn't have any reason for UB.