### PR TITLE
Implements set_smooth and is_smooth

### DIFF
--- a/CSFML/src/Graphics/Font.cpp
+++ b/CSFML/src/Graphics/Font.cpp
@@ -1,4 +1,5 @@
 #include "Graphics/Rect.h"
+#include "SFML/Config.h"
 #include "System/InputStreamStruct.h"
 #include <SFML/Graphics/Font.hpp>
 #include <cstddef>
@@ -75,6 +76,14 @@ extern "C" float sfFont_getUnderlineThickness(const sf::Font *font, unsigned int
 
 extern "C" const sf::Texture *sfFont_getTexture(const sf::Font *font, unsigned int characterSize) {
     return &font->getTexture(characterSize);
+}
+
+extern "C" bool sfFont_isSmooth(const sf::Font *font) {
+    return font->isSmooth();
+}
+
+extern "C" void sfFont_setSmooth(sf::Font *font, bool smooth) {
+    font->setSmooth(smooth);
 }
 
 typedef struct

--- a/examples/rc-resources.rs
+++ b/examples/rc-resources.rs
@@ -4,7 +4,7 @@ use sfml::{
         Transformable,
     },
     system::Vector2f,
-    window::{Event, Style},
+    window::{Event, Key, Style},
 };
 
 include!("../example_common.rs");
