### PR TITLE
Fix clippy errors

### DIFF
--- a/src/window/context.rs
+++ b/src/window/context.rs
@@ -69,8 +69,14 @@ impl Context {
     /// Get the address of an OpenGL function.
     /// # Arguments
     /// * name - Name of the function to get the address of
-    /// 
-    /// Returns the address of the OpenGL function, 0 on failure 
+    ///
+    /// Returns the address of the OpenGL function, 0 on failure
+    ///
+    /// # Safety
+    ///
+    /// Return addresses to functions is inherently an unsafe operation. Must check failure on
+    /// your own. rust-sfml DOES NOT perform any checks on the returned pointer.
+    #[must_use]
     pub unsafe fn get_function(name: &CStr) -> *const std::ffi::c_void {
         unsafe { ffi::sfContext_getFunction(name.as_ptr()) }
     }


### PR DESCRIPTION
Clippy was complaining that #[must_use] MUST be implemented for this function.

It was also complaining that a # Safety documentation has yet to be written.



The only part I believe that needs a code review is the message for the # Safety documentation. I've never used this function, so I am unsure what it does. I did my best reading off the context clues what the official SFML documentation, and usages I could find.