### PR TITLE
Allow dynamic linkage of FLAC and ogg

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install deps
       run: |
        sudo apt-get update
-       sudo apt-get install libpthread-stubs0-dev libgl1-mesa-dev libx11-dev libx11-xcb-dev libxcb-image0-dev libxrandr-dev libxcb-randr0-dev libudev-dev libfreetype6-dev libglew-dev libjpeg8-dev libgpgme11-dev libsndfile1-dev libopenal-dev libjpeg62 libxcursor-dev cmake libclang-dev clang
+       sudo apt-get install libpthread-stubs0-dev libgl1-mesa-dev libx11-dev libx11-xcb-dev libxcb-image0-dev libxrandr-dev libxcb-randr0-dev libudev-dev libfreetype6-dev libglew-dev libjpeg8-dev libgpgme11-dev libsndfile1-dev libopenal-dev libjpeg62 libxcursor-dev cmake libclang-dev clang libflac-dev
     - name: Build
       run: |
        git submodule update --init
@@ -49,6 +49,7 @@ jobs:
        # Also test non-default feature combinations
        cargo test --no-default-features --features=ci-headless --verbose
        cargo test --no-default-features --features=ci-headless,audio --verbose
+       cargo test --no-default-features --features=ci-headless,audio,build-flac-ogg --verbose
        cargo test --no-default-features --features=ci-headless,window --verbose
        cargo test --no-default-features --features=ci-headless,graphics --verbose
        # Test packaging (building from .crate archive, without SFML submodule)

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install deps
       run: |
-        brew install freetype libvorbis
+        brew install freetype libvorbis flac libogg
     - name: Build
       run: |
        git submodule update --init
@@ -47,7 +47,9 @@ jobs:
        cargo test --release --features=ci-headless --verbose
        # Also test non-default feature combinations
        cargo test --no-default-features --features=ci-headless --verbose
-       cargo test --no-default-features --features=ci-headless,audio --verbose
+       # Specify search paths for dynamically-linked FLAC and ogg
+       LIBRARY_PATH=/opt/homebrew/lib cargo test --no-default-features --features=ci-headless,audio --verbose
+       cargo test --no-default-features --features=ci-headless,audio,build-flac-ogg --verbose
        cargo test --no-default-features --features=ci-headless,window --verbose
        cargo test --no-default-features --features=ci-headless,graphics --verbose
        # Test packaging (building from .crate archive, without SFML submodule)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,7 +46,7 @@ jobs:
        cargo test --release --features=ci-headless --verbose &&
        # Also test non-default feature combinations
        cargo test --no-default-features --features=ci-headless --verbose &&
-       cargo test --no-default-features --features=ci-headless,audio --verbose &&
+       cargo test --no-default-features --features=ci-headless,audio,build-flac-ogg --verbose &&
        cargo test --no-default-features --features=ci-headless,window --verbose &&
        cargo test --no-default-features --features=ci-headless,graphics --verbose &&
        # Test packaging (building from .crate archive, without SFML submodule) (allow dirty because of openal32.dll)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,13 +39,16 @@ cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]
 
 [features]
-default = ["graphics", "audio"]
+default = ["graphics", "audio", "build-flac-ogg"]
 window = ["dep:bitflags"]
 graphics = ["window"]
 audio = ["dep:libflac-sys"]
 serde = ["dep:serde"]
 # Used to skip running certain tests on CI, since it's running in a headless environment.
 ci-headless = []
+# When enabled, libFLAC and libogg will be built from source and statically linked
+# Otherwise, they will be dynamically linked
+build-flac-ogg = ["libflac-sys?/build-flac", "libflac-sys?/build-ogg"]
 
 [dependencies]
 link-cplusplus = "1.0.9"
@@ -65,6 +68,7 @@ optional = true
 
 [dependencies.libflac-sys]
 version = "0.3"
+default-features = false
 optional = true
 
 [build-dependencies]


### PR DESCRIPTION
* Allow libFLAC and libogg to be dynamically linked rather than built from source by libflac-sys and statically linked.
* The static linking of these two libraries is maintained as the default behavior but one can choose to dynamically link them by opting out of the new `build-flac-ogg` feature flag, which is on by default.

Tested on OSX and Debian-ish Linux by:
1. Running the pong example with dynamic linking of libogg and libFLAC: ` cargo run --example pong --no-default-features --features=audio,graphics,build-flac-ogg`
2. Running the pong example with static linking of libogg and libFLAC:  `cargo run --example pong`
    * Used https://github.com/mgeier/libflac-sys/pull/39 to allow it to build with CMake 4.0 on OSX
    * Tested with an older version of CMake and vanilla libflac-sys on Linux

This also works as a workaround for  #339 until libflac-sys is updated (https://github.com/mgeier/libflac-sys/pull/39).