### PR TITLE
Symlink target sfml build into CSFML for clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+CSFML/build


### PR DESCRIPTION
I thought it would be nice to have the custom CSFML code have hooks for clangd autocomplete, etc... It seems not too crazy to implement. Just need to symlink the build dir built in target into CSFML. clangd now hooks up nicely

need to set environment variable SYMLINK_CSFML=1 to get it to work