### PR TITLE
Fix all clippy lints

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -196,9 +196,7 @@ fn main() {
     if is_windows {
         cmake.cxxflag("/std:c++17").cxxflag("/EHsc");
     }
-    if !feat_audio {
-        cmake.define("SFML_BUILD_AUDIO", "FALSE");
-    } else {
+    if feat_audio {
         // Add search path for libFLAC built by libflac-sys
         let (libogg_loc, libflac_loc) = match win_env {
             Some(WinEnv::Msvc) => {
@@ -228,6 +226,8 @@ fn main() {
             }
             (_, LinkageKind::Dynamic) => (),
         }
+    } else {
+        cmake.define("SFML_BUILD_AUDIO", "FALSE");
     }
     if !feat_window {
         cmake.define("SFML_BUILD_WINDOW", "FALSE");

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -160,7 +160,7 @@ fn main() -> SfResult<()> {
                         unsafe {
                             match Cursor::from_pixels(
                                 &pixels,
-                                Vector2::new(DRAW_GRID_WH as u32, DRAW_GRID_WH as u32),
+                                Vector2::new(u32::from(DRAW_GRID_WH), u32::from(DRAW_GRID_WH)),
                                 hotspot,
                             ) {
                                 Ok(cursor) => {
@@ -174,9 +174,7 @@ fn main() -> SfResult<()> {
                         modif = false;
                     }
                     if mouse_over(&clear_button, position) {
-                        for px in pixel_grid.iter_mut() {
-                            *px = false;
-                        }
+                        pixel_grid.fill(false);
                         modif = true;
                     }
                     if mouse_over(&hotspot_button, position) {
@@ -216,9 +214,9 @@ fn main() -> SfResult<()> {
             clear_button_highlighted = true;
         }
         // Grid interactions
-        let rela_x = mp.x - DRAW_AREA_TOPLEFT.0 as i32;
-        let rela_y = mp.y - DRAW_AREA_TOPLEFT.1 as i32;
-        let (gx, gy) = (rela_x / DRAW_CELL_WH as i32, rela_y / DRAW_CELL_WH as i32);
+        let rela_x = mp.x - i32::from(DRAW_AREA_TOPLEFT.0);
+        let rela_y = mp.y - i32::from(DRAW_AREA_TOPLEFT.1);
+        let (gx, gy) = (rela_x / i32::from(DRAW_CELL_WH), rela_y / i32::from(DRAW_CELL_WH));
         if gx >= 0 && gy >= 0 {
             if let Some(cell) = gridindex(&mut pixel_grid, gx as usize, gy as usize) {
                 if hotspot_selection {
@@ -277,7 +275,7 @@ fn main() -> SfResult<()> {
         shape.set_fill_color(Color::TRANSPARENT);
         for y in 0..DRAW_GRID_WH {
             for x in 0..DRAW_GRID_WH {
-                if hotspot.x == x as u32 && hotspot.y == y as u32 {
+                if hotspot.x == u32::from(x) && hotspot.y == u32::from(y) {
                     shape.set_outline_color(Color::RED);
                 } else {
                     shape.set_outline_color(Color::rgb(180, 180, 180));
@@ -287,10 +285,10 @@ fn main() -> SfResult<()> {
                 } else {
                     shape.set_fill_color(Color::TRANSPARENT);
                 }
-                shape.set_size((DRAW_CELL_WH as f32, DRAW_CELL_WH as f32));
+                shape.set_size((f32::from(DRAW_CELL_WH), f32::from(DRAW_CELL_WH)));
                 shape.set_position((
-                    DRAW_AREA_TOPLEFT.0 as f32 + (x as f32 * DRAW_CELL_WH as f32),
-                    DRAW_AREA_TOPLEFT.1 as f32 + (y as f32 * DRAW_CELL_WH as f32),
+                    f32::from(DRAW_AREA_TOPLEFT.0) + (f32::from(x) * f32::from(DRAW_CELL_WH)),
+                    f32::from(DRAW_AREA_TOPLEFT.1) + (f32::from(y) * f32::from(DRAW_CELL_WH)),
                 ));
                 rw.draw(&shape);
             }

--- a/examples/custom-drawable.rs
+++ b/examples/custom-drawable.rs
@@ -34,7 +34,7 @@ impl Drawable for Bullet<'_> {
         _: &RenderStates<'texture, 'shader, 'shader_texture>,
     ) {
         render_target.draw(&self.head);
-        render_target.draw(&self.torso)
+        render_target.draw(&self.torso);
     }
 }
 
@@ -63,7 +63,7 @@ fn main() -> SfResult<()> {
 
         window.clear(Color::BLACK);
         window.draw(&bullet);
-        window.display()
+        window.display();
     }
     Ok(())
 }

--- a/examples/custom-sound-recorder.rs
+++ b/examples/custom-sound-recorder.rs
@@ -224,7 +224,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 for (i, &sample) in samp_buf.iter().enumerate() {
                     let ratio = samp_buf.len() as f32 / rw.size().x as f32;
                     rect.set_position((i as f32 / ratio, 300.0));
-                    rect.set_size((2.0, sample as f32 / 48.0));
+                    rect.set_size((2.0, f32::from(sample) / 48.0));
                     rw.draw(&rect);
                 }
             }

--- a/examples/custom-sound-stream.rs
+++ b/examples/custom-sound-stream.rs
@@ -19,7 +19,7 @@ const BUF_SIZE: usize = 2048;
 
 impl SoundStream for BitMelody {
     fn get_data(&mut self) -> (&[i16], bool) {
-        for buf_sample in self.buf.iter_mut() {
+        for buf_sample in &mut self.buf {
             self.t = self.t.wrapping_add(1);
             let t = self.t;
             let melody = b"36364689";
@@ -60,7 +60,7 @@ impl BitMelody {
         }
     }
     fn total_duration_samples(&self) -> usize {
-        (FULLVOL_DURATION + INIT_VOL as i32 * 4096) as usize
+        (FULLVOL_DURATION + i32::from(INIT_VOL) * 4096) as usize
     }
 }
 

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -1,4 +1,4 @@
-use sfml::{SfResult, graphics::*, system::*, window::*};
+use sfml::{SfResult, graphics::{RenderWindow, Font, CircleShape, Text, Transformable, RenderTarget, Color, Shape, Drawable}, system::Vector2i, window::{Style, Event, Key, VideoMode, mouse}};
 
 include!("../example_common.rs");
 

--- a/examples/opengl.rs
+++ b/examples/opengl.rs
@@ -61,7 +61,7 @@ fn main() -> SfResult<()> {
             gl::glViewport(0, 0, window.size().x as _, window.size().y as _);
             gl::glMatrixMode(gl::GL_PROJECTION);
             gl::glLoadIdentity();
-            let ratio = (window.size().x / window.size().y) as gl::GLdouble;
+            let ratio = gl::GLdouble::from(window.size().x / window.size().y);
             gl::glFrustum(-ratio, ratio, -1., 1., 1., 500.);
             gl::glEnable(gl::GL_TEXTURE_2D);
             Texture::bind(&texture);
@@ -88,13 +88,13 @@ fn main() -> SfResult<()> {
                 3,
                 gl::GL_FLOAT,
                 5 * size_of::<gl::GLfloat>() as i32,
-                cube.as_ptr() as *const c_void,
+                cube.as_ptr().cast::<c_void>(),
             );
             gl::glTexCoordPointer(
                 2,
                 gl::GL_FLOAT,
                 5 * size_of::<gl::GLfloat>() as i32,
-                cube.as_ptr().offset(3) as *const c_void,
+                cube.as_ptr().offset(3).cast::<c_void>(),
             );
 
             // Disable normal and color vertex components

--- a/examples/pong.rs
+++ b/examples/pong.rs
@@ -279,7 +279,7 @@ fn main() -> SfResult<()> {
         }
 
         // Display things on screen
-        window.display()
+        window.display();
     }
     Ok(())
 }

--- a/examples/positional-audio.rs
+++ b/examples/positional-audio.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
     if music.channel_count() != 1 {
         return Err("Sorry, only sounds with 1 channel are supported.".into());
-    };
+    }
     music.set_looping(true);
     music.play();
     music.set_position(Vector3::new(0., 0., 0.));

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -51,7 +51,7 @@ impl Effect for Pixelate<'_> {
         self.shader
             .set_uniform_float("pixel_threshold", (x + y) / 30.0)
     }
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "pixelate"
     }
 }
@@ -112,7 +112,7 @@ impl Effect for WaveBlur<'_> {
         self.shader
             .set_uniform_float("blur_radius", (x + y) * 0.008)
     }
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "wave + blur"
     }
 }
@@ -166,7 +166,7 @@ impl Effect for StormBlink {
         self.shader
             .set_uniform_float("blink_alpha", 0.5 + (t * 3.).cos() * 0.25)
     }
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "storm + blink"
     }
 }
@@ -220,7 +220,7 @@ impl Drawable for Edge<'_> {
 impl Effect for Edge<'_> {
     fn update(&mut self, t: f32, x: f32, y: f32) -> SfResult<()> {
         self.shader
-            .set_uniform_float("edge_threshold", 1. - (x + y) / 2.)?;
+            .set_uniform_float("edge_threshold", 1. - f32::midpoint(x, y))?;
         let entities_len = self.entities.len() as f32;
 
         for (i, en) in self.entities.iter_mut().enumerate() {
@@ -238,7 +238,7 @@ impl Effect for Edge<'_> {
         self.surface.display();
         Ok(())
     }
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "edge post-effect"
     }
 }
@@ -307,7 +307,7 @@ impl Effect for Geometry<'_> {
         Ok(())
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "Geometry Shader Billboards"
     }
 }
@@ -355,7 +355,7 @@ fn main() -> SfResult<()> {
 
     while window.is_open() {
         while let Some(event) = window.poll_event() {
-            use crate::Event::*;
+            use crate::Event::{Closed, KeyPressed};
             match event {
                 Closed => window.close(),
                 KeyPressed { code, .. } => match code {

--- a/examples/unicode-text-entry.rs
+++ b/examples/unicode-text-entry.rs
@@ -27,7 +27,7 @@ fn main() -> SfResult<()> {
     match std::env::args().nth(1) {
         Some(path) => font.open_from_file(&path)?,
         None => font.load_from_memory_static(include_bytes!("resources/sansation.ttf"))?,
-    };
+    }
     let mut string = String::from("This text can be edited.\nTry it!");
 
     let mut text = Text::new(&string, &font, 24);

--- a/examples/vertex-arrays.rs
+++ b/examples/vertex-arrays.rs
@@ -28,7 +28,7 @@ fn main() -> SfResult<()> {
 
     println!("\nIterate over the vertices of a vertex array");
     for v in &vertex_array {
-        println!("Vertex Color: {:?} | Position: {:?}", v.color, v.position)
+        println!("Vertex Color: {:?} | Position: {:?}", v.color, v.position);
     }
 
     println!("\nMutable access to a vertex");
@@ -84,7 +84,7 @@ fn main() -> SfResult<()> {
         window.draw_primitives(&vertex_array, PrimitiveType::LINE_STRIP, &rs);
         window.draw(&bound_rect);
         // Display things on screen
-        window.display()
+        window.display();
     }
     Ok(())
 }

--- a/examples/vertex-buffers.rs
+++ b/examples/vertex-buffers.rs
@@ -52,7 +52,7 @@ fn main() -> SfResult<()> {
         window.clear(Color::BLACK);
         window.draw(&*vertex_buffer);
         // Display things on screen
-        window.display()
+        window.display();
     }
     Ok(())
 }

--- a/examples/window-test.rs
+++ b/examples/window-test.rs
@@ -47,7 +47,7 @@ fn main() -> SfResult<()> {
                     Key::Up => cfg_idx = cfg_idx.saturating_sub(1),
                     Key::Down => {
                         if cfg_idx + 1 < configs.len() + fs_modes.len() {
-                            cfg_idx += 1
+                            cfg_idx += 1;
                         }
                     }
                     Key::Enter => match configs.get(cfg_idx) {
@@ -58,7 +58,7 @@ fn main() -> SfResult<()> {
                                 cfg.style,
                                 State::Windowed,
                                 &ContextSettings::default(),
-                            )?
+                            )?;
                         }
                         None => match fs_modes.get(cfg_idx - configs.len()) {
                             Some(mode) => {
@@ -68,7 +68,7 @@ fn main() -> SfResult<()> {
                                     Default::default(),
                                     State::Fullscreen,
                                     &ContextSettings::default(),
-                                )?
+                                )?;
                             }
                             None => {
                                 eprintln!("Invalid index: {cfg_idx}");

--- a/src/audio/capture.rs
+++ b/src/audio/capture.rs
@@ -361,8 +361,20 @@ fn test_devices() {
     let mut recorder = SoundBufferRecorder::new();
     assert_eq!(*recorder.device(), *default);
     if let Some(device) = devices.last() {
-        recorder.set_device(device.to_str().unwrap()).unwrap();
-        assert_eq!(recorder.device().to_str().unwrap(), device);
+        recorder
+            .set_device(
+                device
+                    .to_str()
+                    .expect("Test code shall fail if this does not work"),
+            )
+            .expect("Test code shall fail if this does not work");
+        assert_eq!(
+            recorder
+                .device()
+                .to_str()
+                .expect("Test code shall fail if this does not work"),
+            device
+        );
     }
 }
 

--- a/src/audio/music.rs
+++ b/src/audio/music.rs
@@ -111,7 +111,7 @@ impl<'src> Music<'src> {
         &mut self,
         stream: &'src mut InputStream<T>,
     ) -> SfResult<()> {
-        unsafe { ffi::audio::sfMusic_openFromStream(self.music, &mut *stream.stream) }
+        unsafe { ffi::audio::sfMusic_openFromStream(self.music, &raw mut *stream.stream) }
             .into_sf_result()
     }
 

--- a/src/audio/sound_buffer.rs
+++ b/src/audio/sound_buffer.rs
@@ -110,7 +110,7 @@ impl SoundBuffer {
     /// Load the sound buffer from a custom stream.
     pub fn load_from_stream<T: Read + Seek>(&mut self, stream: &mut T) -> SfResult<()> {
         let mut stream = InputStream::new(stream);
-        unsafe { ffi::audio::sfSoundBuffer_loadFromStream(self, &mut *stream.stream) }
+        unsafe { ffi::audio::sfSoundBuffer_loadFromStream(self, &raw mut *stream.stream) }
             .into_sf_result()
     }
     /// Load the sound buffer from a slice of audio samples.

--- a/src/ffi/system.rs
+++ b/src/ffi/system.rs
@@ -12,10 +12,10 @@ use crate::{
 pub type sfTime = i64;
 
 type sfInputStreamHelperReadCb =
-    Option<unsafe extern "C" fn(data: *mut c_void, size: i64, userData: *mut c_void) -> i64>;
+    Option<unsafe extern "C" fn(data: *mut c_void, size: i64, user_data: *mut c_void) -> i64>;
 type sfInputStreamHelperSeekCb =
     Option<unsafe extern "C" fn(pos: i64, user_data: *mut c_void) -> i64>;
-type sfInputStreamHelperTellCb = Option<unsafe extern "C" fn(userData: *mut c_void) -> i64>;
+type sfInputStreamHelperTellCb = Option<unsafe extern "C" fn(user_data: *mut c_void) -> i64>;
 type sfInputStreamHelperGetSizeCb = Option<unsafe extern "C" fn(user_data: *mut c_void) -> i64>;
 pub type sfBuffer = crate::system::buffer::Buffer;
 

--- a/src/graphics/circle_shape.rs
+++ b/src/graphics/circle_shape.rs
@@ -91,7 +91,7 @@ impl Drawable for CircleShape<'_> {
         target: &mut dyn RenderTarget,
         states: &RenderStates<'texture, 'shader, 'shader_texture>,
     ) {
-        target.draw_circle_shape(self, states)
+        target.draw_circle_shape(self, states);
     }
 }
 

--- a/src/graphics/convex_shape.rs
+++ b/src/graphics/convex_shape.rs
@@ -101,7 +101,7 @@ impl Drawable for ConvexShape<'_> {
         target: &mut dyn RenderTarget,
         states: &RenderStates<'texture, 'shader, 'shader_texture>,
     ) {
-        target.draw_convex_shape(self, states)
+        target.draw_convex_shape(self, states);
     }
 }
 

--- a/src/graphics/custom_shape.rs
+++ b/src/graphics/custom_shape.rs
@@ -165,7 +165,7 @@ impl Drawable for CustomShape<'_> {
         target: &mut dyn RenderTarget,
         states: &RenderStates<'texture, 'shader, 'shader_texture>,
     ) {
-        target.draw_shape(self, states)
+        target.draw_shape(self, states);
     }
 }
 

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -148,7 +148,7 @@ impl Font {
     /// [`Font::from_file`], [`Font::from_memory`]
     pub unsafe fn open_from_stream<T: Read + Seek>(&mut self, stream: &mut T) -> SfResult<()> {
         let mut input_stream = InputStream::new(stream);
-        unsafe { ffi::sfFont_openFromStream(self, &mut *input_stream.stream) }.into_sf_result()
+        unsafe { ffi::sfFont_openFromStream(self, &raw mut *input_stream.stream) }.into_sf_result()
     }
 
     /// Load the font from a file in memory.

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -96,7 +96,7 @@ impl Image {
     /// If this function fails, the image is left unchanged.
     pub fn load_from_stream<T: Read + Seek>(&mut self, stream: &mut T) -> SfResult<()> {
         let mut input_stream = InputStream::new(stream);
-        unsafe { ffi::sfImage_loadFromStream(self, &mut *input_stream.stream) }.into_sf_result()?;
+        unsafe { ffi::sfImage_loadFromStream(self, &raw mut *input_stream.stream) }.into_sf_result()?;
         Ok(())
     }
 }
@@ -350,10 +350,10 @@ impl fmt::Display for PixelAccessError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::XTooLarge { x, width } => {
-                write!(f, "x index out of bounds. x:{} width:{}", x, width)
+                write!(f, "x index out of bounds. x:{x} width:{width}")
             }
             Self::YTooLarge { y, height } => {
-                write!(f, "y index out of bounds. y:{} height:{}", y, height)
+                write!(f, "y index out of bounds. y:{y} height:{height}")
             }
         }
     }

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -99,7 +99,7 @@ pub fn vertex_array_bounds(vertices: &[Vertex]) -> FloatRect {
             if pos.y < top {
                 top = pos.y;
             } else if pos.y > bottom {
-                bottom = pos.y
+                bottom = pos.y;
             }
         }
         FloatRect::new(

--- a/src/graphics/rc_font.rs
+++ b/src/graphics/rc_font.rs
@@ -285,7 +285,7 @@ impl RcFont {
     /// # Arguments
     /// * `smooth` - True to enable smoothing, false to disable smoothing
     pub fn set_smooth(&mut self, smooth: bool) {
-        self.font.borrow_mut().set_smooth(smooth)
+        self.font.borrow_mut().set_smooth(smooth);
     }
 
     /// Get the source font of an [`RcFont`]

--- a/src/graphics/rc_sprite.rs
+++ b/src/graphics/rc_sprite.rs
@@ -40,7 +40,7 @@ impl RcSprite {
     }
 
     fn set_rc_texture(&mut self, texture: &RcTexture) {
-        self.texture = texture.downgrade()
+        self.texture = texture.downgrade();
     }
 
     /// Create a new sprite with a texture
@@ -245,7 +245,7 @@ impl Drawable for RcSprite {
         states: &RenderStates<'texture, 'shader, 'shader_texture>,
     ) {
         if self.texture_exists() {
-            target.draw_rc_sprite(self, states)
+            target.draw_rc_sprite(self, states);
         }
     }
 }
@@ -365,18 +365,14 @@ impl Transformable for RcSprite {
     ///
     /// Panics if texture doesn't exist
     fn transform(&self) -> &Transform {
-        if !self.texture_exists() {
-            panic!("{}", PANIC_ERROR_MSG);
-        }
+        assert!(self.texture_exists(), "{}", PANIC_ERROR_MSG);
         unsafe { &*ffi::sfSprite_getTransform(self.handle.as_ptr()) }
     }
     /// Reference [`Transformable::inverse_transform`] for additional information
     ///
     /// Panics if texture doesn't exist
     fn inverse_transform(&self) -> &Transform {
-        if !self.texture_exists() {
-            panic!("{}", PANIC_ERROR_MSG);
-        }
+        assert!(self.texture_exists(), "{}", PANIC_ERROR_MSG);
         unsafe { &*ffi::sfSprite_getInverseTransform(self.handle.as_ptr()) }
     }
 }

--- a/src/graphics/rc_text.rs
+++ b/src/graphics/rc_text.rs
@@ -79,7 +79,7 @@ impl RcText {
     pub fn set_string<S: SfStrConv>(&mut self, string: S) {
         string.with_as_sfstr(|sfstr| unsafe {
             ffi::sfText_setUnicodeString(self.handle.as_ptr(), sfstr.as_ptr());
-        })
+        });
     }
 
     /// Get the string of a `RcText`
@@ -116,7 +116,7 @@ impl RcText {
                     .0
                     .as_ptr()
                     .cast_const(),
-            )
+            );
         }
     }
 