@@ -31,14 +31,17 @@ impl FloatingResource {
     }
 
     fn with_font(font: &RcFont, up: bool, left: bool, speed: f32) -> Self {
-        Self {
+        let mut self_ = Self {
             up,
             left,
             sprite: Default::default(),
-            text: RcText::new("SFML", font, 32),
+            text: RcText::new("SFML", font, 16),
             speed,
             render_sprite: false,
-        }
+        };
+        self_.text.scale(Vector2f::new(2., 2.));
+
+        self_
     }
 
     fn render(&self, window: &mut RenderWindow) {
@@ -102,6 +105,13 @@ fn test_getting_rc_texture_from_texture() -> RcTexture {
     RcTexture::from_texture(Texture::from_file(example_res!("frank.jpeg")).unwrap())
 }
 
+fn get_set_smooth_rc_text(font: &RcFont) -> RcText {
+    let mut set_smooth_text = RcText::new("Press 's' to enable/disable font smoothing", font, 16);
+    set_smooth_text.scale(Vector2f::new(2., 2.));
+
+    set_smooth_text
+}
+
 fn main() {
     let mut window =
         RenderWindow::new((800, 600), "SFML window", Style::CLOSE, &Default::default());
@@ -112,7 +122,7 @@ fn main() {
     let texture2 = test_getting_rc_texture_from_texture();
 
     // Create a new font.
-    let font = RcFont::from_file(example_res!("sansation.ttf")).unwrap();
+    let mut font = RcFont::from_file(example_res!("sansation.ttf")).unwrap();
 
     // Load many resources with no lifetime contingencies
     let mut floating_resources = Vec::from([
@@ -128,10 +138,21 @@ fn main() {
         FloatingResource::with_font(&font, true, true, 2.75f32),
     ]);
 
+    let set_smooth_text = get_set_smooth_rc_text(&font);
+
     while window.is_open() {
         while let Some(event) = window.poll_event() {
             if event == Event::Closed {
                 window.close();
+            }
+
+            match event {
+                Event::Closed => window.close(),
+                Event::KeyPressed { code, .. } if code == Key::S => {
+                    let smooth = !font.is_smooth();
+                    font.set_smooth(smooth)
+                }
+                _ => {}
             }
         }
 
@@ -146,6 +167,8 @@ fn main() {
         for floating_resource in &floating_resources {
             floating_resource.render(&mut window);
         }
+
+        window.draw(&set_smooth_text);
         window.display();
     }
 }

--- a/src/ffi/graphics_bindgen.rs
+++ b/src/ffi/graphics_bindgen.rs
@@ -82,6 +82,8 @@ pub fn sfFont_getLineSpacing(font: *const sfFont, characterSize: c_uint) -> f32;
 pub fn sfFont_getUnderlinePosition(font: *const sfFont, characterSize: c_uint) -> f32;
 pub fn sfFont_getUnderlineThickness(font: *const sfFont, characterSize: c_uint) -> f32;
 pub fn sfFont_getTexture(font: *const sfFont, characterSize: c_uint) -> *const sfTexture;
+pub fn sfFont_isSmooth(font: *const sfFont) -> bool;
+pub fn sfFont_setSmooth(font: *const sfFont, smooth: bool);
 pub fn sfFont_getInfo(font: *const sfFont) -> sfFontInfo;
 // Image.cpp
 pub fn sfImage_create(width: c_uint, height: c_uint) -> *mut sfImage;

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -275,6 +275,38 @@ impl Font {
                 .expect("sfFont_getTexture failed")
         }
     }
+
+    /// Check if the font has anti-aliasing enabled/disabled
+    ///
+    /// # Usage Example
+    /// ```no_run
+    /// # use sfml::graphics::Font;
+    /// # let mut font = Font::from_file("examples/resources/sansation.ttf").unwrap();
+    /// font.set_smooth(true);
+    /// assert_eq!(font.is_smooth(), true);
+    /// ````
+    #[must_use]
+    pub fn is_smooth(&self) -> bool {
+        unsafe { ffi::sfFont_isSmooth(self) }
+    }
+
+    /// Enables/Disables font smoothing.
+    ///
+    /// # Arguments
+    /// * `smooth` - True to enable smoothing, false to disable smoothing
+    ///
+    /// # Usage Example
+    ///
+    /// ```no_run
+    /// # use sfml::graphics::Font;
+    /// # let font = Font::from_file("examples/resources/sansation.ttf").unwrap();
+    /// let texture = font.texture(32);
+    /// # use sfml::system::Vector2;
+    /// assert_eq!(texture.size(), Vector2::new(128, 128));
+    /// ```
+    pub fn set_smooth(&mut self, smooth: bool) {
+        unsafe { ffi::sfFont_setSmooth(self, smooth) }
+    }
 }
 
 impl ToOwned for Font {

--- a/src/graphics/rc_font.rs
+++ b/src/graphics/rc_font.rs
@@ -265,6 +265,38 @@ impl RcFont {
         unsafe { (**self.font.as_ptr()).texture(character_size) }
     }
 
+    /// Check if the font has anti-aliasing enabled/disabled
+    ///
+    /// # Usage Example
+    /// ```no_run
+    /// # use sfml::graphics::Font;
+    /// # let mut font = Font::from_file("examples/resources/sansation.ttf").unwrap();
+    /// font.set_smooth(true);
+    /// assert_eq!(font.is_smooth(), true);
+    /// ````
+    #[must_use]
+    pub fn is_smooth(&self) -> bool {
+        self.font.borrow().is_smooth()
+    }
+
+    /// Enables/Disables font smoothing.
+    ///
+    /// # Arguments
+    /// * `smooth` - True to enable smoothing, false to disable smoothing
+    ///
+    /// # Usage Example
+    ///
+    /// ```no_run
+    /// # use sfml::graphics::Font;
+    /// # let font = Font::from_file("examples/resources/sansation.ttf").unwrap();
+    /// let texture = font.texture(32);
+    /// # use sfml::system::Vector2;
+    /// assert_eq!(texture.size(), Vector2::new(128, 128));
+    /// ```
+    pub fn set_smooth(&mut self, smooth: bool) {
+        self.font.borrow_mut().set_smooth(smooth)
+    }
+
     /// INTERNAL FUNCTION ONLY
     /// Allows other rc variants to request a weak pointer to the texture
     pub(super) fn downgrade(&self) -> std::rc::Weak<RefCell<SfBox<Font>>> {


### PR DESCRIPTION
New 2.6.x SFML allows for setting the smoothness to fonts. rust-sfml should reflect this ability too.