### PR TITLE
Use isPressed instead of denoting type in function name

### DIFF
--- a/src/window/keyboard.rs
+++ b/src/window/keyboard.rs
@@ -10,7 +10,7 @@ impl Key {
     /// pressed or released while no window was focused and no events were
     /// triggered.
     #[must_use]
-    pub fn is_key_pressed(self) -> bool {
+    pub fn is_pressed(self) -> bool {
         thread_safety::set_window_thread();
 
         unsafe { ffi::sfKeyboard_isKeyPressed(self) }
@@ -30,7 +30,7 @@ impl Scancode {
     /// pressed or released while no window was focused and no events were
     /// triggered.
     #[must_use]
-    pub fn is_scancode_pressed(self) -> bool {
+    pub fn is_pressed(self) -> bool {
         thread_safety::set_window_thread();
         unsafe { ffi::sfKeyboard_isScancodePressed(self) }
     }


### PR DESCRIPTION
Discriminating factor is already done via the implementation type either Key or Scancode. I wrote this originally as a carbon copy from SFML.

I think this change is healthy to make rust-sfml more "rusty" instead of "Cy-eeee"

Pedantic change, but I think it is for the better.