### PR TITLE
Update cmake dependency to 0.1.53

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ optional = true
 
 [build-dependencies]
 cc = "1.0.79"
-cmake = "0.1.51"
+cmake = "0.1.53"
 pkg-config = "0.3.31"
 
 [dev-dependencies]


### PR DESCRIPTION
This cmake-rs release contains a fix that speeds up cmake builds on OSX.

See https://github.com/rust-lang/cmake-rs/releases/tag/v0.1.53