### PR TITLE
Add ownership for InputStream and Music.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,10 @@ name = "music-stream"
 required-features = ["audio"]
 
 [[example]]
+name = "music-stream-owned"
+required-features = ["audio"]
+
+[[example]]
 name = "pong"
 required-features = ["graphics", "audio"]
 

--- a/examples/music-stream-owned.rs
+++ b/examples/music-stream-owned.rs
@@ -1,0 +1,47 @@
+use {
+    sfml::{
+        audio::{
+            Music,
+            sound_source::{self, SoundSource},
+        },
+        system::{InputStream, Time, sleep},
+    },
+    std::{error::Error, fs::File, io::Write},
+};
+
+include!("../example_common.rs");
+
+fn get_music() -> Result<Music<'static, File>, Box<dyn Error>> {
+    let file = File::open("orchestral.ogg")?;
+    let stream = InputStream::new_owned(file);
+    let music = Music::from_stream_owned(stream)?;
+
+    Ok(music)
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    example_ensure_right_working_dir();
+
+    let mut music = get_music()?;
+
+    // Display Music information
+    println!("orchestral.ogg :");
+    println!(" {} seconds", music.duration().as_seconds());
+    println!(" {} samples / sec", music.sample_rate());
+    println!(" {} channels", music.channel_count());
+
+    music.play();
+
+    while music.status() == sound_source::Status::Playing {
+        // Leave some CPU time for other processes
+        sleep(Time::milliseconds(100));
+        // Display the playing position
+        print!(
+            "\rPlaying... {:.2} sec",
+            music.playing_offset().as_seconds()
+        );
+        let _ = std::io::stdout().flush();
+    }
+    println!();
+    Ok(())
+}

--- a/src/audio/music.rs
+++ b/src/audio/music.rs
@@ -66,7 +66,7 @@ impl<'src, S> Music<'src, S> {
     }
     /// Create a new `Music` by "opening" it from a stream, with ownership.
     ///
-    /// See [`Self::open_from_stream`].
+    /// See [`Self::open_from_stream_owned`].
     pub fn from_stream_owned(stream: InputStream<'src, S>) -> SfResult<Self> {
         let mut new = Self::new()?;
         new.open_from_stream_owned(stream)?;


### PR DESCRIPTION
Add methods for `InputStream` and `Music` that allow them to own their sources.
It will make it possible to use them without lifetimes with custom source.