### PR TITLE
Implement safer pixel data functions

### DIFF
--- a/src/window/context.rs
+++ b/src/window/context.rs
@@ -69,8 +69,8 @@ impl Context {
     /// Get the address of an OpenGL function.
     /// # Arguments
     /// * name - Name of the function to get the address of
-    /// 
-    /// Returns the address of the OpenGL function, 0 on failure 
+    ///
+    /// Returns the address of the OpenGL function, 0 on failure
     pub unsafe fn get_function(name: &CStr) -> *const std::ffi::c_void {
         unsafe { ffi::sfContext_getFunction(name.as_ptr()) }
     }


### PR DESCRIPTION
I believe that it is unnecessary for the user to use unsafe functions when it can easily be implemented with safe functionality. This is an example of doing it safely with a small abstraction. Rust is all about safe code, not unsafe code. Such a simple abstraction should be hidden from the user



Note not inside of commit:
I haven't tested it. I'll test it soon and leave a comment that I have tested it's functionality. 

This will be a breaking change, but I believe it is for the better. People using these functions will have to change their code and decide whether they want to use the unchecked or standard version of the function.