### PR TITLE
Expose StencilMode and CoordinateType to user

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -194,7 +194,9 @@ fn main() {
         // Disable "install" step
         .no_build_target(true);
     if is_windows {
-        cmake.cxxflag("/std:c++17").cxxflag("/EHsc");
+        cmake.define("CMAKE_CXX_STANDARD", "17");
+        cmake.define("CMAKE_CXX_STANDARD_REQUIRED", "ON");
+        cmake.define("CMAKE_CXX_FLAGS_INIT", "/EHsc");
     }
     if feat_audio {
         // Add search path for libFLAC built by libflac-sys

--- a/src/ffi/graphics.rs
+++ b/src/ffi/graphics.rs
@@ -195,7 +195,7 @@ pub enum StencilUpdateOperation {
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
 pub struct StencilValue {
     /// The stored stencil value    
-    value: u32,
+    pub value: u32,
 }
 
 /// Stencil modes for drawing
@@ -203,18 +203,21 @@ pub struct StencilValue {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct StencilMode {
     /// The comparison we're performing the stencil test with    
-    comparison: StencilComparison,
+    pub comparison: StencilComparison,
     /// The update operation to perform if the stencil test passes     
-    update_operation: StencilUpdateOperation,
+    pub update_operation: StencilUpdateOperation,
     /// The reference value we're performing the stencil test with      
-    reference: StencilValue,
+    pub reference: StencilValue,
     /// The mask to apply to both the reference value and the value in the stencil buffer     
-    mask: StencilValue,
+    pub mask: StencilValue,
     /// Whether we should update the color buffer in addition to the stencil buffer     
-    only: bool,
+    pub only: bool,
 }
 
 impl StencilMode {
+    /// Default stencil mode
+    ///
+    /// This can be used in a const context, unlike the [`Default`] implementation.
     pub const DEFAULT: Self = Self {
         comparison: StencilComparison::Always,
         update_operation: StencilUpdateOperation::Keep,
@@ -232,7 +235,7 @@ impl Default for StencilMode {
 /// Types of texture coordinates that can be used for rendering.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum CoordinateType {
+pub enum sfCoordinateType {
     /// Texture coordinates in range [0 .. 1].
     sfCoordinateTypeNormalized,
     /// Texture coordinates in range [0 .. size].    

--- a/src/graphics/coordinate_type.rs
+++ b/src/graphics/coordinate_type.rs
@@ -1,0 +1,13 @@
+use crate::ffi::graphics::sfCoordinateType;
+
+/// Types of texture coordinates that can be used for rendering.
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct CoordinateType(pub(super) sfCoordinateType);
+
+impl CoordinateType {
+    /// Texutre coordinates in range [0 .. 1].
+    pub const NORMALIZED: Self = Self(sfCoordinateType::sfCoordinateTypeNormalized);
+    /// Texture coordinates in range [0 .. size].
+    pub const PIXELS: Self = Self(sfCoordinateType::sfCoordinateTypePixels);
+}

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -9,6 +9,7 @@ pub use {
         circle_shape::CircleShape,
         color::Color,
         convex_shape::ConvexShape,
+        coordinate_type::CoordinateType,
         custom_shape::{CustomShape, CustomShapePoints},
         drawable::Drawable,
         font::{Font, Info as FontInfo},
@@ -37,13 +38,14 @@ pub use {
         vertex_buffer::{VertexBuffer, VertexBufferUsage},
         view::View,
     },
-    crate::ffi::graphics::ShaderType,
+    crate::ffi::graphics::{ShaderType, StencilMode},
 };
 
 pub mod blend_mode;
 mod circle_shape;
 mod color;
 mod convex_shape;
+mod coordinate_type;
 mod custom_shape;
 mod drawable;
 mod font;

--- a/src/graphics/render_states.rs
+++ b/src/graphics/render_states.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ffi::graphics::{CoordinateType, StencilMode},
-    graphics::{BlendMode, Shader, Texture, Transform},
+    ffi::graphics::StencilMode,
+    graphics::{BlendMode, Shader, Texture, Transform, coordinate_type::CoordinateType},
 };
 
 /// Define the states used for drawing to a [`RenderTarget`].
@@ -76,7 +76,7 @@ impl RenderStates<'_, '_, '_> {
         blend_mode: BlendMode::ALPHA,
         stencil_mode: StencilMode::DEFAULT,
         transform: Transform::IDENTITY,
-        coordinate_type: CoordinateType::sfCoordinateTypePixels,
+        coordinate_type: CoordinateType::PIXELS,
         texture: None,
         shader: None,
     };


### PR DESCRIPTION
Another mistake from me. These types should have been available to the user, but I mistakenly left them out. Including them now.