### PR TITLE
Add -ObjC link flag to fix OSX crashes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -303,6 +303,9 @@ fn main() {
         if feat_audio {
             unix_audio_link_support_libs();
         }
+        // SFML contains Objective-C source files on OSX
+        // https://github.com/SFML/SFML/issues/2920
+        println!("cargo::rustc-link-arg=-ObjC");
     } else {
         panic!("Uhhh... Can't determine your environment. Sorry.");
     }


### PR DESCRIPTION
Add `-ObjC` link flag when building on OSX. As noted in https://github.com/SFML/SFML/issues/2920, this is required when statically linking against SFML since it contains Objective-C source files. Without this flag, compiling and linking succeeds but binaries will crash at runtime.