@@ -335,7 +335,7 @@ impl Drawable for RcText {
         states: &RenderStates<'texture, 'shader, 'shader_texture>,
     ) {
         if self.font_exists() {
-            target.draw_rc_text(self, states)
+            target.draw_rc_text(self, states);
         }
     }
 }
@@ -466,18 +466,14 @@ impl Transformable for RcText {
     ///
     /// Panics if font doesn't exist
     fn transform(&self) -> &Transform {
-        if !self.font_exists() {
-            panic!("{}", PANIC_ERROR_MSG);
-        }
+        assert!(self.font_exists(), "{}", PANIC_ERROR_MSG);
         unsafe { &*ffi::sfText_getTransform(self.handle.as_ptr()) }
     }
     /// Reference [`Transformable::inverse_transform`] for additional information
     ///
     /// Panics if font doesn't exist
     fn inverse_transform(&self) -> &Transform {
-        if !self.font_exists() {
-            panic!("{}", PANIC_ERROR_MSG);
-        }
+        assert!(self.font_exists(), "{}", PANIC_ERROR_MSG);
         unsafe { &*ffi::sfText_getInverseTransform(self.handle.as_ptr()) }
     }
 }

--- a/src/graphics/rc_texture.rs
+++ b/src/graphics/rc_texture.rs
@@ -103,7 +103,7 @@ impl RcTexture {
     /// used when drawing SFML entities. It must be used only if you
     /// mix `Texture` with OpenGL code.
     pub fn bind(&self) {
-        self.texture.borrow().bind()
+        self.texture.borrow().bind();
     }
 
     /// Create a new `RcTexture`
@@ -219,7 +219,7 @@ impl RcTexture {
         unsafe {
             self.texture
                 .borrow_mut()
-                .update_from_render_window(render_window, dest)
+                .update_from_render_window(render_window, dest);
         }
     }
 
@@ -259,7 +259,7 @@ impl RcTexture {
     pub fn update_from_pixels(&mut self, pixels: &[u8], size: Vector2u, dest: Vector2u) {
         self.texture
             .borrow_mut()
-            .update_from_pixels(pixels, size, dest)
+            .update_from_pixels(pixels, size, dest);
     }
 
     /// Enable or disable the smooth filter on a texture
@@ -267,7 +267,7 @@ impl RcTexture {
     /// # Arguments
     /// * smooth - true to enable smoothing, false to disable it
     pub fn set_smooth(&mut self, smooth: bool) {
-        self.texture.borrow_mut().set_smooth(smooth)
+        self.texture.borrow_mut().set_smooth(smooth);
     }
 
     /// Enable or disable repeating for a texture
@@ -289,7 +289,7 @@ impl RcTexture {
     /// # Arguments
     /// * repeated  - true to repeat the texture, false to disable repeating
     pub fn set_repeated(&mut self, repeated: bool) {
-        self.texture.borrow_mut().set_repeated(repeated)
+        self.texture.borrow_mut().set_repeated(repeated);
     }
 
     /// Get the maximum texture size allowed
@@ -320,7 +320,7 @@ impl RcTexture {
     }
     /// Swap the contents of this texture with those of another.
     pub fn swap(&mut self, other: &mut Texture) {
-        self.texture.borrow_mut().swap(other)
+        self.texture.borrow_mut().swap(other);
     }
 
     /// INTERNAL FUNCTION ONLY

--- a/src/graphics/render_window.rs
+++ b/src/graphics/render_window.rs
@@ -322,7 +322,7 @@ impl RenderWindow {
     pub fn set_title<S: SfStrConv>(&mut self, title: S) {
         title.with_as_sfstr(|sfstr| unsafe {
             ffi::sfRenderWindow_setUnicodeTitle(self, sfstr.as_ptr());
-        })
+        });
     }
 
     /// Show or hide a window.
@@ -494,7 +494,7 @@ impl RenderTarget for RenderWindow {
         render_states: &RenderStates,
     ) {
         unsafe {
-            ffi::sfRenderWindow_drawRectangleShape(self, rectangle_shape.raw(), render_states)
+            ffi::sfRenderWindow_drawRectangleShape(self, rectangle_shape.raw(), render_states);
         }
     }
     fn draw_convex_shape(&mut self, convex_shape: &ConvexShape, render_states: &RenderStates) {

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -333,7 +333,7 @@ impl<'texture> Shader<'texture> {
     /// it mustn't be used when drawing SFML entities.
     /// It must be used only if you mix `Shader` with OpenGL code.
     pub fn bind(shader: Option<&Self>) {
-        unsafe { ffi::sfShader_bind(shader.map_or(ptr::null(), |s| s.raw())) }
+        unsafe { ffi::sfShader_bind(shader.map_or(ptr::null(), Shader::raw)) }
     }
 
     /// Tell whether or not the system supports shaders
@@ -532,7 +532,7 @@ impl<'texture> Shader<'texture> {
         let cstring = CString::new(name)?;
         let name = cstring.as_ptr();
         let value = value.into();
-        let ptr: *const _ = &value.0;
+        let ptr: *const _ = &raw const value.0;
         unsafe {
             ffi::sfShader_setMat3Uniform(self.raw_mut(), name, ptr.cast());
         }
@@ -547,7 +547,7 @@ impl<'texture> Shader<'texture> {
         let cstring = CString::new(name)?;
         let name = cstring.as_ptr();
         let value = value.into();
-        let ptr: *const _ = &value.0;
+        let ptr: *const _ = &raw const value.0;
         unsafe {
             ffi::sfShader_setMat4Uniform(self.raw_mut(), name, ptr.cast());
         }

--- a/src/graphics/sprite.rs
+++ b/src/graphics/sprite.rs
@@ -178,7 +178,7 @@ impl Drawable for Sprite<'_> {
         target: &mut dyn RenderTarget,
         states: &RenderStates<'texture, 'shader, 'shader_texture>,
     ) {
-        target.draw_sprite(self, states)
+        target.draw_sprite(self, states);
     }
 }
 

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -60,7 +60,7 @@ impl<'s> Text<'s> {
     pub fn set_string<S: SfStrConv>(&mut self, string: S) {
         string.with_as_sfstr(|sfstr| unsafe {
             ffi::sfText_setUnicodeString(self.handle.as_ptr(), sfstr.as_ptr());
-        })
+        });
     }
 
     /// Get the string of a text
@@ -271,7 +271,7 @@ impl Drawable for Text<'_> {
         target: &mut dyn RenderTarget,
         states: &RenderStates<'texture, 'shader, 'shader_texture>,
     ) {
-        target.draw_text(self, states)
+        target.draw_text(self, states);
     }
 }
 

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -110,7 +110,7 @@ impl Texture {
     ) -> SfResult<()> {
         let mut input_stream = InputStream::new(stream);
         unsafe {
-            ffi::sfTexture_loadFromStream(self, &mut *input_stream.stream, srgb, area)
+            ffi::sfTexture_loadFromStream(self, &raw mut *input_stream.stream, srgb, area)
                 .into_sf_result()
         }
     }

--- a/src/graphics/transform.rs
+++ b/src/graphics/transform.rs
@@ -75,7 +75,9 @@ impl Transform {
 
         // Compute the inverse if the determinant is not zero
         // (don't use an epsilon because the determinant may *really* be tiny)
-        if det != 0. {
+        if det == 0. {
+            Self::IDENTITY
+        } else {
             Self::new(
                 (self.matrix[15] * self.matrix[5] - self.matrix[7] * self.matrix[13]) / det,
                 -(self.matrix[15] * self.matrix[4] - self.matrix[7] * self.matrix[12]) / det,
@@ -87,8 +89,6 @@ impl Transform {
                 -(self.matrix[7] * self.matrix[0] - self.matrix[3] * self.matrix[4]) / det,
                 (self.matrix[5] * self.matrix[0] - self.matrix[1] * self.matrix[4]) / det,
             )
-        } else {
-            Self::IDENTITY
         }
     }
 

--- a/src/graphics/vertex_buffer.rs
+++ b/src/graphics/vertex_buffer.rs
@@ -246,6 +246,6 @@ impl Drawable for VertexBuffer {
         target: &mut dyn RenderTarget,
         states: &RenderStates<'texture, 'shader, 'shader_texture>,
     ) {
-        target.draw_vertex_buffer(self, states)
+        target.draw_vertex_buffer(self, states);
     }
 }

--- a/src/system/angle.rs
+++ b/src/system/angle.rs
@@ -587,9 +587,9 @@ mod tests {
     #[test]
     fn test_display_formatting() {
         let angle = Angle::degrees(45.0);
-        assert_eq!(format!("{}", angle), "45°");
+        assert_eq!(format!("{angle}"), "45°");
 
-        let debug_str = format!("{:?}", angle);
+        let debug_str = format!("{angle:?}");
         assert!(debug_str.contains("degrees"));
         assert!(debug_str.contains("radians"));
     }

--- a/src/system/time.rs
+++ b/src/system/time.rs
@@ -246,7 +246,7 @@ impl Rem for Time {
 
 impl RemAssign for Time {
     fn rem_assign(&mut self, rhs: Self) {
-        self.0 %= rhs.0
+        self.0 %= rhs.0;
     }
 }
 

--- a/src/system/vector3.rs
+++ b/src/system/vector3.rs
@@ -56,6 +56,9 @@ pub struct Vector3<T> {
 }
 /// [`Vector3`] with `f32` coordinates.
 pub type Vector3f = Vector3<f32>;
+// Allow dead code to shut clippy up.
+// Yes it is unused throughout SFML's API, but is implemented for consistency.
+#[allow(dead_code)]
 /// [`Vector3`] with `u32` coordinates.
 pub type Vector3u = Vector3<u32>;
 /// [`Vector3`] with `i32` coordinates.

--- a/src/window/clipboard.rs
+++ b/src/window/clipboard.rs
@@ -37,7 +37,7 @@ pub fn get_string() -> String {
 pub fn set_string<S: SfStrConv>(string: S) {
     string.with_as_sfstr(|sfstr| unsafe {
         crate::ffi::window::sfClipboard_setUnicodeString(sfstr.as_ptr());
-    })
+    });
 }
 
 #[cfg_attr(not(feature = "ci-headless"), test)]

--- a/src/window/context.rs
+++ b/src/window/context.rs
@@ -87,14 +87,14 @@ fn test_settings() {
         Default::default(),
         &Default::default(),
     )
-    .unwrap();
+    .expect("Test code shall fail if this does not work");
     let win_settings = *window.settings();
     thread::spawn(move || {
-        let context = Context::new().unwrap();
+        let context = Context::new().expect("Test code shall fail if this does not work");
         assert_eq!(context.settings(), &win_settings);
     })
     .join()
-    .unwrap();
+    .expect("Test code shall fail if this does not work");
 }
 
 impl Drop for Context {

--- a/src/window/event.rs
+++ b/src/window/event.rs
@@ -201,7 +201,7 @@ pub enum Event {
 
 impl Event {
     pub(crate) unsafe fn from_raw(event: &ffi::Event) -> Option<Self> {
-        use crate::window::Event::*;
+        use crate::window::Event::{Closed, Resized, FocusLost, FocusGained, TextEntered, KeyPressed, KeyReleased, MouseWheelScrolled, MouseButtonPressed, MouseButtonReleased, MouseMoved, MouseMovedRaw, MouseEntered, MouseLeft, JoystickButtonPressed, JoystickButtonReleased, JoystickMoved, JoystickConnected, JoystickDisconnected, TouchBegan, TouchMoved, TouchEnded, SensorChanged};
         let evt = match event.type_ {
             EventType::Closed => Closed,
             EventType::Resized => Resized {

--- a/src/window/sensor.rs
+++ b/src/window/sensor.rs
@@ -46,7 +46,7 @@
 //! [`ORIENTATION`]: Type::ORIENTATION
 //!
 
-use crate::{ffi::window::*, system::Vector3f};
+use crate::{ffi::window::{sfSensor_getValue, sfSensor_isAvailable, sfSensor_setEnabled, sfSensorType}, system::Vector3f};
 
 /// Get the current sensor value.
 #[must_use]

--- a/src/window/touch.rs
+++ b/src/window/touch.rs
@@ -28,7 +28,7 @@
 //! [`Window::touch_position`]: crate::window::Window::touch_position
 //!
 
-use crate::{ffi::window::*, system::Vector2i};
+use crate::{ffi::window::{sfTouch_isDown, sfTouch_getPosition}, system::Vector2i};
 
 /// Check if a touch event is currently down.
 #[must_use]

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -84,8 +84,8 @@ impl Window {
                 style.bits(),
                 state,
                 settings,
-            )
-        })
+            );
+        });
     }
 
     /// Create a window from an existing platform-specific window handle


### PR DESCRIPTION
New SFML 3.x changes had a few "dirty" changes and let some clippy lints in. Fixing all warnings to keep compilation clean.

Run automated clippy lint fixers to fix a lot of these warnings