### PR TITLE
Ported `sf::Context::getFunction()`

### DIFF
--- a/CSFML/src/Window/Window.cpp
+++ b/CSFML/src/Window/Window.cpp
@@ -148,6 +148,6 @@ extern "C" uint64_t sfContext_getActiveContextId() {
     return sf::Context::getActiveContextId();
 }
 
-extern "C" void* sfContext_getFunction(char const* name) {
+extern "C" sf::GlFunctionPointer sfContext_getFunction(char const* name) {
     return sf::Context::getFunction(name);
 }

--- a/CSFML/src/Window/Window.cpp
+++ b/CSFML/src/Window/Window.cpp
@@ -147,3 +147,7 @@ extern "C" const sf::ContextSettings *sfContext_getSettings(const sf::Context *c
 extern "C" uint64_t sfContext_getActiveContextId() {
     return sf::Context::getActiveContextId();
 }
+
+extern "C" void* sfContext_getFunction(char const* name) {
+    return sf::Context::getFunction(name);
+}

--- a/src/ffi/window_bindgen.rs
+++ b/src/ffi/window_bindgen.rs
@@ -78,5 +78,6 @@ pub fn sfContext_destroy(context: *mut sfContext);
 pub fn sfContext_setActive(context: *mut sfContext, active: bool) -> bool;
 pub fn sfContext_getSettings(context: *const sfContext) -> *const sfContextSettings;
 pub fn sfContext_getActiveContextId() -> u64;
+pub fn sfContext_getFunction(name: *const std::ffi::c_char) -> *const std::ffi::c_void;
 
 }

--- a/src/window/context.rs
+++ b/src/window/context.rs
@@ -1,3 +1,5 @@
+use std::ffi::CStr;
+
 use crate::{ffi::window as ffi, window::ContextSettings};
 
 /// Type holding a valid drawing context.
@@ -62,6 +64,15 @@ impl Context {
     #[must_use]
     pub fn active_context_id() -> u64 {
         unsafe { ffi::sfContext_getActiveContextId() }
+    }
+
+    /// Get the address of an OpenGL function.
+    /// # Arguments
+    /// * name - Name of the function to get the address of
+    /// 
+    /// Returns the address of the OpenGL function, 0 on failure 
+    pub unsafe fn get_function(name: &CStr) -> *const std::ffi::c_void {
+        unsafe { ffi::sfContext_getFunction(name.as_ptr()) }
     }
 }
 


### PR DESCRIPTION
Ported `sf::Context::getFunction()`:
- Added as `Context::get_function()` 
Low level details:
- Added `sfContext_getFunction()` to CSFML implementation
- Added `sfContext_getFunction()` FFI function 

Possible changes:
Change `Context::get_function()`'s signature, as it currently is: `unsafe fn(&CStr) -> *const std::ffi::c_void`